### PR TITLE
Ensure parameters are camelCase in openapi spec

### DIFF
--- a/specification/openapi/openapi.go
+++ b/specification/openapi/openapi.go
@@ -243,10 +243,10 @@ func (g *Generator) createObjectSchema(obj specification.Object, service *specif
 	for _, field := range obj.Fields {
 		fieldSchema := g.createFieldSchema(field, service)
 		proxy := base.CreateSchemaProxy(fieldSchema)
-		schema.Properties.Set(field.Name, proxy)
+		schema.Properties.Set(field.TagJSON(), proxy)
 
 		if field.IsRequired(service) {
-			requiredFields = append(requiredFields, field.Name)
+			requiredFields = append(requiredFields, field.TagJSON())
 		}
 	}
 
@@ -428,7 +428,7 @@ func (g *Generator) createOperation(endpoint specification.Endpoint, resource sp
 func (g *Generator) createParameter(field specification.Field, location string, service *specification.Service) *v3.Parameter {
 	isRequired := field.IsRequired(service)
 	param := &v3.Parameter{
-		Name:        field.Name,
+		Name:        field.TagJSON(),
 		In:          location,
 		Description: field.Description,
 		Required:    &isRequired,
@@ -450,10 +450,10 @@ func (g *Generator) createRequestBody(bodyParams []specification.Field, service 
 	for _, field := range bodyParams {
 		fieldSchema := g.createFieldSchema(field, service)
 		proxy := base.CreateSchemaProxy(fieldSchema)
-		schema.Properties.Set(field.Name, proxy)
+		schema.Properties.Set(field.TagJSON(), proxy)
 
 		if field.IsRequired(service) {
-			requiredFields = append(requiredFields, field.Name)
+			requiredFields = append(requiredFields, field.TagJSON())
 		}
 	}
 
@@ -503,7 +503,7 @@ func (g *Generator) createResponse(response specification.EndpointResponse, serv
 			for _, field := range response.BodyFields {
 				fieldSchema := g.createFieldSchema(field, service)
 				proxy := base.CreateSchemaProxy(fieldSchema)
-				schema.Properties.Set(field.Name, proxy)
+				schema.Properties.Set(field.TagJSON(), proxy)
 			}
 		}
 


### PR DESCRIPTION
Enforce camelCase for all parameters and properties in the generated OpenAPI specification and add a test case to verify it.

---
Linear Issue: [INF-246](https://linear.app/meitner-se/issue/INF-246/parameters-should-always-be-in-camelcase-when-writing-it-to-openapi)

<a href="https://cursor.com/background-agent?bcId=bc-a6514378-d377-4d59-b674-837390790109">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a6514378-d377-4d59-b674-837390790109">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

