### PR TITLE
Simplify main go file and update openapi package

### DIFF
--- a/main.go
+++ b/main.go
@@ -163,21 +163,8 @@ func generateOverlay(ctx context.Context, service *specification.Service, inputF
 func generateOpenAPI(ctx context.Context, service *specification.Service, inputFile, outputFile string) error {
 	slog.InfoContext(ctx, "Generating OpenAPI document", logKeyMode, modeOpenAPI)
 
-	// Service already has overlays applied from parsing
-	// Create OpenAPI generator
-	generator := openapi.NewGenerator()
-
-	// Set basic configuration
-	generator.Title = service.Name + " API"
-	generator.Description = "Generated API documentation"
-
-	// Add server information if available
-	if len(service.Servers) > 0 {
-		// Server information is handled by the generator from the service
-	}
-
-	// Generate OpenAPI document
-	document, err := generator.GenerateFromService(service)
+	// Generate OpenAPI document as JSON in a single call
+	outputData, err := openapi.GenerateFromSpecificationToJSON(service)
 	if err != nil {
 		return fmt.Errorf("failed to generate OpenAPI document: %w", err)
 	}
@@ -189,12 +176,6 @@ func generateOpenAPI(ctx context.Context, service *specification.Service, inputF
 	} else {
 		// Ensure output path has .json extension
 		outputPath = ensureJSONExtension(outputPath)
-	}
-
-	// Always generate JSON output for OpenAPI
-	outputData, err := generator.ToJSON(document)
-	if err != nil {
-		return fmt.Errorf("failed to convert OpenAPI document to JSON: %w", err)
 	}
 
 	// Write output file

--- a/specification/openapi/openapi.go
+++ b/specification/openapi/openapi.go
@@ -38,6 +38,12 @@ const (
 	defaultServiceVersion = "1.0.0"
 )
 
+// API generation constants
+const (
+	apiTitleSuffix        = " API"
+	defaultAPIDescription = "Generated API documentation"
+)
+
 // Content type constants
 const (
 	contentTypeJSON = "application/json"
@@ -680,4 +686,35 @@ func (g *Generator) ToJSON(document *v3.Document) ([]byte, error) {
 
 	// Use libopenapi's native RenderJSON method
 	return document.RenderJSON("  ")
+}
+
+// GenerateFromSpecificationToJSON is a convenience method that generates an OpenAPI document
+// from a specification.Service and returns it as JSON in a single call.
+// This method creates a generator with default settings, sets a standard title and description,
+// generates the OpenAPI document, and converts it to JSON format.
+func GenerateFromSpecificationToJSON(service *specification.Service) ([]byte, error) {
+	if service == nil {
+		return nil, errors.New(errorInvalidService)
+	}
+
+	// Create generator with default configuration
+	generator := NewGenerator()
+
+	// Set basic configuration based on service
+	generator.Title = service.Name + apiTitleSuffix
+	generator.Description = defaultAPIDescription
+
+	// Generate OpenAPI document
+	document, err := generator.GenerateFromService(service)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate OpenAPI document: %w", err)
+	}
+
+	// Convert to JSON
+	jsonBytes, err := generator.ToJSON(document)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert OpenAPI document to JSON: %w", err)
+	}
+
+	return jsonBytes, nil
 }


### PR DESCRIPTION
Simplify OpenAPI generation in `main.go` by introducing a new convenience method in the `openapi` package.

The original `main.go` contained a verbose multi-step process for generating OpenAPI documentation. This PR refactors this into a single function call, `openapi.GenerateFromSpecificationToJSON`, making `main.go` cleaner and more readable, as outlined in INF-253.

---
Linear Issue: [INF-253](https://linear.app/meitner-se/issue/INF-253/simplify-maingo)

<a href="https://cursor.com/background-agent?bcId=bc-390819f5-a7e6-41e4-b7b7-105446377b0d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-390819f5-a7e6-41e4-b7b7-105446377b0d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

