### PR TITLE
Avoid filter objects for response-only params

### DIFF
--- a/specification/specification.go
+++ b/specification/specification.go
@@ -1063,8 +1063,15 @@ func ApplyFilterOverlay(input *Service) *Service {
 	// Copy resources
 	copy(result.Resources, input.Resources)
 
-	// Generate Filter objects from existing Objects
+	// Collect types used in request body parameters
+	usedTypes := collectTypesUsedInBodyParams(result)
+
+	// Generate Filter objects only for Objects used in request body parameters
 	for _, obj := range input.Objects {
+		// Skip objects that are not used in request body parameters
+		if !usedTypes[obj.Name] {
+			continue
+		}
 		// Generate main filter object
 		mainFilter := Object{
 			Name:        obj.Name + filterSuffix,


### PR DESCRIPTION
Prevent the generation of filter objects for types only used in responses to reduce API specification bloat.

Previously, filter objects were generated for all defined types, including those like `Pagination` and `Error` which are exclusively used in API responses. Since filters are designed to modify query parameters for request data, generating them for response-only types was unnecessary and added clutter to the API specification. This change ensures filters are only created for types that can actually be filtered via request body parameters.

---
Linear Issue: [INF-248](https://linear.app/meitner-se/issue/INF-248/do-not-generate-filter-objects-for-objects-that-isnt-used-in-the)

<a href="https://cursor.com/background-agent?bcId=bc-b3f5ff94-e944-446e-804b-886803c6d9bc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b3f5ff94-e944-446e-804b-886803c6d9bc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

