### PR TITLE
Add speakeasy pagination to openapi spec

### DIFF
--- a/testdata/school-management-api-expected.json
+++ b/testdata/school-management-api-expected.json
@@ -680,6 +680,13 @@
               }
             }
           }
+        },
+        "x-speakeasy-pagination": {
+          "strategy": "offsetLimit",
+          "offsetParam": "offset",
+          "limitParam": "limit",
+          "totalField": "pagination.total",
+          "dataField": "data"
         }
       },
       "post": {
@@ -1359,22 +1366,16 @@
               }
             }
           }
+        },
+        "x-speakeasy-pagination": {
+          "strategy": "offsetLimit",
+          "offsetParam": "offset",
+          "limitParam": "limit",
+          "totalField": "pagination.total",
+          "dataField": "data"
         }
       }
     }
-  },
-  "x-speakeasy-retries": {
-    "strategy": "backoff",
-    "backoff": {
-      "initialInterval": 500,
-      "maxInterval": 60000,
-      "maxElapsedTime": 3600000,
-      "exponent": 1.5
-    },
-    "statusCodes": [
-      "5XX"
-    ],
-    "retryConnectionErrors": true
   },
   "components": {
     "schemas": {
@@ -1593,14 +1594,14 @@
       "Students": {
         "type": "object",
         "properties": {
-          "meta": {
-            "title": "Meta",
-            "description": "Metadata information for the Students"
-          },
           "id": {
             "type": "string",
             "format": "uuid",
             "description": "Unique student identifier"
+          },
+          "meta": {
+            "title": "Meta",
+            "description": "Metadata information for the Students"
           },
           "firstName": {
             "type": "string",
@@ -1655,37 +1656,6 @@
         ],
         "description": "Student management resource"
       },
-      "StudentRequestError": {
-        "type": "object",
-        "properties": {
-          "firstName": {
-            "title": "ErrorField",
-            "description": "Student's first name",
-            "nullable": true
-          },
-          "lastName": {
-            "title": "ErrorField",
-            "description": "Student's last name",
-            "nullable": true
-          },
-          "studentId": {
-            "title": "ErrorField",
-            "description": "School-assigned student ID",
-            "nullable": true
-          },
-          "status": {
-            "title": "ErrorField",
-            "description": "Current status of the student",
-            "nullable": true
-          },
-          "gradeLevel": {
-            "title": "ErrorField",
-            "description": "Current grade level",
-            "nullable": true
-          }
-        },
-        "description": "Request error object for Student"
-      },
       "ContactRequestError": {
         "type": "object",
         "properties": {
@@ -1727,6 +1697,37 @@
           }
         },
         "description": "Request error object for Address"
+      },
+      "StudentRequestError": {
+        "type": "object",
+        "properties": {
+          "firstName": {
+            "title": "ErrorField",
+            "description": "Student's first name",
+            "nullable": true
+          },
+          "lastName": {
+            "title": "ErrorField",
+            "description": "Student's last name",
+            "nullable": true
+          },
+          "studentId": {
+            "title": "ErrorField",
+            "description": "School-assigned student ID",
+            "nullable": true
+          },
+          "status": {
+            "title": "ErrorField",
+            "description": "Current status of the student",
+            "nullable": true
+          },
+          "gradeLevel": {
+            "title": "ErrorField",
+            "description": "Current grade level",
+            "nullable": true
+          }
+        },
+        "description": "Request error object for Student"
       },
       "StudentsBulkImportRequestError": {
         "type": "object",
@@ -2407,5 +2408,18 @@
         "description": "Null filter fields for Student"
       }
     }
+  },
+  "x-speakeasy-retries": {
+    "strategy": "backoff",
+    "backoff": {
+      "initialInterval": 500,
+      "maxInterval": 60000,
+      "maxElapsedTime": 3600000,
+      "exponent": 1.5
+    },
+    "statusCodes": [
+      "5XX"
+    ],
+    "retryConnectionErrors": true
   }
 }


### PR DESCRIPTION
Add Speakeasy pagination configuration to the OpenAPI spec for paginated endpoints to enable automatic SDK pagination.

---
Linear Issue: [INF-261](https://linear.app/meitner-se/issue/INF-261/add-speakeasy-pagination-to-openapi)

<a href="https://cursor.com/background-agent?bcId=bc-84e9462d-1acd-4852-bee0-2ef8ae51f409">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-84e9462d-1acd-4852-bee0-2ef8ae51f409">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

