### PR TITLE
Implement openapi base functions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/pb33f/libopenapi v0.25.9
 	github.com/stretchr/testify v1.11.1
 	github.com/xeipuuv/gojsonschema v1.2.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -25,5 +26,4 @@ require (
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/pb33f/libopenapi v0.25.9
 	github.com/stretchr/testify v1.11.1
 	github.com/xeipuuv/gojsonschema v1.2.0
-	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -26,4 +25,5 @@ require (
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/specification/openapi/doc.go
+++ b/specification/openapi/doc.go
@@ -5,30 +5,46 @@
 // The generated specifications follow the OpenAPI 3.1.0 standard and include comprehensive
 // schema definitions, endpoint documentation, and validation rules.
 //
-// The package leverages the libopenapi library for robust OpenAPI 3.1 support, providing
+// The package leverages the pb33f/libopenapi library for robust OpenAPI 3.1 support, providing
 // enterprise-grade functionality for generating, validating, and manipulating OpenAPI specifications.
+// By using libopenapi's high-level v3.Document types instead of custom definitions, we ensure
+// compatibility with the official OpenAPI 3.1 specification and gain access to powerful
+// parsing, validation, and serialization capabilities.
 //
 // # Future Usage
 //
 // Once implementation is complete, typical usage will be:
 //
 //	generator := openapi.NewGenerator()
-//	spec, err := generator.GenerateFromService(service)
+//	document, err := generator.GenerateFromService(service)
 //	if err != nil {
 //	    log.Fatal(err)
 //	}
 //
 //	// Convert to YAML
-//	yamlBytes, err := generator.ToYAML(spec)
+//	yamlBytes, err := generator.ToYAML(document)
 //	if err != nil {
 //	    log.Fatal(err)
 //	}
 //
 //	// Convert to JSON
-//	jsonBytes, err := generator.ToJSON(spec)
+//	jsonBytes, err := generator.ToJSON(document)
 //	if err != nil {
 //	    log.Fatal(err)
 //	}
+//
+// # libopenapi Integration
+//
+// This package uses types from github.com/pb33f/libopenapi:
+//   - v3.Document: High-level OpenAPI 3.1 document representation
+//   - base.Info: OpenAPI info section with title, description, and version
+//   - base.Schema: OpenAPI schema definitions for objects and types
+//   - v3.Components: OpenAPI components section for reusable schemas
+//   - v3.PathItem: OpenAPI path definitions with HTTP operations
+//
+// These types provide enterprise-grade OpenAPI 3.1 support with built-in
+// validation, parsing, and serialization capabilities, eliminating the need
+// for custom OpenAPI type definitions.
 //
 // # OpenAPI 3.1 Features
 //

--- a/specification/openapi/openapi.go
+++ b/specification/openapi/openapi.go
@@ -1,9 +1,169 @@
 package openapi
 
 import (
-	_ "github.com/pb33f/libopenapi"
+	"errors"
+
+	"github.com/meitner-se/publicapis-gen/specification"
 )
 
-// Import guard to prevent unused import errors until implementation is added.
-// This will be removed once actual functionality is implemented.
-var _ = struct{}{}
+// Error constants
+const (
+	errorNotImplemented    = "not implemented"
+	errorInvalidService    = "invalid service: service cannot be nil"
+	errorInvalidSpec       = "invalid specification: spec cannot be nil"
+	errorFailedToMarshal   = "failed to marshal specification"
+	errorFailedToUnmarshal = "failed to unmarshal specification"
+)
+
+// Generator handles OpenAPI 3.1 specification generation from specification.Service.
+type Generator struct {
+	// Version specifies the OpenAPI version to generate (default: "3.1.0")
+	Version string
+
+	// Title specifies the API title (defaults to service name if not set)
+	Title string
+
+	// Description specifies the API description
+	Description string
+
+	// ServerURL specifies the base server URL for the API
+	ServerURL string
+}
+
+// Specification represents a complete OpenAPI 3.1 specification.
+// This is a simplified structure that will be expanded as needed.
+type Specification struct {
+	OpenAPI    string              `json:"openapi" yaml:"openapi"`
+	Info       Info                `json:"info" yaml:"info"`
+	Servers    []Server            `json:"servers,omitempty" yaml:"servers,omitempty"`
+	Paths      map[string]PathItem `json:"paths,omitempty" yaml:"paths,omitempty"`
+	Components *Components         `json:"components,omitempty" yaml:"components,omitempty"`
+}
+
+// Info represents the info section of an OpenAPI specification.
+type Info struct {
+	Title       string `json:"title" yaml:"title"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+	Version     string `json:"version" yaml:"version"`
+}
+
+// Server represents a server entry in the OpenAPI specification.
+type Server struct {
+	URL         string `json:"url" yaml:"url"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+}
+
+// PathItem represents a path entry in the OpenAPI paths section.
+type PathItem struct {
+	Get    *Operation `json:"get,omitempty" yaml:"get,omitempty"`
+	Post   *Operation `json:"post,omitempty" yaml:"post,omitempty"`
+	Put    *Operation `json:"put,omitempty" yaml:"put,omitempty"`
+	Patch  *Operation `json:"patch,omitempty" yaml:"patch,omitempty"`
+	Delete *Operation `json:"delete,omitempty" yaml:"delete,omitempty"`
+}
+
+// Operation represents an HTTP operation in OpenAPI.
+type Operation struct {
+	Summary     string              `json:"summary,omitempty" yaml:"summary,omitempty"`
+	Description string              `json:"description,omitempty" yaml:"description,omitempty"`
+	OperationID string              `json:"operationId,omitempty" yaml:"operationId,omitempty"`
+	Parameters  []Parameter         `json:"parameters,omitempty" yaml:"parameters,omitempty"`
+	RequestBody *RequestBody        `json:"requestBody,omitempty" yaml:"requestBody,omitempty"`
+	Responses   map[string]Response `json:"responses" yaml:"responses"`
+	Tags        []string            `json:"tags,omitempty" yaml:"tags,omitempty"`
+}
+
+// Parameter represents a parameter in OpenAPI.
+type Parameter struct {
+	Name        string  `json:"name" yaml:"name"`
+	In          string  `json:"in" yaml:"in"`
+	Description string  `json:"description,omitempty" yaml:"description,omitempty"`
+	Required    bool    `json:"required,omitempty" yaml:"required,omitempty"`
+	Schema      *Schema `json:"schema,omitempty" yaml:"schema,omitempty"`
+}
+
+// RequestBody represents a request body in OpenAPI.
+type RequestBody struct {
+	Description string               `json:"description,omitempty" yaml:"description,omitempty"`
+	Content     map[string]MediaType `json:"content" yaml:"content"`
+	Required    bool                 `json:"required,omitempty" yaml:"required,omitempty"`
+}
+
+// Response represents a response in OpenAPI.
+type Response struct {
+	Description string               `json:"description" yaml:"description"`
+	Content     map[string]MediaType `json:"content,omitempty" yaml:"content,omitempty"`
+}
+
+// MediaType represents a media type in OpenAPI.
+type MediaType struct {
+	Schema *Schema `json:"schema,omitempty" yaml:"schema,omitempty"`
+}
+
+// Components represents the components section of OpenAPI.
+type Components struct {
+	Schemas map[string]Schema `json:"schemas,omitempty" yaml:"schemas,omitempty"`
+}
+
+// Schema represents a schema in OpenAPI.
+type Schema struct {
+	Type                 string            `json:"type,omitempty" yaml:"type,omitempty"`
+	Format               string            `json:"format,omitempty" yaml:"format,omitempty"`
+	Description          string            `json:"description,omitempty" yaml:"description,omitempty"`
+	Properties           map[string]Schema `json:"properties,omitempty" yaml:"properties,omitempty"`
+	Items                *Schema           `json:"items,omitempty" yaml:"items,omitempty"`
+	Required             []string          `json:"required,omitempty" yaml:"required,omitempty"`
+	Enum                 []interface{}     `json:"enum,omitempty" yaml:"enum,omitempty"`
+	Reference            string            `json:"$ref,omitempty" yaml:"$ref,omitempty"`
+	AdditionalProperties interface{}       `json:"additionalProperties,omitempty" yaml:"additionalProperties,omitempty"`
+}
+
+// NewGenerator creates a new OpenAPI generator with default settings.
+func NewGenerator() *Generator {
+	return &Generator{
+		Version: "3.1.0",
+	}
+}
+
+// GenerateFromService generates an OpenAPI 3.1 specification from a specification.Service.
+// This is currently a stub implementation that returns an error.
+func (g *Generator) GenerateFromService(service *specification.Service) (*Specification, error) {
+	if service == nil {
+		return nil, errors.New(errorInvalidService)
+	}
+
+	// TODO: Implement actual conversion from specification.Service to OpenAPI Specification
+	// This will involve:
+	// 1. Converting Service metadata to OpenAPI Info
+	// 2. Converting Resources to OpenAPI Paths
+	// 3. Converting Objects and Enums to OpenAPI Schemas
+	// 4. Handling endpoints, parameters, and responses
+
+	return nil, errors.New(errorNotImplemented)
+}
+
+// ToYAML converts an OpenAPI specification to YAML format.
+// This is currently a stub implementation that returns an error.
+func (g *Generator) ToYAML(spec *Specification) ([]byte, error) {
+	if spec == nil {
+		return nil, errors.New(errorInvalidSpec)
+	}
+	
+	// TODO: Implement YAML marshalling
+	// This should use yaml.Marshal to convert the specification to YAML
+	
+	return nil, errors.New(errorNotImplemented)
+}
+
+// ToJSON converts an OpenAPI specification to JSON format.
+// This is currently a stub implementation that returns an error.
+func (g *Generator) ToJSON(spec *Specification) ([]byte, error) {
+	if spec == nil {
+		return nil, errors.New(errorInvalidSpec)
+	}
+	
+	// TODO: Implement JSON marshalling
+	// This should use json.Marshal to convert the specification to JSON
+	
+	return nil, errors.New(errorNotImplemented)
+}

--- a/specification/openapi/openapi.go
+++ b/specification/openapi/openapi.go
@@ -4,15 +4,26 @@ import (
 	"errors"
 
 	"github.com/meitner-se/publicapis-gen/specification"
+	"github.com/pb33f/libopenapi"
+	"github.com/pb33f/libopenapi/datamodel/high/base"
+	"github.com/pb33f/libopenapi/datamodel/high/v3"
 )
 
 // Error constants
 const (
 	errorNotImplemented    = "not implemented"
 	errorInvalidService    = "invalid service: service cannot be nil"
-	errorInvalidSpec       = "invalid specification: spec cannot be nil"
+	errorInvalidDocument   = "invalid document: document cannot be nil"
 	errorFailedToMarshal   = "failed to marshal specification"
 	errorFailedToUnmarshal = "failed to unmarshal specification"
+)
+
+// Import guards to prevent unused import errors until implementation is added.
+// These will be used in the full implementation.
+var (
+	_ = libopenapi.NewDocument
+	_ = (*base.Info)(nil)
+	_ = (*v3.Document)(nil)
 )
 
 // Generator handles OpenAPI 3.1 specification generation from specification.Service.
@@ -30,94 +41,6 @@ type Generator struct {
 	ServerURL string
 }
 
-// Specification represents a complete OpenAPI 3.1 specification.
-// This is a simplified structure that will be expanded as needed.
-type Specification struct {
-	OpenAPI    string              `json:"openapi" yaml:"openapi"`
-	Info       Info                `json:"info" yaml:"info"`
-	Servers    []Server            `json:"servers,omitempty" yaml:"servers,omitempty"`
-	Paths      map[string]PathItem `json:"paths,omitempty" yaml:"paths,omitempty"`
-	Components *Components         `json:"components,omitempty" yaml:"components,omitempty"`
-}
-
-// Info represents the info section of an OpenAPI specification.
-type Info struct {
-	Title       string `json:"title" yaml:"title"`
-	Description string `json:"description,omitempty" yaml:"description,omitempty"`
-	Version     string `json:"version" yaml:"version"`
-}
-
-// Server represents a server entry in the OpenAPI specification.
-type Server struct {
-	URL         string `json:"url" yaml:"url"`
-	Description string `json:"description,omitempty" yaml:"description,omitempty"`
-}
-
-// PathItem represents a path entry in the OpenAPI paths section.
-type PathItem struct {
-	Get    *Operation `json:"get,omitempty" yaml:"get,omitempty"`
-	Post   *Operation `json:"post,omitempty" yaml:"post,omitempty"`
-	Put    *Operation `json:"put,omitempty" yaml:"put,omitempty"`
-	Patch  *Operation `json:"patch,omitempty" yaml:"patch,omitempty"`
-	Delete *Operation `json:"delete,omitempty" yaml:"delete,omitempty"`
-}
-
-// Operation represents an HTTP operation in OpenAPI.
-type Operation struct {
-	Summary     string              `json:"summary,omitempty" yaml:"summary,omitempty"`
-	Description string              `json:"description,omitempty" yaml:"description,omitempty"`
-	OperationID string              `json:"operationId,omitempty" yaml:"operationId,omitempty"`
-	Parameters  []Parameter         `json:"parameters,omitempty" yaml:"parameters,omitempty"`
-	RequestBody *RequestBody        `json:"requestBody,omitempty" yaml:"requestBody,omitempty"`
-	Responses   map[string]Response `json:"responses" yaml:"responses"`
-	Tags        []string            `json:"tags,omitempty" yaml:"tags,omitempty"`
-}
-
-// Parameter represents a parameter in OpenAPI.
-type Parameter struct {
-	Name        string  `json:"name" yaml:"name"`
-	In          string  `json:"in" yaml:"in"`
-	Description string  `json:"description,omitempty" yaml:"description,omitempty"`
-	Required    bool    `json:"required,omitempty" yaml:"required,omitempty"`
-	Schema      *Schema `json:"schema,omitempty" yaml:"schema,omitempty"`
-}
-
-// RequestBody represents a request body in OpenAPI.
-type RequestBody struct {
-	Description string               `json:"description,omitempty" yaml:"description,omitempty"`
-	Content     map[string]MediaType `json:"content" yaml:"content"`
-	Required    bool                 `json:"required,omitempty" yaml:"required,omitempty"`
-}
-
-// Response represents a response in OpenAPI.
-type Response struct {
-	Description string               `json:"description" yaml:"description"`
-	Content     map[string]MediaType `json:"content,omitempty" yaml:"content,omitempty"`
-}
-
-// MediaType represents a media type in OpenAPI.
-type MediaType struct {
-	Schema *Schema `json:"schema,omitempty" yaml:"schema,omitempty"`
-}
-
-// Components represents the components section of OpenAPI.
-type Components struct {
-	Schemas map[string]Schema `json:"schemas,omitempty" yaml:"schemas,omitempty"`
-}
-
-// Schema represents a schema in OpenAPI.
-type Schema struct {
-	Type                 string            `json:"type,omitempty" yaml:"type,omitempty"`
-	Format               string            `json:"format,omitempty" yaml:"format,omitempty"`
-	Description          string            `json:"description,omitempty" yaml:"description,omitempty"`
-	Properties           map[string]Schema `json:"properties,omitempty" yaml:"properties,omitempty"`
-	Items                *Schema           `json:"items,omitempty" yaml:"items,omitempty"`
-	Required             []string          `json:"required,omitempty" yaml:"required,omitempty"`
-	Enum                 []interface{}     `json:"enum,omitempty" yaml:"enum,omitempty"`
-	Reference            string            `json:"$ref,omitempty" yaml:"$ref,omitempty"`
-	AdditionalProperties interface{}       `json:"additionalProperties,omitempty" yaml:"additionalProperties,omitempty"`
-}
-
 // NewGenerator creates a new OpenAPI generator with default settings.
 func NewGenerator() *Generator {
 	return &Generator{
@@ -125,45 +48,46 @@ func NewGenerator() *Generator {
 	}
 }
 
-// GenerateFromService generates an OpenAPI 3.1 specification from a specification.Service.
+// GenerateFromService generates an OpenAPI 3.1 document from a specification.Service.
 // This is currently a stub implementation that returns an error.
-func (g *Generator) GenerateFromService(service *specification.Service) (*Specification, error) {
+func (g *Generator) GenerateFromService(service *specification.Service) (*v3.Document, error) {
 	if service == nil {
 		return nil, errors.New(errorInvalidService)
 	}
 
-	// TODO: Implement actual conversion from specification.Service to OpenAPI Specification
+	// TODO: Implement actual conversion from specification.Service to OpenAPI Document
 	// This will involve:
 	// 1. Converting Service metadata to OpenAPI Info
 	// 2. Converting Resources to OpenAPI Paths
 	// 3. Converting Objects and Enums to OpenAPI Schemas
 	// 4. Handling endpoints, parameters, and responses
+	// 5. Creating a libopenapi Document from the high-level structure
 
 	return nil, errors.New(errorNotImplemented)
 }
 
-// ToYAML converts an OpenAPI specification to YAML format.
+// ToYAML converts an OpenAPI document to YAML format.
 // This is currently a stub implementation that returns an error.
-func (g *Generator) ToYAML(spec *Specification) ([]byte, error) {
-	if spec == nil {
-		return nil, errors.New(errorInvalidSpec)
+func (g *Generator) ToYAML(document *v3.Document) ([]byte, error) {
+	if document == nil {
+		return nil, errors.New(errorInvalidDocument)
 	}
-	
-	// TODO: Implement YAML marshalling
-	// This should use yaml.Marshal to convert the specification to YAML
-	
+
+	// TODO: Implement YAML marshalling using libopenapi
+	// This should use the libopenapi Document's serialization methods
+
 	return nil, errors.New(errorNotImplemented)
 }
 
-// ToJSON converts an OpenAPI specification to JSON format.
+// ToJSON converts an OpenAPI document to JSON format.
 // This is currently a stub implementation that returns an error.
-func (g *Generator) ToJSON(spec *Specification) ([]byte, error) {
-	if spec == nil {
-		return nil, errors.New(errorInvalidSpec)
+func (g *Generator) ToJSON(document *v3.Document) ([]byte, error) {
+	if document == nil {
+		return nil, errors.New(errorInvalidDocument)
 	}
-	
-	// TODO: Implement JSON marshalling
-	// This should use json.Marshal to convert the specification to JSON
-	
+
+	// TODO: Implement JSON marshalling using libopenapi
+	// This should use the libopenapi Document's serialization methods
+
 	return nil, errors.New(errorNotImplemented)
 }

--- a/specification/openapi/openapi_test.go
+++ b/specification/openapi/openapi_test.go
@@ -8,9 +8,9 @@ import (
 )
 
 const (
-	expectedErrorNotImplemented = "not implemented"
-	expectedErrorInvalidService = "invalid service: service cannot be nil"
-	expectedErrorInvalidSpec    = "invalid specification: spec cannot be nil"
+	expectedErrorNotImplemented  = "not implemented"
+	expectedErrorInvalidService  = "invalid service: service cannot be nil"
+	expectedErrorInvalidDocument = "invalid document: document cannot be nil"
 )
 
 // TestNewGenerator tests the creation of a new OpenAPI generator.
@@ -30,9 +30,9 @@ func TestNewGenerator(t *testing.T) {
 func TestGenerateFromServiceWithNilService(t *testing.T) {
 	generator := NewGenerator()
 
-	spec, err := generator.GenerateFromService(nil)
+	document, err := generator.GenerateFromService(nil)
 
-	assert.Nil(t, spec, "Specification should be nil when service is nil")
+	assert.Nil(t, document, "Document should be nil when service is nil")
 	assert.EqualError(t, err, expectedErrorInvalidService, "Should return invalid service error")
 }
 
@@ -43,102 +43,30 @@ func TestGenerateFromServiceWithValidService(t *testing.T) {
 		Name: "TestService",
 	}
 
-	spec, err := generator.GenerateFromService(service)
+	document, err := generator.GenerateFromService(service)
 
-	assert.Nil(t, spec, "Specification should be nil in stub implementation")
+	assert.Nil(t, document, "Document should be nil in stub implementation")
 	assert.EqualError(t, err, expectedErrorNotImplemented, "Should return not implemented error")
 }
 
-// TestToYAMLWithNilSpec tests error handling when specification is nil.
-func TestToYAMLWithNilSpec(t *testing.T) {
+// TestToYAMLWithNilDocument tests error handling when document is nil.
+func TestToYAMLWithNilDocument(t *testing.T) {
 	generator := NewGenerator()
 
 	yamlBytes, err := generator.ToYAML(nil)
 
-	assert.Nil(t, yamlBytes, "YAML bytes should be nil when spec is nil")
-	assert.EqualError(t, err, expectedErrorInvalidSpec, "Should return invalid spec error")
+	assert.Nil(t, yamlBytes, "YAML bytes should be nil when document is nil")
+	assert.EqualError(t, err, expectedErrorInvalidDocument, "Should return invalid document error")
 }
 
-// TestToYAMLWithValidSpec tests stub behavior with valid specification.
-func TestToYAMLWithValidSpec(t *testing.T) {
-	generator := NewGenerator()
-	spec := &Specification{
-		OpenAPI: "3.1.0",
-		Info: Info{
-			Title:   "Test API",
-			Version: "1.0.0",
-		},
-	}
-
-	yamlBytes, err := generator.ToYAML(spec)
-
-	assert.Nil(t, yamlBytes, "YAML bytes should be nil in stub implementation")
-	assert.EqualError(t, err, expectedErrorNotImplemented, "Should return not implemented error")
-}
-
-// TestToJSONWithNilSpec tests error handling when specification is nil.
-func TestToJSONWithNilSpec(t *testing.T) {
+// TestToJSONWithNilDocument tests error handling when document is nil.
+func TestToJSONWithNilDocument(t *testing.T) {
 	generator := NewGenerator()
 
 	jsonBytes, err := generator.ToJSON(nil)
 
-	assert.Nil(t, jsonBytes, "JSON bytes should be nil when spec is nil")
-	assert.EqualError(t, err, expectedErrorInvalidSpec, "Should return invalid spec error")
-}
-
-// TestToJSONWithValidSpec tests stub behavior with valid specification.
-func TestToJSONWithValidSpec(t *testing.T) {
-	generator := NewGenerator()
-	spec := &Specification{
-		OpenAPI: "3.1.0",
-		Info: Info{
-			Title:   "Test API",
-			Version: "1.0.0",
-		},
-	}
-
-	jsonBytes, err := generator.ToJSON(spec)
-
-	assert.Nil(t, jsonBytes, "JSON bytes should be nil in stub implementation")
-	assert.EqualError(t, err, expectedErrorNotImplemented, "Should return not implemented error")
-}
-
-// TestSpecificationStructure tests the OpenAPI specification structure.
-func TestSpecificationStructure(t *testing.T) {
-	expectedOpenAPI := "3.1.0"
-	expectedTitle := "Test API"
-	expectedVersion := "1.0.0"
-	expectedDescription := "Test API Description"
-	expectedServerURL := "https://api.example.com"
-	expectedServerDescription := "Production server"
-
-	spec := &Specification{
-		OpenAPI: expectedOpenAPI,
-		Info: Info{
-			Title:       expectedTitle,
-			Version:     expectedVersion,
-			Description: expectedDescription,
-		},
-		Servers: []Server{
-			{
-				URL:         expectedServerURL,
-				Description: expectedServerDescription,
-			},
-		},
-		Paths:      make(map[string]PathItem),
-		Components: &Components{Schemas: make(map[string]Schema)},
-	}
-
-	assert.Equal(t, expectedOpenAPI, spec.OpenAPI, "OpenAPI version should match")
-	assert.Equal(t, expectedTitle, spec.Info.Title, "Info title should match")
-	assert.Equal(t, expectedVersion, spec.Info.Version, "Info version should match")
-	assert.Equal(t, expectedDescription, spec.Info.Description, "Info description should match")
-	assert.Len(t, spec.Servers, 1, "Should have one server")
-	assert.Equal(t, expectedServerURL, spec.Servers[0].URL, "Server URL should match")
-	assert.Equal(t, expectedServerDescription, spec.Servers[0].Description, "Server description should match")
-	assert.NotNil(t, spec.Paths, "Paths should not be nil")
-	assert.NotNil(t, spec.Components, "Components should not be nil")
-	assert.NotNil(t, spec.Components.Schemas, "Schemas should not be nil")
+	assert.Nil(t, jsonBytes, "JSON bytes should be nil when document is nil")
+	assert.EqualError(t, err, expectedErrorInvalidDocument, "Should return invalid document error")
 }
 
 // TestGeneratorConfiguration tests generator configuration options.

--- a/specification/openapi/openapi_test.go
+++ b/specification/openapi/openapi_test.go
@@ -1,0 +1,160 @@
+package openapi
+
+import (
+	"testing"
+
+	"github.com/meitner-se/publicapis-gen/specification"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	expectedErrorNotImplemented = "not implemented"
+	expectedErrorInvalidService = "invalid service: service cannot be nil"
+	expectedErrorInvalidSpec    = "invalid specification: spec cannot be nil"
+)
+
+// TestNewGenerator tests the creation of a new OpenAPI generator.
+func TestNewGenerator(t *testing.T) {
+	expectedVersion := "3.1.0"
+
+	generator := NewGenerator()
+
+	assert.NotNil(t, generator, "Generator should not be nil")
+	assert.Equal(t, expectedVersion, generator.Version, "Generator version should be 3.1.0")
+	assert.Equal(t, "", generator.Title, "Generator title should be empty by default")
+	assert.Equal(t, "", generator.Description, "Generator description should be empty by default")
+	assert.Equal(t, "", generator.ServerURL, "Generator server URL should be empty by default")
+}
+
+// TestGenerateFromServiceWithNilService tests error handling when service is nil.
+func TestGenerateFromServiceWithNilService(t *testing.T) {
+	generator := NewGenerator()
+
+	spec, err := generator.GenerateFromService(nil)
+
+	assert.Nil(t, spec, "Specification should be nil when service is nil")
+	assert.EqualError(t, err, expectedErrorInvalidService, "Should return invalid service error")
+}
+
+// TestGenerateFromServiceWithValidService tests stub behavior with valid service.
+func TestGenerateFromServiceWithValidService(t *testing.T) {
+	generator := NewGenerator()
+	service := &specification.Service{
+		Name: "TestService",
+	}
+
+	spec, err := generator.GenerateFromService(service)
+
+	assert.Nil(t, spec, "Specification should be nil in stub implementation")
+	assert.EqualError(t, err, expectedErrorNotImplemented, "Should return not implemented error")
+}
+
+// TestToYAMLWithNilSpec tests error handling when specification is nil.
+func TestToYAMLWithNilSpec(t *testing.T) {
+	generator := NewGenerator()
+
+	yamlBytes, err := generator.ToYAML(nil)
+
+	assert.Nil(t, yamlBytes, "YAML bytes should be nil when spec is nil")
+	assert.EqualError(t, err, expectedErrorInvalidSpec, "Should return invalid spec error")
+}
+
+// TestToYAMLWithValidSpec tests stub behavior with valid specification.
+func TestToYAMLWithValidSpec(t *testing.T) {
+	generator := NewGenerator()
+	spec := &Specification{
+		OpenAPI: "3.1.0",
+		Info: Info{
+			Title:   "Test API",
+			Version: "1.0.0",
+		},
+	}
+
+	yamlBytes, err := generator.ToYAML(spec)
+
+	assert.Nil(t, yamlBytes, "YAML bytes should be nil in stub implementation")
+	assert.EqualError(t, err, expectedErrorNotImplemented, "Should return not implemented error")
+}
+
+// TestToJSONWithNilSpec tests error handling when specification is nil.
+func TestToJSONWithNilSpec(t *testing.T) {
+	generator := NewGenerator()
+
+	jsonBytes, err := generator.ToJSON(nil)
+
+	assert.Nil(t, jsonBytes, "JSON bytes should be nil when spec is nil")
+	assert.EqualError(t, err, expectedErrorInvalidSpec, "Should return invalid spec error")
+}
+
+// TestToJSONWithValidSpec tests stub behavior with valid specification.
+func TestToJSONWithValidSpec(t *testing.T) {
+	generator := NewGenerator()
+	spec := &Specification{
+		OpenAPI: "3.1.0",
+		Info: Info{
+			Title:   "Test API",
+			Version: "1.0.0",
+		},
+	}
+
+	jsonBytes, err := generator.ToJSON(spec)
+
+	assert.Nil(t, jsonBytes, "JSON bytes should be nil in stub implementation")
+	assert.EqualError(t, err, expectedErrorNotImplemented, "Should return not implemented error")
+}
+
+// TestSpecificationStructure tests the OpenAPI specification structure.
+func TestSpecificationStructure(t *testing.T) {
+	expectedOpenAPI := "3.1.0"
+	expectedTitle := "Test API"
+	expectedVersion := "1.0.0"
+	expectedDescription := "Test API Description"
+	expectedServerURL := "https://api.example.com"
+	expectedServerDescription := "Production server"
+
+	spec := &Specification{
+		OpenAPI: expectedOpenAPI,
+		Info: Info{
+			Title:       expectedTitle,
+			Version:     expectedVersion,
+			Description: expectedDescription,
+		},
+		Servers: []Server{
+			{
+				URL:         expectedServerURL,
+				Description: expectedServerDescription,
+			},
+		},
+		Paths:      make(map[string]PathItem),
+		Components: &Components{Schemas: make(map[string]Schema)},
+	}
+
+	assert.Equal(t, expectedOpenAPI, spec.OpenAPI, "OpenAPI version should match")
+	assert.Equal(t, expectedTitle, spec.Info.Title, "Info title should match")
+	assert.Equal(t, expectedVersion, spec.Info.Version, "Info version should match")
+	assert.Equal(t, expectedDescription, spec.Info.Description, "Info description should match")
+	assert.Len(t, spec.Servers, 1, "Should have one server")
+	assert.Equal(t, expectedServerURL, spec.Servers[0].URL, "Server URL should match")
+	assert.Equal(t, expectedServerDescription, spec.Servers[0].Description, "Server description should match")
+	assert.NotNil(t, spec.Paths, "Paths should not be nil")
+	assert.NotNil(t, spec.Components, "Components should not be nil")
+	assert.NotNil(t, spec.Components.Schemas, "Schemas should not be nil")
+}
+
+// TestGeneratorConfiguration tests generator configuration options.
+func TestGeneratorConfiguration(t *testing.T) {
+	expectedTitle := "Custom API"
+	expectedDescription := "Custom API Description"
+	expectedServerURL := "https://custom.example.com"
+
+	generator := &Generator{
+		Version:     "3.1.0",
+		Title:       expectedTitle,
+		Description: expectedDescription,
+		ServerURL:   expectedServerURL,
+	}
+
+	assert.Equal(t, expectedTitle, generator.Title, "Generator title should match configured value")
+	assert.Equal(t, expectedDescription, generator.Description, "Generator description should match configured value")
+	assert.Equal(t, expectedServerURL, generator.ServerURL, "Generator server URL should match configured value")
+}


### PR DESCRIPTION
Implement base functions and OpenAPI 3.1 data structures as stubs for specification generation (INF-230).

---
Linear Issue: [INF-230](https://linear.app/meitner-se/issue/INF-230/implement-the-base-functions-for-openapi-specification)

<a href="https://cursor.com/background-agent?bcId=bc-85e8224d-4459-4180-aea5-7d3ac1718600">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-85e8224d-4459-4180-aea5-7d3ac1718600">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

