### PR TITLE
Add config to skip auto columns

### DIFF
--- a/specification/specification.go
+++ b/specification/specification.go
@@ -348,6 +348,9 @@ type Resource struct {
 
 	// Endpoints of the resource
 	Endpoints []Endpoint `json:"endpoints"`
+
+	// SkipAutoColumns indicates whether to skip generating auto columns (ID, CreatedAt, etc.) for this resource
+	SkipAutoColumns bool `json:"skip_auto_columns,omitempty"`
 }
 
 // Field contains information about a field within an endpoint or resource or Object.
@@ -619,9 +622,11 @@ func generateObjectsFromResources(result *Service, resources []Resource) {
 				// Get readable fields from the resource
 				fields := resource.GetReadableFields()
 
-				// Add auto-columns to the object
-				autoColumns := CreateAutoColumns()
-				fields = append(autoColumns, fields...)
+				// Add auto-columns to the object if not skipped
+				if !resource.ShouldSkipAutoColumns() {
+					autoColumns := CreateAutoColumns()
+					fields = append(autoColumns, fields...)
+				}
 
 				// Create a new Object based on the Resource
 				newObject := Object{
@@ -1363,6 +1368,11 @@ func (r Resource) HasReadOperation() bool {
 // HasUpdateOperation checks if the Resource supports Update operations.
 func (r Resource) HasUpdateOperation() bool {
 	return slices.Contains(r.Operations, OperationUpdate)
+}
+
+// ShouldSkipAutoColumns checks if the Resource should skip generating auto columns.
+func (r Resource) ShouldSkipAutoColumns() bool {
+	return r.SkipAutoColumns
 }
 
 // GetPluralName returns the pluralized name of the resource.


### PR DESCRIPTION
Add `SkipAutoColumns` configuration to the Resource specification to allow skipping the generation of default auto columns.

---
Linear Issue: [INF-242](https://linear.app/meitner-se/issue/INF-242/add-configuration-in-resource-specification-to-skip-generating-the)

<a href="https://cursor.com/background-agent?bcId=bc-601afa52-8fb6-4685-80f6-e848dd0dc352">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-601afa52-8fb6-4685-80f6-e848dd0dc352">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

