### PR TITLE
Add total to pagination object

### DIFF
--- a/specification/specification.go
+++ b/specification/specification.go
@@ -161,6 +161,8 @@ const (
 	offsetFieldDescription      = "Number of items to skip from the beginning of the result set"
 	limitFieldName              = "Limit"
 	limitFieldDescription       = "Maximum number of items to return in the result set"
+	totalFieldName              = "Total"
+	totalFieldDescription       = "Total number of items available for pagination"
 )
 
 // Auto-column constants
@@ -631,6 +633,11 @@ func addDefaultEnumsAndObjects(result *Service, input *Service) {
 				{
 					Name:        limitFieldName,
 					Description: limitFieldDescription,
+					Type:        FieldTypeInt,
+				},
+				{
+					Name:        totalFieldName,
+					Description: totalFieldDescription,
 					Type:        FieldTypeInt,
 				},
 			},


### PR DESCRIPTION
Add `Total` field to the default pagination object to indicate the total number of entries available for pagination.

---
Linear Issue: [INF-251](https://linear.app/meitner-se/issue/INF-251/add-total-to-the-default-pagination-object)

<a href="https://cursor.com/background-agent?bcId=bc-f776c792-707c-468e-854c-b2993436ab09">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f776c792-707c-468e-854c-b2993436ab09">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

