### PR TITLE
Implement main go program logic

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,15 +2,58 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"flag"
+	"fmt"
 	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/goccy/go-yaml"
+	"github.com/meitner-se/publicapis-gen/specification"
+	"github.com/meitner-se/publicapis-gen/specification/openapi"
 )
 
 // Error messages and log keys
 const (
-	errorNotImplemented = "not implemented"
-	errorFailedToRun    = "failed to run"
-	logKeyError         = "error"
+	errorNotImplemented    = "not implemented"
+	errorFailedToRun       = "failed to run"
+	errorInvalidFile       = "invalid input file"
+	errorUnsupportedFormat = "unsupported file format"
+	errorInvalidMode       = "invalid operation mode"
+	errorFileRead          = "failed to read file"
+	errorFileParse         = "failed to parse file"
+	errorFileWrite         = "failed to write file"
+	logKeyError            = "error"
+	logKeyFile             = "file"
+	logKeyMode             = "mode"
+)
+
+// Operation modes
+const (
+	modeOverlay = "overlay"
+	modeOpenAPI = "openapi"
+)
+
+// File extensions
+const (
+	extYAML = ".yaml"
+	extYML  = ".yml"
+	extJSON = ".json"
+)
+
+// Output file suffixes
+const (
+	suffixOverlay = "-overlay"
+	suffixOpenAPI = "-openapi"
+)
+
+// Usage messages
+const (
+	usageDescription = "publicapis-gen - Generate API specifications and OpenAPI documents"
+	usageExample     = "\nExamples:\n  publicapis-gen -file=spec.yaml -mode=overlay\n  publicapis-gen -file=spec.json -mode=openapi\n  publicapis-gen -file=spec.yaml -mode=openapi -output=api-spec.yaml"
 )
 
 func main() {
@@ -18,9 +61,245 @@ func main() {
 
 	if err := run(ctx); err != nil {
 		slog.ErrorContext(ctx, errorFailedToRun, logKeyError, err)
+		os.Exit(1)
 	}
 }
 
-func run(_ context.Context) error {
-	return errors.New(errorNotImplemented)
+func run(ctx context.Context) error {
+	// Parse command line flags
+	var (
+		fileFlag   = flag.String("file", "", "Path to input specification file (YAML or JSON)")
+		modeFlag   = flag.String("mode", "", "Operation mode: 'overlay' or 'openapi'")
+		outputFlag = flag.String("output", "", "Output file path (optional, defaults to input name with suffix)")
+		helpFlag   = flag.Bool("help", false, "Show help message")
+	)
+
+	// Set custom usage function
+	flag.Usage = func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "%s\n\n", usageDescription)
+		fmt.Fprintf(flag.CommandLine.Output(), "Usage: %s [options]\n\n", os.Args[0])
+		flag.PrintDefaults()
+		fmt.Fprintf(flag.CommandLine.Output(), "%s\n", usageExample)
+	}
+
+	flag.Parse()
+
+	// Show help if requested
+	if *helpFlag {
+		flag.Usage()
+		return nil
+	}
+
+	// Validate required flags
+	if *fileFlag == "" {
+		flag.Usage()
+		return fmt.Errorf("%s: file flag is required", errorInvalidFile)
+	}
+
+	if *modeFlag == "" {
+		flag.Usage()
+		return fmt.Errorf("%s: mode flag is required", errorInvalidMode)
+	}
+
+	// Validate mode
+	if *modeFlag != modeOverlay && *modeFlag != modeOpenAPI {
+		return fmt.Errorf("%s: mode must be '%s' or '%s'", errorInvalidMode, modeOverlay, modeOpenAPI)
+	}
+
+	// Read and parse input file
+	service, err := readSpecificationFile(*fileFlag)
+	if err != nil {
+		return err
+	}
+
+	slog.InfoContext(ctx, "Successfully parsed input file", logKeyFile, *fileFlag)
+
+	// Execute the requested operation
+	switch *modeFlag {
+	case modeOverlay:
+		return generateOverlay(ctx, service, *fileFlag, *outputFlag)
+	case modeOpenAPI:
+		return generateOpenAPI(ctx, service, *fileFlag, *outputFlag)
+	default:
+		return fmt.Errorf("%s: unsupported mode '%s'", errorInvalidMode, *modeFlag)
+	}
+}
+
+// readSpecificationFile reads and parses a YAML or JSON specification file.
+func readSpecificationFile(filePath string) (*specification.Service, error) {
+	// Check if file exists
+	if _, err := os.Stat(filePath); os.IsNotExist(err) {
+		return nil, fmt.Errorf("%s: file does not exist: %s", errorInvalidFile, filePath)
+	}
+
+	// Read file contents
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", errorFileRead, err)
+	}
+
+	// Determine file format by extension
+	ext := strings.ToLower(filepath.Ext(filePath))
+	var service specification.Service
+
+	switch ext {
+	case extYAML, extYML:
+		if err := yaml.Unmarshal(data, &service); err != nil {
+			return nil, fmt.Errorf("%s: YAML parsing error: %w", errorFileParse, err)
+		}
+	case extJSON:
+		if err := json.Unmarshal(data, &service); err != nil {
+			return nil, fmt.Errorf("%s: JSON parsing error: %w", errorFileParse, err)
+		}
+	default:
+		return nil, fmt.Errorf("%s: file must have .yaml, .yml, or .json extension", errorUnsupportedFormat)
+	}
+
+	return &service, nil
+}
+
+// generateOverlay generates a specification with overlay applied.
+func generateOverlay(ctx context.Context, service *specification.Service, inputFile, outputFile string) error {
+	slog.InfoContext(ctx, "Generating specification with overlay", logKeyMode, modeOverlay)
+
+	// Apply overlay to the service
+	overlayedService := specification.ApplyOverlay(service)
+	if overlayedService == nil {
+		return errors.New("failed to apply overlay to specification")
+	}
+
+	// Apply filter overlay as well
+	finalService := specification.ApplyFilterOverlay(overlayedService)
+	if finalService == nil {
+		return errors.New("failed to apply filter overlay to specification")
+	}
+
+	// Determine output file path
+	outputPath := outputFile
+	if outputPath == "" {
+		outputPath = generateOutputPath(inputFile, suffixOverlay)
+	}
+
+	// Write output file
+	return writeSpecificationFile(ctx, finalService, outputPath)
+}
+
+// generateOpenAPI generates an OpenAPI document from the specification.
+func generateOpenAPI(ctx context.Context, service *specification.Service, inputFile, outputFile string) error {
+	slog.InfoContext(ctx, "Generating OpenAPI document", logKeyMode, modeOpenAPI)
+
+	// Apply overlay to the service first
+	overlayedService := specification.ApplyOverlay(service)
+	if overlayedService == nil {
+		return errors.New("failed to apply overlay to specification")
+	}
+
+	// Apply filter overlay as well
+	finalService := specification.ApplyFilterOverlay(overlayedService)
+	if finalService == nil {
+		return errors.New("failed to apply filter overlay to specification")
+	}
+
+	// Create OpenAPI generator
+	generator := openapi.NewGenerator()
+
+	// Set basic configuration
+	generator.Title = finalService.Name + " API"
+	generator.Description = "Generated API documentation"
+
+	// Add server information if available
+	if len(finalService.Servers) > 0 {
+		// Server information is handled by the generator from the service
+	}
+
+	// Generate OpenAPI document
+	document, err := generator.GenerateFromService(finalService)
+	if err != nil {
+		return fmt.Errorf("failed to generate OpenAPI document: %w", err)
+	}
+
+	// Determine output file path
+	outputPath := outputFile
+	if outputPath == "" {
+		outputPath = generateOutputPath(inputFile, suffixOpenAPI)
+	}
+
+	// Determine output format based on extension
+	ext := strings.ToLower(filepath.Ext(outputPath))
+	var outputData []byte
+
+	switch ext {
+	case extYAML, extYML:
+		outputData, err = generator.ToYAML(document)
+		if err != nil {
+			return fmt.Errorf("failed to convert OpenAPI document to YAML: %w", err)
+		}
+	case extJSON:
+		outputData, err = generator.ToJSON(document)
+		if err != nil {
+			return fmt.Errorf("failed to convert OpenAPI document to JSON: %w", err)
+		}
+	default:
+		// Default to YAML if extension is not recognized
+		outputPath = strings.TrimSuffix(outputPath, filepath.Ext(outputPath)) + extYAML
+		outputData, err = generator.ToYAML(document)
+		if err != nil {
+			return fmt.Errorf("failed to convert OpenAPI document to YAML: %w", err)
+		}
+	}
+
+	// Write output file
+	if err := os.WriteFile(outputPath, outputData, 0644); err != nil {
+		return fmt.Errorf("%s: %w", errorFileWrite, err)
+	}
+
+	slog.InfoContext(ctx, "Successfully generated OpenAPI document", logKeyFile, outputPath)
+	fmt.Printf("OpenAPI document generated: %s\n", outputPath)
+
+	return nil
+}
+
+// writeSpecificationFile writes a specification to a file in the appropriate format.
+func writeSpecificationFile(ctx context.Context, service *specification.Service, outputPath string) error {
+	// Determine output format based on extension
+	ext := strings.ToLower(filepath.Ext(outputPath))
+	var outputData []byte
+	var err error
+
+	switch ext {
+	case extYAML, extYML:
+		outputData, err = yaml.Marshal(service)
+		if err != nil {
+			return fmt.Errorf("failed to marshal specification to YAML: %w", err)
+		}
+	case extJSON:
+		outputData, err = json.MarshalIndent(service, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal specification to JSON: %w", err)
+		}
+	default:
+		// Default to YAML if extension is not recognized
+		outputPath = strings.TrimSuffix(outputPath, filepath.Ext(outputPath)) + extYAML
+		outputData, err = yaml.Marshal(service)
+		if err != nil {
+			return fmt.Errorf("failed to marshal specification to YAML: %w", err)
+		}
+	}
+
+	// Write output file
+	if err := os.WriteFile(outputPath, outputData, 0644); err != nil {
+		return fmt.Errorf("%s: %w", errorFileWrite, err)
+	}
+
+	slog.InfoContext(ctx, "Successfully generated specification with overlay", logKeyFile, outputPath)
+	fmt.Printf("Specification with overlay generated: %s\n", outputPath)
+
+	return nil
+}
+
+// generateOutputPath generates an output file path based on input file and suffix.
+func generateOutputPath(inputFile, suffix string) string {
+	ext := filepath.Ext(inputFile)
+	base := strings.TrimSuffix(inputFile, ext)
+	return base + suffix + ext
 }

--- a/main_test.go
+++ b/main_test.go
@@ -3,18 +3,28 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"flag"
 	"log/slog"
+	"os"
 	"testing"
 
+	"github.com/goccy/go-yaml"
+	"github.com/meitner-se/publicapis-gen/specification"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func Test_main(t *testing.T) {
+	// Save original os.Args and flag state
+	origArgs := os.Args
+	defer func() { os.Args = origArgs }()
+
+	// Reset flag package for this test
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
+
 	// Arrange
-	expectedLogLevel := "level=ERROR"
-	expectedLogMessage := `msg="failed to run"`
-	expectedErrorMessage := `error="not implemented"`
+	os.Args = []string{"publicapis-gen", "-help"}
 
 	t.Cleanup(func() {
 		slog.SetDefault(slog.Default())
@@ -26,23 +36,218 @@ func Test_main(t *testing.T) {
 	// Act
 	main()
 
-	// Assert
+	// Assert - When help is shown, the program should exit cleanly without errors
 	logOutput := buf.String()
-	assert.NotEmpty(t, logOutput, "Log output should not be empty")
-	assert.Contains(t, logOutput, expectedLogLevel, "Log should contain ERROR level")
-	assert.Contains(t, logOutput, expectedLogMessage, "Log should contain 'failed to run' message")
-	assert.Contains(t, logOutput, expectedErrorMessage, "Log should contain 'not implemented' error")
+	assert.Empty(t, logOutput, "No error logs should be generated when showing help")
 }
 
 func Test_run(t *testing.T) {
-	// Arrange
-	expectedErrorMessage := errorNotImplemented
-	ctx := context.Background()
+	// Save original os.Args and flag state
+	origArgs := os.Args
+	defer func() { os.Args = origArgs }()
 
-	// Act
-	err := run(ctx)
+	t.Run("help flag shows usage", func(t *testing.T) {
+		// Reset flag package for this test
+		flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
 
-	// Assert
-	require.Error(t, err, "run() should return an error")
-	assert.Equal(t, expectedErrorMessage, err.Error(), "Error message should match expected 'not implemented' message")
+		// Arrange
+		os.Args = []string{"publicapis-gen", "-help"}
+		ctx := context.Background()
+
+		// Act
+		err := run(ctx)
+
+		// Assert
+		assert.Nil(t, err, "run() should not return an error when showing help")
+	})
+
+	t.Run("missing file flag returns error", func(t *testing.T) {
+		// Reset flag package for this test
+		flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
+
+		// Arrange
+		os.Args = []string{"publicapis-gen"}
+		ctx := context.Background()
+
+		// Act
+		err := run(ctx)
+
+		// Assert
+		require.Error(t, err, "run() should return an error when file flag is missing")
+		assert.Contains(t, err.Error(), errorInvalidFile, "Error should mention invalid file")
+	})
+
+	t.Run("missing mode flag returns error", func(t *testing.T) {
+		// Reset flag package for this test
+		flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
+
+		// Arrange
+		os.Args = []string{"publicapis-gen", "-file=test.yaml"}
+		ctx := context.Background()
+
+		// Act
+		err := run(ctx)
+
+		// Assert
+		require.Error(t, err, "run() should return an error when mode flag is missing")
+		assert.Contains(t, err.Error(), errorInvalidMode, "Error should mention invalid mode")
+	})
+
+	t.Run("invalid mode returns error", func(t *testing.T) {
+		// Reset flag package for this test
+		flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
+
+		// Arrange
+		os.Args = []string{"publicapis-gen", "-file=test.yaml", "-mode=invalid"}
+		ctx := context.Background()
+
+		// Act
+		err := run(ctx)
+
+		// Assert
+		require.Error(t, err, "run() should return an error for invalid mode")
+		assert.Contains(t, err.Error(), errorInvalidMode, "Error should mention invalid mode")
+	})
+
+	t.Run("nonexistent file returns error", func(t *testing.T) {
+		// Reset flag package for this test
+		flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
+
+		// Arrange
+		os.Args = []string{"publicapis-gen", "-file=nonexistent.yaml", "-mode=overlay"}
+		ctx := context.Background()
+
+		// Act
+		err := run(ctx)
+
+		// Assert
+		require.Error(t, err, "run() should return an error for nonexistent file")
+		assert.Contains(t, err.Error(), errorInvalidFile, "Error should mention invalid file")
+	})
+}
+
+func Test_readSpecificationFile(t *testing.T) {
+	t.Run("reads valid YAML file", func(t *testing.T) {
+		// Create a temporary YAML file
+		testService := specification.Service{
+			Name:      "TestService",
+			Version:   "1.0.0",
+			Resources: []specification.Resource{},
+			Objects:   []specification.Object{},
+			Enums:     []specification.Enum{},
+		}
+
+		yamlData, err := yaml.Marshal(&testService)
+		require.NoError(t, err)
+
+		tmpFile, err := os.CreateTemp("", "test-spec-*.yaml")
+		require.NoError(t, err)
+		defer os.Remove(tmpFile.Name())
+
+		_, err = tmpFile.Write(yamlData)
+		require.NoError(t, err)
+		tmpFile.Close()
+
+		// Test reading the file
+		service, err := readSpecificationFile(tmpFile.Name())
+
+		// Assert
+		require.NoError(t, err)
+		assert.Equal(t, "TestService", service.Name)
+		assert.Equal(t, "1.0.0", service.Version)
+	})
+
+	t.Run("reads valid JSON file", func(t *testing.T) {
+		// Create a temporary JSON file
+		testService := specification.Service{
+			Name:      "TestService",
+			Version:   "1.0.0",
+			Resources: []specification.Resource{},
+			Objects:   []specification.Object{},
+			Enums:     []specification.Enum{},
+		}
+
+		jsonData, err := json.MarshalIndent(&testService, "", "  ")
+		require.NoError(t, err)
+
+		tmpFile, err := os.CreateTemp("", "test-spec-*.json")
+		require.NoError(t, err)
+		defer os.Remove(tmpFile.Name())
+
+		_, err = tmpFile.Write(jsonData)
+		require.NoError(t, err)
+		tmpFile.Close()
+
+		// Test reading the file
+		service, err := readSpecificationFile(tmpFile.Name())
+
+		// Assert
+		require.NoError(t, err)
+		assert.Equal(t, "TestService", service.Name)
+		assert.Equal(t, "1.0.0", service.Version)
+	})
+
+	t.Run("returns error for nonexistent file", func(t *testing.T) {
+		// Act
+		service, err := readSpecificationFile("nonexistent.yaml")
+
+		// Assert
+		require.Error(t, err)
+		assert.Nil(t, service)
+		assert.Contains(t, err.Error(), errorInvalidFile)
+	})
+
+	t.Run("returns error for unsupported file extension", func(t *testing.T) {
+		// Create a temporary file with unsupported extension
+		tmpFile, err := os.CreateTemp("", "test-spec-*.txt")
+		require.NoError(t, err)
+		defer os.Remove(tmpFile.Name())
+		tmpFile.Close()
+
+		// Act
+		service, err := readSpecificationFile(tmpFile.Name())
+
+		// Assert
+		require.Error(t, err)
+		assert.Nil(t, service)
+		assert.Contains(t, err.Error(), errorUnsupportedFormat)
+	})
+}
+
+func Test_generateOutputPath(t *testing.T) {
+	testCases := []struct {
+		name      string
+		inputFile string
+		suffix    string
+		expected  string
+	}{
+		{
+			name:      "YAML file with overlay suffix",
+			inputFile: "spec.yaml",
+			suffix:    suffixOverlay,
+			expected:  "spec-overlay.yaml",
+		},
+		{
+			name:      "JSON file with OpenAPI suffix",
+			inputFile: "api.json",
+			suffix:    suffixOpenAPI,
+			expected:  "api-openapi.json",
+		},
+		{
+			name:      "File with path and overlay suffix",
+			inputFile: "/path/to/spec.yml",
+			suffix:    suffixOverlay,
+			expected:  "/path/to/spec-overlay.yml",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Act
+			result := generateOutputPath(tc.inputFile, tc.suffix)
+
+			// Assert
+			assert.Equal(t, tc.expected, result)
+		})
+	}
 }


### PR DESCRIPTION
Implement a CLI tool in `main.go` to generate API specifications with overlays and convert them to OpenAPI documents, addressing INF-244.

This PR provides the core logic and CLI interface for a tool that takes a YAML or JSON specification file and can either generate the specification with applied overlays or convert it into an OpenAPI document. The design is extensible to support additional operations in the future.

---
Linear Issue: [INF-244](https://linear.app/meitner-se/issue/INF-244/implement-logic-in-maingo)

<a href="https://cursor.com/background-agent?bcId=bc-ae17f1fc-d22a-47a2-95a5-869b12ac5d60">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ae17f1fc-d22a-47a2-95a5-869b12ac5d60">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

