### PR TITLE
Update overlay descriptions with resource names

### DIFF
--- a/specification/specification.go
+++ b/specification/specification.go
@@ -161,16 +161,16 @@ const (
 
 // Auto-column constants
 const (
-	autoColumnIDName        = "ID"
-	autoColumnIDDescription = "Unique identifier for the resource"
-	autoColumnCreatedAtName = "CreatedAt"
-	autoColumnCreatedAtDesc = "Timestamp when the resource was created"
-	autoColumnCreatedByName = "CreatedBy"
-	autoColumnCreatedByDesc = "User who created the resource"
-	autoColumnUpdatedAtName = "UpdatedAt"
-	autoColumnUpdatedAtDesc = "Timestamp when the resource was last updated"
-	autoColumnUpdatedByName = "UpdatedBy"
-	autoColumnUpdatedByDesc = "User who last updated the resource"
+	autoColumnIDName            = "ID"
+	autoColumnIDDescTemplate    = "Unique identifier for the %s"
+	autoColumnCreatedAtName     = "CreatedAt"
+	autoColumnCreatedAtTemplate = "Timestamp when the %s was created"
+	autoColumnCreatedByName     = "CreatedBy"
+	autoColumnCreatedByTemplate = "User who created the %s"
+	autoColumnUpdatedAtName     = "UpdatedAt"
+	autoColumnUpdatedAtTemplate = "Timestamp when the %s was last updated"
+	autoColumnUpdatedByName     = "UpdatedBy"
+	autoColumnUpdatedByTemplate = "User who last updated the %s"
 )
 
 // HTTP Methods
@@ -204,7 +204,7 @@ const (
 	updateEndpointDescPrefix  = "Update a "
 	updateResponseStatusCode  = 200
 	updateIDParamName         = "id"
-	updateIDParamDescription  = "The unique identifier of the resource to update"
+	updateIDParamDescTemplate = "The unique identifier of the %s to update"
 )
 
 // Delete Endpoint Constants
@@ -215,7 +215,7 @@ const (
 	deleteEndpointDescPrefix  = "Delete a "
 	deleteResponseStatusCode  = 204
 	deleteIDParamName         = "id"
-	deleteIDParamDescription  = "The unique identifier of the resource to delete"
+	deleteIDParamDescTemplate = "The unique identifier of the %s to delete"
 )
 
 // Get Endpoint Constants
@@ -624,7 +624,7 @@ func generateObjectsFromResources(result *Service, resources []Resource) {
 
 				// Add auto-columns to the object if not skipped
 				if !resource.ShouldSkipAutoColumns() {
-					autoColumns := CreateAutoColumns()
+					autoColumns := CreateAutoColumns(resource.Name)
 					fields = append(autoColumns, fields...)
 				}
 
@@ -679,7 +679,7 @@ func generateUpdateEndpoint(result *Service, resource Resource) {
 		bodyParams := resource.GetUpdateBodyParams()
 		idParam := Field{
 			Name:        updateIDParamName,
-			Description: updateIDParamDescription,
+			Description: fmt.Sprintf(updateIDParamDescTemplate, resource.Name),
 			Type:        FieldTypeUUID,
 		}
 		resourceName := resource.Name
@@ -702,7 +702,7 @@ func generateDeleteEndpoint(result *Service, resource Resource) {
 	if resource.HasDeleteOperation() && !resource.HasEndpoint(deleteEndpointName) {
 		idParam := Field{
 			Name:        deleteIDParamName,
-			Description: deleteIDParamDescription,
+			Description: fmt.Sprintf(deleteIDParamDescTemplate, resource.Name),
 			Type:        FieldTypeUUID,
 		}
 		deleteEndpoint := Endpoint{
@@ -1563,60 +1563,60 @@ func CreateIDParam(description string) Field {
 }
 
 // CreateAutoColumnID creates a standard ID field for auto-columns.
-func CreateAutoColumnID() Field {
+func CreateAutoColumnID(resourceName string) Field {
 	return Field{
 		Name:        autoColumnIDName,
-		Description: autoColumnIDDescription,
+		Description: fmt.Sprintf(autoColumnIDDescTemplate, resourceName),
 		Type:        FieldTypeUUID,
 	}
 }
 
 // CreateAutoColumnCreatedAt creates a standard CreatedAt field for auto-columns.
-func CreateAutoColumnCreatedAt() Field {
+func CreateAutoColumnCreatedAt(resourceName string) Field {
 	return Field{
 		Name:        autoColumnCreatedAtName,
-		Description: autoColumnCreatedAtDesc,
+		Description: fmt.Sprintf(autoColumnCreatedAtTemplate, resourceName),
 		Type:        FieldTypeTimestamp,
 	}
 }
 
 // CreateAutoColumnCreatedBy creates a standard CreatedBy field for auto-columns.
-func CreateAutoColumnCreatedBy() Field {
+func CreateAutoColumnCreatedBy(resourceName string) Field {
 	return Field{
 		Name:        autoColumnCreatedByName,
-		Description: autoColumnCreatedByDesc,
+		Description: fmt.Sprintf(autoColumnCreatedByTemplate, resourceName),
 		Type:        FieldTypeUUID,
 		Modifiers:   []string{ModifierNullable},
 	}
 }
 
 // CreateAutoColumnUpdatedAt creates a standard UpdatedAt field for auto-columns.
-func CreateAutoColumnUpdatedAt() Field {
+func CreateAutoColumnUpdatedAt(resourceName string) Field {
 	return Field{
 		Name:        autoColumnUpdatedAtName,
-		Description: autoColumnUpdatedAtDesc,
+		Description: fmt.Sprintf(autoColumnUpdatedAtTemplate, resourceName),
 		Type:        FieldTypeTimestamp,
 	}
 }
 
 // CreateAutoColumnUpdatedBy creates a standard UpdatedBy field for auto-columns.
-func CreateAutoColumnUpdatedBy() Field {
+func CreateAutoColumnUpdatedBy(resourceName string) Field {
 	return Field{
 		Name:        autoColumnUpdatedByName,
-		Description: autoColumnUpdatedByDesc,
+		Description: fmt.Sprintf(autoColumnUpdatedByTemplate, resourceName),
 		Type:        FieldTypeUUID,
 		Modifiers:   []string{ModifierNullable},
 	}
 }
 
 // CreateAutoColumns creates all standard auto-column fields for resources.
-func CreateAutoColumns() []Field {
+func CreateAutoColumns(resourceName string) []Field {
 	return []Field{
-		CreateAutoColumnID(),
-		CreateAutoColumnCreatedAt(),
-		CreateAutoColumnCreatedBy(),
-		CreateAutoColumnUpdatedAt(),
-		CreateAutoColumnUpdatedBy(),
+		CreateAutoColumnID(resourceName),
+		CreateAutoColumnCreatedAt(resourceName),
+		CreateAutoColumnCreatedBy(resourceName),
+		CreateAutoColumnUpdatedAt(resourceName),
+		CreateAutoColumnUpdatedBy(resourceName),
 	}
 }
 

--- a/specification/specification_test.go
+++ b/specification/specification_test.go
@@ -2,6 +2,7 @@ package specification
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/goccy/go-yaml"
@@ -1083,108 +1084,131 @@ func TestCreateIDParam(t *testing.T) {
 }
 
 func TestCreateAutoColumnID(t *testing.T) {
+	// Arrange
+	resourceName := "User"
+	expectedDescription := fmt.Sprintf(autoColumnIDDescTemplate, resourceName)
+
 	// Act
-	idField := CreateAutoColumnID()
+	idField := CreateAutoColumnID(resourceName)
 
 	// Assert
 	assert.Equal(t, autoColumnIDName, idField.Name, "Auto-column ID should have correct name")
-	assert.Equal(t, autoColumnIDDescription, idField.Description, "Auto-column ID should have correct description")
+	assert.Equal(t, expectedDescription, idField.Description, "Auto-column ID should have correct description")
 	assert.Equal(t, FieldTypeUUID, idField.Type, "Auto-column ID should have UUID type")
 	assert.Empty(t, idField.Modifiers, "Auto-column ID should have no modifiers")
 	assert.Empty(t, idField.Default, "Auto-column ID should have no default value")
 	assert.Empty(t, idField.Example, "Auto-column ID should have no example")
 
 	t.Run("consistency", func(t *testing.T) {
-		id1 := CreateAutoColumnID()
-		id2 := CreateAutoColumnID()
+		id1 := CreateAutoColumnID(resourceName)
+		id2 := CreateAutoColumnID(resourceName)
 
 		assert.Equal(t, id1, id2, "CreateAutoColumnID should return consistent results")
 	})
 }
 
 func TestCreateAutoColumnCreatedAt(t *testing.T) {
+	// Arrange
+	resourceName := "User"
+	expectedDescription := fmt.Sprintf(autoColumnCreatedAtTemplate, resourceName)
+
 	// Act
-	createdAtField := CreateAutoColumnCreatedAt()
+	createdAtField := CreateAutoColumnCreatedAt(resourceName)
 
 	// Assert
 	assert.Equal(t, autoColumnCreatedAtName, createdAtField.Name, "Auto-column CreatedAt should have correct name")
-	assert.Equal(t, autoColumnCreatedAtDesc, createdAtField.Description, "Auto-column CreatedAt should have correct description")
+	assert.Equal(t, expectedDescription, createdAtField.Description, "Auto-column CreatedAt should have correct description")
 	assert.Equal(t, FieldTypeTimestamp, createdAtField.Type, "Auto-column CreatedAt should have Timestamp type")
 	assert.Empty(t, createdAtField.Modifiers, "Auto-column CreatedAt should have no modifiers")
 	assert.Empty(t, createdAtField.Default, "Auto-column CreatedAt should have no default value")
 	assert.Empty(t, createdAtField.Example, "Auto-column CreatedAt should have no example")
 
 	t.Run("consistency", func(t *testing.T) {
-		createdAt1 := CreateAutoColumnCreatedAt()
-		createdAt2 := CreateAutoColumnCreatedAt()
+		createdAt1 := CreateAutoColumnCreatedAt(resourceName)
+		createdAt2 := CreateAutoColumnCreatedAt(resourceName)
 
 		assert.Equal(t, createdAt1, createdAt2, "CreateAutoColumnCreatedAt should return consistent results")
 	})
 }
 
 func TestCreateAutoColumnCreatedBy(t *testing.T) {
+	// Arrange
+	resourceName := "User"
+	expectedDescription := fmt.Sprintf(autoColumnCreatedByTemplate, resourceName)
+
 	// Act
-	createdByField := CreateAutoColumnCreatedBy()
+	createdByField := CreateAutoColumnCreatedBy(resourceName)
 
 	// Assert
 	assert.Equal(t, autoColumnCreatedByName, createdByField.Name, "Auto-column CreatedBy should have correct name")
-	assert.Equal(t, autoColumnCreatedByDesc, createdByField.Description, "Auto-column CreatedBy should have correct description")
+	assert.Equal(t, expectedDescription, createdByField.Description, "Auto-column CreatedBy should have correct description")
 	assert.Equal(t, FieldTypeUUID, createdByField.Type, "Auto-column CreatedBy should have UUID type")
 	assert.Equal(t, []string{ModifierNullable}, createdByField.Modifiers, "Auto-column CreatedBy should have nullable modifier")
 	assert.Empty(t, createdByField.Default, "Auto-column CreatedBy should have no default value")
 	assert.Empty(t, createdByField.Example, "Auto-column CreatedBy should have no example")
 
 	t.Run("consistency", func(t *testing.T) {
-		createdBy1 := CreateAutoColumnCreatedBy()
-		createdBy2 := CreateAutoColumnCreatedBy()
+		createdBy1 := CreateAutoColumnCreatedBy(resourceName)
+		createdBy2 := CreateAutoColumnCreatedBy(resourceName)
 
 		assert.Equal(t, createdBy1, createdBy2, "CreateAutoColumnCreatedBy should return consistent results")
 	})
 }
 
 func TestCreateAutoColumnUpdatedAt(t *testing.T) {
+	// Arrange
+	resourceName := "User"
+	expectedDescription := fmt.Sprintf(autoColumnUpdatedAtTemplate, resourceName)
+
 	// Act
-	updatedAtField := CreateAutoColumnUpdatedAt()
+	updatedAtField := CreateAutoColumnUpdatedAt(resourceName)
 
 	// Assert
 	assert.Equal(t, autoColumnUpdatedAtName, updatedAtField.Name, "Auto-column UpdatedAt should have correct name")
-	assert.Equal(t, autoColumnUpdatedAtDesc, updatedAtField.Description, "Auto-column UpdatedAt should have correct description")
+	assert.Equal(t, expectedDescription, updatedAtField.Description, "Auto-column UpdatedAt should have correct description")
 	assert.Equal(t, FieldTypeTimestamp, updatedAtField.Type, "Auto-column UpdatedAt should have Timestamp type")
 	assert.Empty(t, updatedAtField.Modifiers, "Auto-column UpdatedAt should have no modifiers")
 	assert.Empty(t, updatedAtField.Default, "Auto-column UpdatedAt should have no default value")
 	assert.Empty(t, updatedAtField.Example, "Auto-column UpdatedAt should have no example")
 
 	t.Run("consistency", func(t *testing.T) {
-		updatedAt1 := CreateAutoColumnUpdatedAt()
-		updatedAt2 := CreateAutoColumnUpdatedAt()
+		updatedAt1 := CreateAutoColumnUpdatedAt(resourceName)
+		updatedAt2 := CreateAutoColumnUpdatedAt(resourceName)
 
 		assert.Equal(t, updatedAt1, updatedAt2, "CreateAutoColumnUpdatedAt should return consistent results")
 	})
 }
 
 func TestCreateAutoColumnUpdatedBy(t *testing.T) {
+	// Arrange
+	resourceName := "User"
+	expectedDescription := fmt.Sprintf(autoColumnUpdatedByTemplate, resourceName)
+
 	// Act
-	updatedByField := CreateAutoColumnUpdatedBy()
+	updatedByField := CreateAutoColumnUpdatedBy(resourceName)
 
 	// Assert
 	assert.Equal(t, autoColumnUpdatedByName, updatedByField.Name, "Auto-column UpdatedBy should have correct name")
-	assert.Equal(t, autoColumnUpdatedByDesc, updatedByField.Description, "Auto-column UpdatedBy should have correct description")
+	assert.Equal(t, expectedDescription, updatedByField.Description, "Auto-column UpdatedBy should have correct description")
 	assert.Equal(t, FieldTypeUUID, updatedByField.Type, "Auto-column UpdatedBy should have UUID type")
 	assert.Equal(t, []string{ModifierNullable}, updatedByField.Modifiers, "Auto-column UpdatedBy should have nullable modifier")
 	assert.Empty(t, updatedByField.Default, "Auto-column UpdatedBy should have no default value")
 	assert.Empty(t, updatedByField.Example, "Auto-column UpdatedBy should have no example")
 
 	t.Run("consistency", func(t *testing.T) {
-		updatedBy1 := CreateAutoColumnUpdatedBy()
-		updatedBy2 := CreateAutoColumnUpdatedBy()
+		updatedBy1 := CreateAutoColumnUpdatedBy(resourceName)
+		updatedBy2 := CreateAutoColumnUpdatedBy(resourceName)
 
 		assert.Equal(t, updatedBy1, updatedBy2, "CreateAutoColumnUpdatedBy should return consistent results")
 	})
 }
 
 func TestCreateAutoColumns(t *testing.T) {
+	// Arrange
+	resourceName := "User"
+
 	// Act
-	autoColumns := CreateAutoColumns()
+	autoColumns := CreateAutoColumns(resourceName)
 
 	// Assert
 	assert.Equal(t, 5, len(autoColumns), "Should return exactly 5 auto-columns")
@@ -1210,9 +1234,16 @@ func TestCreateAutoColumns(t *testing.T) {
 	assert.Empty(t, autoColumns[3].Modifiers, "UpdatedAt should have no modifiers")
 	assert.Equal(t, []string{ModifierNullable}, autoColumns[4].Modifiers, "UpdatedBy should be nullable")
 
+	// Verify descriptions use resource name
+	assert.Equal(t, fmt.Sprintf(autoColumnIDDescTemplate, resourceName), autoColumns[0].Description, "ID description should use resource name")
+	assert.Equal(t, fmt.Sprintf(autoColumnCreatedAtTemplate, resourceName), autoColumns[1].Description, "CreatedAt description should use resource name")
+	assert.Equal(t, fmt.Sprintf(autoColumnCreatedByTemplate, resourceName), autoColumns[2].Description, "CreatedBy description should use resource name")
+	assert.Equal(t, fmt.Sprintf(autoColumnUpdatedAtTemplate, resourceName), autoColumns[3].Description, "UpdatedAt description should use resource name")
+	assert.Equal(t, fmt.Sprintf(autoColumnUpdatedByTemplate, resourceName), autoColumns[4].Description, "UpdatedBy description should use resource name")
+
 	t.Run("consistency", func(t *testing.T) {
-		autoColumns1 := CreateAutoColumns()
-		autoColumns2 := CreateAutoColumns()
+		autoColumns1 := CreateAutoColumns(resourceName)
+		autoColumns2 := CreateAutoColumns(resourceName)
 
 		assert.Equal(t, autoColumns1, autoColumns2, "CreateAutoColumns should return consistent results")
 	})
@@ -1534,31 +1565,31 @@ func TestApplyOverlay(t *testing.T) {
 
 		// Verify ID field
 		assert.Equal(t, autoColumnIDName, autoColumnFields[0].Name)
-		assert.Equal(t, autoColumnIDDescription, autoColumnFields[0].Description)
+		assert.Equal(t, fmt.Sprintf(autoColumnIDDescTemplate, "Users"), autoColumnFields[0].Description)
 		assert.Equal(t, FieldTypeUUID, autoColumnFields[0].Type)
 		assert.Empty(t, autoColumnFields[0].Modifiers)
 
 		// Verify CreatedAt field
 		assert.Equal(t, autoColumnCreatedAtName, autoColumnFields[1].Name)
-		assert.Equal(t, autoColumnCreatedAtDesc, autoColumnFields[1].Description)
+		assert.Equal(t, fmt.Sprintf(autoColumnCreatedAtTemplate, "Users"), autoColumnFields[1].Description)
 		assert.Equal(t, FieldTypeTimestamp, autoColumnFields[1].Type)
 		assert.Empty(t, autoColumnFields[1].Modifiers)
 
 		// Verify CreatedBy field
 		assert.Equal(t, autoColumnCreatedByName, autoColumnFields[2].Name)
-		assert.Equal(t, autoColumnCreatedByDesc, autoColumnFields[2].Description)
+		assert.Equal(t, fmt.Sprintf(autoColumnCreatedByTemplate, "Users"), autoColumnFields[2].Description)
 		assert.Equal(t, FieldTypeUUID, autoColumnFields[2].Type)
 		assert.Equal(t, []string{ModifierNullable}, autoColumnFields[2].Modifiers)
 
 		// Verify UpdatedAt field
 		assert.Equal(t, autoColumnUpdatedAtName, autoColumnFields[3].Name)
-		assert.Equal(t, autoColumnUpdatedAtDesc, autoColumnFields[3].Description)
+		assert.Equal(t, fmt.Sprintf(autoColumnUpdatedAtTemplate, "Users"), autoColumnFields[3].Description)
 		assert.Equal(t, FieldTypeTimestamp, autoColumnFields[3].Type)
 		assert.Empty(t, autoColumnFields[3].Modifiers)
 
 		// Verify UpdatedBy field
 		assert.Equal(t, autoColumnUpdatedByName, autoColumnFields[4].Name)
-		assert.Equal(t, autoColumnUpdatedByDesc, autoColumnFields[4].Description)
+		assert.Equal(t, fmt.Sprintf(autoColumnUpdatedByTemplate, "Users"), autoColumnFields[4].Description)
 		assert.Equal(t, FieldTypeUUID, autoColumnFields[4].Type)
 		assert.Equal(t, []string{ModifierNullable}, autoColumnFields[4].Modifiers)
 


### PR DESCRIPTION
Update auto-generated overlay descriptions to use specific resource names instead of generic "the resource" text.

---
Linear Issue: [INF-243](https://linear.app/meitner-se/issue/INF-243/update-descriptions-for-the-generated-overlays)

<a href="https://cursor.com/background-agent?bcId=bc-f4fe737f-c6af-44dc-a36e-7b3ef22dd263">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f4fe737f-c6af-44dc-a36e-7b3ef22dd263">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

