### PR TITLE
Generate filter objects for data structures

### DIFF
--- a/specification/specification.go
+++ b/specification/specification.go
@@ -8,6 +8,33 @@ const (
 	OperationDelete = "Delete"
 )
 
+// Field Types
+const (
+	FieldTypeUUID      = "UUID"
+	FieldTypeDate      = "Date"
+	FieldTypeTimestamp = "Timestamp"
+	FieldTypeString    = "String"
+	FieldTypeInt       = "Int"
+	FieldTypeBool      = "Bool"
+)
+
+// Field Modifiers
+const (
+	ModifierNullable = "nullable"
+	ModifierArray    = "array"
+)
+
+// Filter suffixes
+const (
+	filterSuffix           = "Filter"
+	filterEqualsSuffix     = "FilterEquals"
+	filterNotEqualsSuffix  = "FilterNotEquals"
+	filterRangeSuffix      = "FilterRange"
+	filterContainsSuffix   = "FilterContains"
+	filterLikeSuffix       = "FilterLike"
+	filterNullSuffix       = "FilterNull"
+)
+
 // Service is the definition of an API service.
 type Service struct {
 	// Name of the service
@@ -244,6 +271,269 @@ func ApplyOverlay(input *Service) *Service {
 				result.Objects = append(result.Objects, newObject)
 			}
 		}
+	}
+
+	return result
+}
+
+// containsModifier checks if a slice of modifiers contains a specific modifier.
+func containsModifier(modifiers []string, modifier string) bool {
+	for _, mod := range modifiers {
+		if mod == modifier {
+			return true
+		}
+	}
+	return false
+}
+
+// isComparableType returns true if the field type supports range operations.
+func isComparableType(fieldType string) bool {
+	switch fieldType {
+	case FieldTypeInt, FieldTypeDate, FieldTypeTimestamp:
+		return true
+	default:
+		return false
+	}
+}
+
+// isStringType returns true if the field type is a string type that supports LIKE operations.
+func isStringType(fieldType string) bool {
+	return fieldType == FieldTypeString
+}
+
+// canBeNull returns true if the field can be null (has nullable modifier or is an array).
+func canBeNull(field Field) bool {
+	return containsModifier(field.Modifiers, ModifierNullable) || containsModifier(field.Modifiers, ModifierArray)
+}
+
+// generateFilterField creates a filter field based on the original field and filter type.
+func generateFilterField(originalField Field, isPointer bool) Field {
+	fieldType := originalField.Type
+	if isPointer {
+		// For pointer fields in filter structs, we use the pointer form
+		fieldType = "*" + fieldType
+	}
+	
+	// For array fields in Contains filters, we use slice form
+	if originalField.Type == FieldTypeString && !isPointer {
+		fieldType = "[]" + originalField.Type
+	} else if originalField.Type == FieldTypeInt && !isPointer {
+		fieldType = "[]" + originalField.Type
+	}
+	
+	return Field{
+		Name:        originalField.Name,
+		Description: originalField.Description,
+		Type:        fieldType,
+		Modifiers:   []string{}, // Filter fields don't inherit modifiers
+	}
+}
+
+// ApplyFilterOverlay applies filter overlay to a specification, generating Filter objects 
+// from existing Objects. This should be called after ApplyOverlay to ensure all Objects
+// are available for filter generation.
+func ApplyFilterOverlay(input *Service) *Service {
+	if input == nil {
+		return nil
+	}
+
+	// Create a deep copy of the input service
+	result := &Service{
+		Name:      input.Name,
+		Enums:     make([]Enum, len(input.Enums)),
+		Objects:   make([]Object, 0, len(input.Objects)*7), // Estimate for filter objects
+		Resources: make([]Resource, len(input.Resources)),
+	}
+
+	// Copy enums
+	copy(result.Enums, input.Enums)
+	
+	// Copy existing objects first
+	result.Objects = append(result.Objects, input.Objects...)
+	
+	// Copy resources
+	copy(result.Resources, input.Resources)
+
+	// Generate Filter objects from existing Objects
+	for _, obj := range input.Objects {
+		// Generate main filter object
+		mainFilter := Object{
+			Name:        obj.Name + filterSuffix,
+			Description: "Filter object for " + obj.Name,
+			Fields: []Field{
+				{
+					Name:        "Equals",
+					Description: "Equality filters for " + obj.Name,
+					Type:        "*" + obj.Name + filterEqualsSuffix,
+					Modifiers:   []string{},
+				},
+				{
+					Name:        "NotEquals", 
+					Description: "Inequality filters for " + obj.Name,
+					Type:        "*" + obj.Name + filterNotEqualsSuffix,
+					Modifiers:   []string{},
+				},
+				{
+					Name:        "GreaterThan",
+					Description: "Greater than filters for " + obj.Name,
+					Type:        "*" + obj.Name + filterRangeSuffix,
+					Modifiers:   []string{},
+				},
+				{
+					Name:        "SmallerThan",
+					Description: "Smaller than filters for " + obj.Name,
+					Type:        "*" + obj.Name + filterRangeSuffix,
+					Modifiers:   []string{},
+				},
+				{
+					Name:        "GreaterOrEqual",
+					Description: "Greater than or equal filters for " + obj.Name,
+					Type:        "*" + obj.Name + filterRangeSuffix,
+					Modifiers:   []string{},
+				},
+				{
+					Name:        "SmallerOrEqual",
+					Description: "Smaller than or equal filters for " + obj.Name,
+					Type:        "*" + obj.Name + filterRangeSuffix,
+					Modifiers:   []string{},
+				},
+				{
+					Name:        "Contains",
+					Description: "Contains filters for " + obj.Name,
+					Type:        "*" + obj.Name + filterContainsSuffix,
+					Modifiers:   []string{},
+				},
+				{
+					Name:        "NotContains",
+					Description: "Not contains filters for " + obj.Name,
+					Type:        "*" + obj.Name + filterContainsSuffix,
+					Modifiers:   []string{},
+				},
+				{
+					Name:        "Like",
+					Description: "LIKE filters for " + obj.Name,
+					Type:        "*" + obj.Name + filterLikeSuffix,
+					Modifiers:   []string{},
+				},
+				{
+					Name:        "NotLike",
+					Description: "NOT LIKE filters for " + obj.Name,
+					Type:        "*" + obj.Name + filterLikeSuffix,
+					Modifiers:   []string{},
+				},
+				{
+					Name:        "Null",
+					Description: "Null filters for " + obj.Name,
+					Type:        "*" + obj.Name + filterNullSuffix,
+					Modifiers:   []string{},
+				},
+				{
+					Name:        "NotNull",
+					Description: "Not null filters for " + obj.Name,
+					Type:        "*" + obj.Name + filterNullSuffix,
+					Modifiers:   []string{},
+				},
+				{
+					Name:        "OrCondition",
+					Description: "OrCondition decides if this filter is within an OR-condition or AND-condition",
+					Type:        FieldTypeBool,
+					Modifiers:   []string{},
+				},
+				{
+					Name:        "NestedFilters",
+					Description: "NestedFilters of the " + obj.Name + ", useful for more complex filters",
+					Type:        "[]" + obj.Name + filterSuffix,
+					Modifiers:   []string{},
+				},
+			},
+		}
+		result.Objects = append(result.Objects, mainFilter)
+
+		// Generate FilterEquals object - contains all fields as pointers
+		equalsFilter := Object{
+			Name:        obj.Name + filterEqualsSuffix,
+			Description: "Equality filter fields for " + obj.Name,
+			Fields:      make([]Field, 0, len(obj.Fields)),
+		}
+		for _, field := range obj.Fields {
+			equalsFilter.Fields = append(equalsFilter.Fields, generateFilterField(field, true))
+		}
+		result.Objects = append(result.Objects, equalsFilter)
+
+		// Generate FilterNotEquals object - same as FilterEquals
+		notEqualsFilter := Object{
+			Name:        obj.Name + filterNotEqualsSuffix,
+			Description: "Inequality filter fields for " + obj.Name,
+			Fields:      make([]Field, 0, len(obj.Fields)),
+		}
+		for _, field := range obj.Fields {
+			notEqualsFilter.Fields = append(notEqualsFilter.Fields, generateFilterField(field, true))
+		}
+		result.Objects = append(result.Objects, notEqualsFilter)
+
+		// Generate FilterRange object - only comparable fields
+		rangeFilter := Object{
+			Name:        obj.Name + filterRangeSuffix,
+			Description: "Range filter fields for " + obj.Name,
+			Fields:      make([]Field, 0),
+		}
+		for _, field := range obj.Fields {
+			if isComparableType(field.Type) {
+				rangeFilter.Fields = append(rangeFilter.Fields, generateFilterField(field, true))
+			}
+		}
+		result.Objects = append(result.Objects, rangeFilter)
+
+		// Generate FilterContains object - all fields except timestamps as arrays
+		containsFilter := Object{
+			Name:        obj.Name + filterContainsSuffix,
+			Description: "Contains filter fields for " + obj.Name,
+			Fields:      make([]Field, 0),
+		}
+		for _, field := range obj.Fields {
+			if field.Type != FieldTypeTimestamp {
+				containsField := Field{
+					Name:        field.Name,
+					Description: field.Description,
+					Type:        "[]" + field.Type,
+					Modifiers:   []string{},
+				}
+				containsFilter.Fields = append(containsFilter.Fields, containsField)
+			}
+		}
+		result.Objects = append(result.Objects, containsFilter)
+
+		// Generate FilterLike object - only string fields
+		likeFilter := Object{
+			Name:        obj.Name + filterLikeSuffix,
+			Description: "LIKE filter fields for " + obj.Name,
+			Fields:      make([]Field, 0),
+		}
+		for _, field := range obj.Fields {
+			if isStringType(field.Type) {
+				likeFilter.Fields = append(likeFilter.Fields, generateFilterField(field, true))
+			}
+		}
+		result.Objects = append(result.Objects, likeFilter)
+
+		// Generate FilterNull object - only nullable fields or arrays
+		nullFilter := Object{
+			Name:        obj.Name + filterNullSuffix,
+			Description: "Null filter fields for " + obj.Name,
+			Fields:      make([]Field, 0),
+		}
+		for _, field := range obj.Fields {
+			if canBeNull(field) {
+				nullField := Field{
+					Name:        field.Name,
+					Description: field.Description,
+					Type:        "*" + FieldTypeBool,
+					Modifiers:   []string{},
+				}
+				nullFilter.Fields = append(nullFilter.Fields, nullField)
+			}
+		}
+		result.Objects = append(result.Objects, nullFilter)
 	}
 
 	return result

--- a/specification/specification.go
+++ b/specification/specification.go
@@ -308,15 +308,15 @@ func canBeNull(field Field) bool {
 // generateFilterField creates a filter field based on the original field and filter type.
 func generateFilterField(originalField Field, isNullable bool, isArray bool) Field {
 	modifiers := []string{}
-	
+
 	if isNullable {
 		modifiers = append(modifiers, ModifierNullable)
 	}
-	
+
 	if isArray {
 		modifiers = append(modifiers, ModifierArray)
 	}
-	
+
 	return Field{
 		Name:        originalField.Name,
 		Description: originalField.Description,
@@ -325,7 +325,7 @@ func generateFilterField(originalField Field, isNullable bool, isArray bool) Fie
 	}
 }
 
-// ApplyFilterOverlay applies filter overlay to a specification, generating Filter objects 
+// ApplyFilterOverlay applies filter overlay to a specification, generating Filter objects
 // from existing Objects. This should be called after ApplyOverlay to ensure all Objects
 // are available for filter generation.
 func ApplyFilterOverlay(input *Service) *Service {
@@ -343,10 +343,10 @@ func ApplyFilterOverlay(input *Service) *Service {
 
 	// Copy enums
 	copy(result.Enums, input.Enums)
-	
+
 	// Copy existing objects first
 	result.Objects = append(result.Objects, input.Objects...)
-	
+
 	// Copy resources
 	copy(result.Resources, input.Resources)
 
@@ -364,7 +364,7 @@ func ApplyFilterOverlay(input *Service) *Service {
 					Modifiers:   []string{ModifierNullable},
 				},
 				{
-					Name:        "NotEquals", 
+					Name:        "NotEquals",
 					Description: "Inequality filters for " + obj.Name,
 					Type:        obj.Name + filterEqualsSuffix,
 					Modifiers:   []string{ModifierNullable},

--- a/specification/specification.go
+++ b/specification/specification.go
@@ -26,13 +26,12 @@ const (
 
 // Filter suffixes
 const (
-	filterSuffix           = "Filter"
-	filterEqualsSuffix     = "FilterEquals"
-	filterNotEqualsSuffix  = "FilterNotEquals"
-	filterRangeSuffix      = "FilterRange"
-	filterContainsSuffix   = "FilterContains"
-	filterLikeSuffix       = "FilterLike"
-	filterNullSuffix       = "FilterNull"
+	filterSuffix         = "Filter"
+	filterEqualsSuffix   = "FilterEquals"
+	filterRangeSuffix    = "FilterRange"
+	filterContainsSuffix = "FilterContains"
+	filterLikeSuffix     = "FilterLike"
+	filterNullSuffix     = "FilterNull"
 )
 
 // Service is the definition of an API service.
@@ -307,25 +306,22 @@ func canBeNull(field Field) bool {
 }
 
 // generateFilterField creates a filter field based on the original field and filter type.
-func generateFilterField(originalField Field, isPointer bool) Field {
-	fieldType := originalField.Type
-	if isPointer {
-		// For pointer fields in filter structs, we use the pointer form
-		fieldType = "*" + fieldType
+func generateFilterField(originalField Field, isNullable bool, isArray bool) Field {
+	modifiers := []string{}
+	
+	if isNullable {
+		modifiers = append(modifiers, ModifierNullable)
 	}
 	
-	// For array fields in Contains filters, we use slice form
-	if originalField.Type == FieldTypeString && !isPointer {
-		fieldType = "[]" + originalField.Type
-	} else if originalField.Type == FieldTypeInt && !isPointer {
-		fieldType = "[]" + originalField.Type
+	if isArray {
+		modifiers = append(modifiers, ModifierArray)
 	}
 	
 	return Field{
 		Name:        originalField.Name,
 		Description: originalField.Description,
-		Type:        fieldType,
-		Modifiers:   []string{}, // Filter fields don't inherit modifiers
+		Type:        originalField.Type,
+		Modifiers:   modifiers,
 	}
 }
 
@@ -364,74 +360,74 @@ func ApplyFilterOverlay(input *Service) *Service {
 				{
 					Name:        "Equals",
 					Description: "Equality filters for " + obj.Name,
-					Type:        "*" + obj.Name + filterEqualsSuffix,
-					Modifiers:   []string{},
+					Type:        obj.Name + filterEqualsSuffix,
+					Modifiers:   []string{ModifierNullable},
 				},
 				{
 					Name:        "NotEquals", 
 					Description: "Inequality filters for " + obj.Name,
-					Type:        "*" + obj.Name + filterNotEqualsSuffix,
-					Modifiers:   []string{},
+					Type:        obj.Name + filterEqualsSuffix,
+					Modifiers:   []string{ModifierNullable},
 				},
 				{
 					Name:        "GreaterThan",
 					Description: "Greater than filters for " + obj.Name,
-					Type:        "*" + obj.Name + filterRangeSuffix,
-					Modifiers:   []string{},
+					Type:        obj.Name + filterRangeSuffix,
+					Modifiers:   []string{ModifierNullable},
 				},
 				{
 					Name:        "SmallerThan",
 					Description: "Smaller than filters for " + obj.Name,
-					Type:        "*" + obj.Name + filterRangeSuffix,
-					Modifiers:   []string{},
+					Type:        obj.Name + filterRangeSuffix,
+					Modifiers:   []string{ModifierNullable},
 				},
 				{
 					Name:        "GreaterOrEqual",
 					Description: "Greater than or equal filters for " + obj.Name,
-					Type:        "*" + obj.Name + filterRangeSuffix,
-					Modifiers:   []string{},
+					Type:        obj.Name + filterRangeSuffix,
+					Modifiers:   []string{ModifierNullable},
 				},
 				{
 					Name:        "SmallerOrEqual",
 					Description: "Smaller than or equal filters for " + obj.Name,
-					Type:        "*" + obj.Name + filterRangeSuffix,
-					Modifiers:   []string{},
+					Type:        obj.Name + filterRangeSuffix,
+					Modifiers:   []string{ModifierNullable},
 				},
 				{
 					Name:        "Contains",
 					Description: "Contains filters for " + obj.Name,
-					Type:        "*" + obj.Name + filterContainsSuffix,
-					Modifiers:   []string{},
+					Type:        obj.Name + filterContainsSuffix,
+					Modifiers:   []string{ModifierNullable},
 				},
 				{
 					Name:        "NotContains",
 					Description: "Not contains filters for " + obj.Name,
-					Type:        "*" + obj.Name + filterContainsSuffix,
-					Modifiers:   []string{},
+					Type:        obj.Name + filterContainsSuffix,
+					Modifiers:   []string{ModifierNullable},
 				},
 				{
 					Name:        "Like",
 					Description: "LIKE filters for " + obj.Name,
-					Type:        "*" + obj.Name + filterLikeSuffix,
-					Modifiers:   []string{},
+					Type:        obj.Name + filterLikeSuffix,
+					Modifiers:   []string{ModifierNullable},
 				},
 				{
 					Name:        "NotLike",
 					Description: "NOT LIKE filters for " + obj.Name,
-					Type:        "*" + obj.Name + filterLikeSuffix,
-					Modifiers:   []string{},
+					Type:        obj.Name + filterLikeSuffix,
+					Modifiers:   []string{ModifierNullable},
 				},
 				{
 					Name:        "Null",
 					Description: "Null filters for " + obj.Name,
-					Type:        "*" + obj.Name + filterNullSuffix,
-					Modifiers:   []string{},
+					Type:        obj.Name + filterNullSuffix,
+					Modifiers:   []string{ModifierNullable},
 				},
 				{
 					Name:        "NotNull",
 					Description: "Not null filters for " + obj.Name,
-					Type:        "*" + obj.Name + filterNullSuffix,
-					Modifiers:   []string{},
+					Type:        obj.Name + filterNullSuffix,
+					Modifiers:   []string{ModifierNullable},
 				},
 				{
 					Name:        "OrCondition",
@@ -442,34 +438,23 @@ func ApplyFilterOverlay(input *Service) *Service {
 				{
 					Name:        "NestedFilters",
 					Description: "NestedFilters of the " + obj.Name + ", useful for more complex filters",
-					Type:        "[]" + obj.Name + filterSuffix,
-					Modifiers:   []string{},
+					Type:        obj.Name + filterSuffix,
+					Modifiers:   []string{ModifierArray},
 				},
 			},
 		}
 		result.Objects = append(result.Objects, mainFilter)
 
-		// Generate FilterEquals object - contains all fields as pointers
+		// Generate FilterEquals object - contains all fields as nullable (used for both Equals and NotEquals)
 		equalsFilter := Object{
 			Name:        obj.Name + filterEqualsSuffix,
-			Description: "Equality filter fields for " + obj.Name,
+			Description: "Equality/Inequality filter fields for " + obj.Name,
 			Fields:      make([]Field, 0, len(obj.Fields)),
 		}
 		for _, field := range obj.Fields {
-			equalsFilter.Fields = append(equalsFilter.Fields, generateFilterField(field, true))
+			equalsFilter.Fields = append(equalsFilter.Fields, generateFilterField(field, true, false))
 		}
 		result.Objects = append(result.Objects, equalsFilter)
-
-		// Generate FilterNotEquals object - same as FilterEquals
-		notEqualsFilter := Object{
-			Name:        obj.Name + filterNotEqualsSuffix,
-			Description: "Inequality filter fields for " + obj.Name,
-			Fields:      make([]Field, 0, len(obj.Fields)),
-		}
-		for _, field := range obj.Fields {
-			notEqualsFilter.Fields = append(notEqualsFilter.Fields, generateFilterField(field, true))
-		}
-		result.Objects = append(result.Objects, notEqualsFilter)
 
 		// Generate FilterRange object - only comparable fields
 		rangeFilter := Object{
@@ -479,7 +464,7 @@ func ApplyFilterOverlay(input *Service) *Service {
 		}
 		for _, field := range obj.Fields {
 			if isComparableType(field.Type) {
-				rangeFilter.Fields = append(rangeFilter.Fields, generateFilterField(field, true))
+				rangeFilter.Fields = append(rangeFilter.Fields, generateFilterField(field, true, false))
 			}
 		}
 		result.Objects = append(result.Objects, rangeFilter)
@@ -492,13 +477,7 @@ func ApplyFilterOverlay(input *Service) *Service {
 		}
 		for _, field := range obj.Fields {
 			if field.Type != FieldTypeTimestamp {
-				containsField := Field{
-					Name:        field.Name,
-					Description: field.Description,
-					Type:        "[]" + field.Type,
-					Modifiers:   []string{},
-				}
-				containsFilter.Fields = append(containsFilter.Fields, containsField)
+				containsFilter.Fields = append(containsFilter.Fields, generateFilterField(field, false, true))
 			}
 		}
 		result.Objects = append(result.Objects, containsFilter)
@@ -511,7 +490,7 @@ func ApplyFilterOverlay(input *Service) *Service {
 		}
 		for _, field := range obj.Fields {
 			if isStringType(field.Type) {
-				likeFilter.Fields = append(likeFilter.Fields, generateFilterField(field, true))
+				likeFilter.Fields = append(likeFilter.Fields, generateFilterField(field, true, false))
 			}
 		}
 		result.Objects = append(result.Objects, likeFilter)
@@ -524,12 +503,11 @@ func ApplyFilterOverlay(input *Service) *Service {
 		}
 		for _, field := range obj.Fields {
 			if canBeNull(field) {
-				nullField := Field{
+				nullField := generateFilterField(Field{
 					Name:        field.Name,
 					Description: field.Description,
-					Type:        "*" + FieldTypeBool,
-					Modifiers:   []string{},
-				}
+					Type:        FieldTypeBool,
+				}, true, false)
 				nullFilter.Fields = append(nullFilter.Fields, nullField)
 			}
 		}

--- a/specification/specification_test.go
+++ b/specification/specification_test.go
@@ -1208,7 +1208,7 @@ func TestApplyFilterOverlay(t *testing.T) {
 				},
 				{
 					Name:        "Product",
-					Description: "Product object", 
+					Description: "Product object",
 					Fields: []Field{
 						{
 							Name:        "ID",

--- a/specification/specification_test.go
+++ b/specification/specification_test.go
@@ -3,6 +3,7 @@ package specification
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/goccy/go-yaml"
@@ -1040,5 +1041,400 @@ func Test_containsOperation(t *testing.T) {
 		operations := []string{"read"}
 		result := containsOperation(operations, "Read")
 		assert.False(t, result) // Should be case-sensitive
+	})
+}
+
+func TestApplyFilterOverlay(t *testing.T) {
+	t.Run("NilInput", func(t *testing.T) {
+		result := ApplyFilterOverlay(nil)
+		assert.Nil(t, result)
+	})
+
+	t.Run("EmptyService", func(t *testing.T) {
+		input := &Service{
+			Name:      "TestService",
+			Enums:     []Enum{},
+			Objects:   []Object{},
+			Resources: []Resource{},
+		}
+
+		result := ApplyFilterOverlay(input)
+		require.NotNil(t, result)
+
+		// Should preserve service structure with no additional objects
+		assert.Equal(t, input.Name, result.Name)
+		assert.Equal(t, 0, len(result.Objects))
+		assert.Equal(t, 0, len(result.Enums))
+		assert.Equal(t, 0, len(result.Resources))
+	})
+
+	t.Run("ServiceWithOneObject", func(t *testing.T) {
+		input := &Service{
+			Name:  "TestService",
+			Enums: []Enum{},
+			Objects: []Object{
+				{
+					Name:        "Person",
+					Description: "Person object",
+					Fields: []Field{
+						{
+							Name:        "FirstName",
+							Type:        FieldTypeString,
+							Description: "First name",
+							Modifiers:   []string{},
+						},
+						{
+							Name:        "LastName",
+							Type:        FieldTypeString,
+							Description: "Last name",
+							Modifiers:   []string{},
+						},
+						{
+							Name:        "Age",
+							Type:        FieldTypeInt,
+							Description: "Age in years",
+							Modifiers:   []string{},
+						},
+						{
+							Name:        "RelatedPersonIDs",
+							Type:        FieldTypeString,
+							Description: "Related person IDs",
+							Modifiers:   []string{ModifierArray},
+						},
+					},
+				},
+			},
+			Resources: []Resource{},
+		}
+
+		result := ApplyFilterOverlay(input)
+		require.NotNil(t, result)
+
+		// Should have original object plus 7 filter objects (main + 6 filter types)
+		assert.Equal(t, 8, len(result.Objects))
+
+		// Check main filter object
+		mainFilter := result.Objects[1] // First is original Person object
+		assert.Equal(t, "PersonFilter", mainFilter.Name)
+		assert.Equal(t, "Filter object for Person", mainFilter.Description)
+		assert.Equal(t, 14, len(mainFilter.Fields)) // 12 filter types + OrCondition + NestedFilters
+
+		// Check that all filter field types are present
+		fieldNames := make(map[string]bool)
+		for _, field := range mainFilter.Fields {
+			fieldNames[field.Name] = true
+		}
+		assert.True(t, fieldNames["Equals"])
+		assert.True(t, fieldNames["NotEquals"])
+		assert.True(t, fieldNames["GreaterThan"])
+		assert.True(t, fieldNames["SmallerThan"])
+		assert.True(t, fieldNames["GreaterOrEqual"])
+		assert.True(t, fieldNames["SmallerOrEqual"])
+		assert.True(t, fieldNames["Contains"])
+		assert.True(t, fieldNames["NotContains"])
+		assert.True(t, fieldNames["Like"])
+		assert.True(t, fieldNames["NotLike"])
+		assert.True(t, fieldNames["Null"])
+		assert.True(t, fieldNames["NotNull"])
+		assert.True(t, fieldNames["OrCondition"])
+		assert.True(t, fieldNames["NestedFilters"])
+
+		// Check FilterEquals object
+		equalsFilter := result.Objects[2]
+		assert.Equal(t, "PersonFilterEquals", equalsFilter.Name)
+		assert.Equal(t, "Equality filter fields for Person", equalsFilter.Description)
+		assert.Equal(t, 4, len(equalsFilter.Fields)) // All original fields
+
+		// Check that fields are pointer types
+		for _, field := range equalsFilter.Fields {
+			assert.True(t, strings.HasPrefix(field.Type, "*"), "Field %s should be pointer type, got %s", field.Name, field.Type)
+		}
+
+		// Check FilterRange object
+		rangeFilter := result.Objects[4] // PersonFilterRange
+		assert.Equal(t, "PersonFilterRange", rangeFilter.Name)
+		assert.Equal(t, 1, len(rangeFilter.Fields)) // Only Age is comparable
+		assert.Equal(t, "Age", rangeFilter.Fields[0].Name)
+		assert.Equal(t, "*Int", rangeFilter.Fields[0].Type)
+
+		// Check FilterContains object
+		containsFilter := result.Objects[5] // PersonFilterContains
+		assert.Equal(t, "PersonFilterContains", containsFilter.Name)
+		assert.Equal(t, 4, len(containsFilter.Fields)) // All fields except timestamp (none in this case)
+
+		// Check that Contains fields are array types
+		for _, field := range containsFilter.Fields {
+			assert.True(t, strings.HasPrefix(field.Type, "[]"), "Field %s should be array type, got %s", field.Name, field.Type)
+		}
+
+		// Check FilterLike object
+		likeFilter := result.Objects[6] // PersonFilterLike
+		assert.Equal(t, "PersonFilterLike", likeFilter.Name)
+		assert.Equal(t, 3, len(likeFilter.Fields)) // Only string fields (FirstName, LastName, RelatedPersonIDs)
+
+		// Check FilterNull object
+		nullFilter := result.Objects[7] // PersonFilterNull
+		assert.Equal(t, "PersonFilterNull", nullFilter.Name)
+		assert.Equal(t, 1, len(nullFilter.Fields)) // Only RelatedPersonIDs has array modifier
+		assert.Equal(t, "RelatedPersonIDs", nullFilter.Fields[0].Name)
+		assert.Equal(t, "*Bool", nullFilter.Fields[0].Type)
+	})
+
+	t.Run("ServiceWithMultipleObjects", func(t *testing.T) {
+		input := &Service{
+			Name:  "TestService",
+			Enums: []Enum{},
+			Objects: []Object{
+				{
+					Name:        "User",
+					Description: "User object",
+					Fields: []Field{
+						{
+							Name:        "ID",
+							Type:        FieldTypeUUID,
+							Description: "User ID",
+							Modifiers:   []string{},
+						},
+						{
+							Name:        "Email",
+							Type:        FieldTypeString,
+							Description: "User email",
+							Modifiers:   []string{ModifierNullable},
+						},
+					},
+				},
+				{
+					Name:        "Product",
+					Description: "Product object", 
+					Fields: []Field{
+						{
+							Name:        "ID",
+							Type:        FieldTypeUUID,
+							Description: "Product ID",
+							Modifiers:   []string{},
+						},
+						{
+							Name:        "Price",
+							Type:        FieldTypeInt,
+							Description: "Product price",
+							Modifiers:   []string{},
+						},
+					},
+				},
+			},
+			Resources: []Resource{},
+		}
+
+		result := ApplyFilterOverlay(input)
+		require.NotNil(t, result)
+
+		// Should have 2 original objects + 2 * 7 filter objects = 16 total objects
+		assert.Equal(t, 16, len(result.Objects))
+
+		// Check that we have filters for both User and Product
+		objectNames := make(map[string]bool)
+		for _, obj := range result.Objects {
+			objectNames[obj.Name] = true
+		}
+
+		// Original objects
+		assert.True(t, objectNames["User"])
+		assert.True(t, objectNames["Product"])
+
+		// User filter objects
+		assert.True(t, objectNames["UserFilter"])
+		assert.True(t, objectNames["UserFilterEquals"])
+		assert.True(t, objectNames["UserFilterNotEquals"])
+		assert.True(t, objectNames["UserFilterRange"])
+		assert.True(t, objectNames["UserFilterContains"])
+		assert.True(t, objectNames["UserFilterLike"])
+		assert.True(t, objectNames["UserFilterNull"])
+
+		// Product filter objects
+		assert.True(t, objectNames["ProductFilter"])
+		assert.True(t, objectNames["ProductFilterEquals"])
+		assert.True(t, objectNames["ProductFilterNotEquals"])
+		assert.True(t, objectNames["ProductFilterRange"])
+		assert.True(t, objectNames["ProductFilterContains"])
+		assert.True(t, objectNames["ProductFilterLike"])
+		assert.True(t, objectNames["ProductFilterNull"])
+	})
+
+	t.Run("PreservesOriginalStructure", func(t *testing.T) {
+		input := &Service{
+			Name: "TestService",
+			Enums: []Enum{
+				{
+					Name:        "Status",
+					Description: "Status enum",
+					Values: []EnumValue{
+						{Name: "Active", Description: "Active status"},
+					},
+				},
+			},
+			Objects: []Object{
+				{
+					Name:        "TestObject",
+					Description: "Test object",
+					Fields: []Field{
+						{Name: "field1", Type: FieldTypeString, Description: "Field 1"},
+					},
+				},
+			},
+			Resources: []Resource{
+				{
+					Name:        "TestResource",
+					Description: "Test resource",
+					Operations:  []string{OperationRead},
+					Fields: []ResourceField{
+						{
+							Field: Field{
+								Name:        "id",
+								Type:        FieldTypeUUID,
+								Description: "Resource ID",
+							},
+							Operations: []string{OperationRead},
+						},
+					},
+				},
+			},
+		}
+
+		result := ApplyFilterOverlay(input)
+		require.NotNil(t, result)
+
+		// Should preserve all original structure
+		assert.Equal(t, input.Name, result.Name)
+		assert.Equal(t, len(input.Enums), len(result.Enums))
+		assert.Equal(t, len(input.Resources), len(result.Resources))
+
+		// Should have original object plus 7 filter objects
+		assert.Equal(t, 8, len(result.Objects)) // 1 original + 7 filter objects
+
+		// First object should be the original one
+		assert.Equal(t, "TestObject", result.Objects[0].Name)
+
+		// Should have generated filter objects
+		assert.Equal(t, "TestObjectFilter", result.Objects[1].Name)
+	})
+}
+
+func Test_containsModifier(t *testing.T) {
+	t.Run("EmptySlice", func(t *testing.T) {
+		result := containsModifier([]string{}, ModifierNullable)
+		assert.False(t, result)
+	})
+
+	t.Run("ModifierExists", func(t *testing.T) {
+		modifiers := []string{ModifierNullable, ModifierArray}
+		result := containsModifier(modifiers, ModifierNullable)
+		assert.True(t, result)
+	})
+
+	t.Run("ModifierDoesNotExist", func(t *testing.T) {
+		modifiers := []string{ModifierArray}
+		result := containsModifier(modifiers, ModifierNullable)
+		assert.False(t, result)
+	})
+}
+
+func Test_isComparableType(t *testing.T) {
+	t.Run("IntType", func(t *testing.T) {
+		result := isComparableType(FieldTypeInt)
+		assert.True(t, result)
+	})
+
+	t.Run("DateType", func(t *testing.T) {
+		result := isComparableType(FieldTypeDate)
+		assert.True(t, result)
+	})
+
+	t.Run("TimestampType", func(t *testing.T) {
+		result := isComparableType(FieldTypeTimestamp)
+		assert.True(t, result)
+	})
+
+	t.Run("StringType", func(t *testing.T) {
+		result := isComparableType(FieldTypeString)
+		assert.False(t, result)
+	})
+
+	t.Run("BoolType", func(t *testing.T) {
+		result := isComparableType(FieldTypeBool)
+		assert.False(t, result)
+	})
+
+	t.Run("UUIDType", func(t *testing.T) {
+		result := isComparableType(FieldTypeUUID)
+		assert.False(t, result)
+	})
+}
+
+func Test_isStringType(t *testing.T) {
+	t.Run("StringType", func(t *testing.T) {
+		result := isStringType(FieldTypeString)
+		assert.True(t, result)
+	})
+
+	t.Run("IntType", func(t *testing.T) {
+		result := isStringType(FieldTypeInt)
+		assert.False(t, result)
+	})
+
+	t.Run("BoolType", func(t *testing.T) {
+		result := isStringType(FieldTypeBool)
+		assert.False(t, result)
+	})
+}
+
+func Test_canBeNull(t *testing.T) {
+	t.Run("NullableField", func(t *testing.T) {
+		field := Field{
+			Name:      "test",
+			Type:      FieldTypeString,
+			Modifiers: []string{ModifierNullable},
+		}
+		result := canBeNull(field)
+		assert.True(t, result)
+	})
+
+	t.Run("ArrayField", func(t *testing.T) {
+		field := Field{
+			Name:      "test",
+			Type:      FieldTypeString,
+			Modifiers: []string{ModifierArray},
+		}
+		result := canBeNull(field)
+		assert.True(t, result)
+	})
+
+	t.Run("BothModifiers", func(t *testing.T) {
+		field := Field{
+			Name:      "test",
+			Type:      FieldTypeString,
+			Modifiers: []string{ModifierNullable, ModifierArray},
+		}
+		result := canBeNull(field)
+		assert.True(t, result)
+	})
+
+	t.Run("NoModifiers", func(t *testing.T) {
+		field := Field{
+			Name:      "test",
+			Type:      FieldTypeString,
+			Modifiers: []string{},
+		}
+		result := canBeNull(field)
+		assert.False(t, result)
+	})
+
+	t.Run("OtherModifiers", func(t *testing.T) {
+		field := Field{
+			Name:      "test",
+			Type:      FieldTypeString,
+			Modifiers: []string{"other"},
+		}
+		result := canBeNull(field)
+		assert.False(t, result)
 	})
 }


### PR DESCRIPTION
Add a specification overlay to generate strictly typed filter objects for existing data objects to be used in search endpoints, addressing INF-204.

---
Linear Issue: [INF-204](https://linear.app/meitner-se/issue/INF-204/specification-overlay-for-filter-objects)

<a href="https://cursor.com/background-agent?bcId=bc-bb682a5e-ed4c-4ef4-8c7a-a61ebd3b162a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bb682a5e-ed4c-4ef4-8c7a-a61ebd3b162a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

