### PR TITLE
Prefix operation IDs with resource name

### DIFF
--- a/specification/openapi/openapi.go
+++ b/specification/openapi/openapi.go
@@ -559,7 +559,7 @@ func (g *Generator) addResourceToPaths(resource specification.Resource, paths *o
 // createOperation creates a v3.Operation from an endpoint using native types.
 func (g *Generator) createOperation(endpoint specification.Endpoint, resource specification.Resource, service *specification.Service) *v3.Operation {
 	operation := &v3.Operation{
-		OperationId: endpoint.Name,
+		OperationId: resource.Name + endpoint.Name,
 		Summary:     endpoint.Title,
 		Description: endpoint.Description,
 		Tags:        []string{resource.Name},

--- a/specification/openapi/openapi_test.go
+++ b/specification/openapi/openapi_test.go
@@ -917,7 +917,7 @@ func countSubstring(s, substr string) int {
 // TestOperationIdPrefixing verifies that operationIds are prefixed with resource names to avoid duplicates.
 func TestOperationIdPrefixing(t *testing.T) {
 	generator := newGenerator()
-	
+
 	// Create a service with multiple resources having the same endpoint names
 	service := &specification.Service{
 		Name:    "MultiResourceAPI",
@@ -976,7 +976,7 @@ func TestOperationIdPrefixing(t *testing.T) {
 					},
 					{
 						Name:        "Create",
-						Title:       "Create Product", 
+						Title:       "Create Product",
 						Description: "Create a new product",
 						Method:      "POST",
 						Path:        "",
@@ -1013,7 +1013,7 @@ func TestOperationIdPrefixing(t *testing.T) {
 
 	// Count the number of unique operationIds to ensure no duplicates
 	userGetCount := countSubstring(jsonString, "\"operationId\": \"UserGet\"")
-	userCreateCount := countSubstring(jsonString, "\"operationId\": \"UserCreate\"") 
+	userCreateCount := countSubstring(jsonString, "\"operationId\": \"UserCreate\"")
 	productGetCount := countSubstring(jsonString, "\"operationId\": \"ProductGet\"")
 	productCreateCount := countSubstring(jsonString, "\"operationId\": \"ProductCreate\"")
 

--- a/specification/openapi/openapi_test.go
+++ b/specification/openapi/openapi_test.go
@@ -914,6 +914,117 @@ func countSubstring(s, substr string) int {
 // GenerateFromSpecificationToJSON Function Tests
 // ============================================================================
 
+// TestOperationIdPrefixing verifies that operationIds are prefixed with resource names to avoid duplicates.
+func TestOperationIdPrefixing(t *testing.T) {
+	generator := newGenerator()
+	
+	// Create a service with multiple resources having the same endpoint names
+	service := &specification.Service{
+		Name:    "MultiResourceAPI",
+		Version: "1.0.0",
+		Resources: []specification.Resource{
+			{
+				Name:        "User",
+				Description: "User resource",
+				Operations:  []string{specification.OperationCreate, specification.OperationRead},
+				Endpoints: []specification.Endpoint{
+					{
+						Name:        "Get",
+						Title:       "Get User",
+						Description: "Get a user by ID",
+						Method:      "GET",
+						Path:        "/{id}",
+						Request: specification.EndpointRequest{
+							PathParams: []specification.Field{
+								{Name: "id", Type: specification.FieldTypeUUID, Description: "User ID"},
+							},
+						},
+						Response: specification.EndpointResponse{StatusCode: 200, ContentType: "application/json"},
+					},
+					{
+						Name:        "Create",
+						Title:       "Create User",
+						Description: "Create a new user",
+						Method:      "POST",
+						Path:        "",
+						Request: specification.EndpointRequest{
+							BodyParams: []specification.Field{
+								{Name: "email", Type: specification.FieldTypeString, Description: "User email"},
+							},
+						},
+						Response: specification.EndpointResponse{StatusCode: 201, ContentType: "application/json"},
+					},
+				},
+			},
+			{
+				Name:        "Product",
+				Description: "Product resource",
+				Operations:  []string{specification.OperationCreate, specification.OperationRead},
+				Endpoints: []specification.Endpoint{
+					{
+						Name:        "Get",
+						Title:       "Get Product",
+						Description: "Get a product by ID",
+						Method:      "GET",
+						Path:        "/{id}",
+						Request: specification.EndpointRequest{
+							PathParams: []specification.Field{
+								{Name: "id", Type: specification.FieldTypeUUID, Description: "Product ID"},
+							},
+						},
+						Response: specification.EndpointResponse{StatusCode: 200, ContentType: "application/json"},
+					},
+					{
+						Name:        "Create",
+						Title:       "Create Product", 
+						Description: "Create a new product",
+						Method:      "POST",
+						Path:        "",
+						Request: specification.EndpointRequest{
+							BodyParams: []specification.Field{
+								{Name: "name", Type: specification.FieldTypeString, Description: "Product name"},
+							},
+						},
+						Response: specification.EndpointResponse{StatusCode: 201, ContentType: "application/json"},
+					},
+				},
+			},
+		},
+	}
+
+	document, err := generator.GenerateFromService(service)
+	assert.NoError(t, err, "Should generate document successfully")
+	assert.NotNil(t, document, "Document should not be nil")
+
+	// Convert to JSON to check operationIds
+	jsonBytes, err := generator.ToJSON(document)
+	assert.NoError(t, err, "Should convert to JSON successfully")
+	jsonString := string(jsonBytes)
+
+	// Verify that operationIds are prefixed with resource names
+	assert.Contains(t, jsonString, "\"operationId\": \"UserGet\"", "User Get operation should have prefixed operationId")
+	assert.Contains(t, jsonString, "\"operationId\": \"UserCreate\"", "User Create operation should have prefixed operationId")
+	assert.Contains(t, jsonString, "\"operationId\": \"ProductGet\"", "Product Get operation should have prefixed operationId")
+	assert.Contains(t, jsonString, "\"operationId\": \"ProductCreate\"", "Product Create operation should have prefixed operationId")
+
+	// Verify that the old unprefixed operationIds are not present
+	assert.NotContains(t, jsonString, "\"operationId\": \"Get\"", "Should not contain unprefixed Get operationId")
+	assert.NotContains(t, jsonString, "\"operationId\": \"Create\"", "Should not contain unprefixed Create operationId")
+
+	// Count the number of unique operationIds to ensure no duplicates
+	userGetCount := countSubstring(jsonString, "\"operationId\": \"UserGet\"")
+	userCreateCount := countSubstring(jsonString, "\"operationId\": \"UserCreate\"") 
+	productGetCount := countSubstring(jsonString, "\"operationId\": \"ProductGet\"")
+	productCreateCount := countSubstring(jsonString, "\"operationId\": \"ProductCreate\"")
+
+	assert.Equal(t, 1, userGetCount, "Should have exactly one UserGet operationId")
+	assert.Equal(t, 1, userCreateCount, "Should have exactly one UserCreate operationId")
+	assert.Equal(t, 1, productGetCount, "Should have exactly one ProductGet operationId")
+	assert.Equal(t, 1, productCreateCount, "Should have exactly one ProductCreate operationId")
+
+	t.Logf("Generated OpenAPI JSON with prefixed operationIds:\n%s", jsonString)
+}
+
 // TestGenerateFromSpecificationToJSON tests the convenience method for generating JSON from a specification.
 func TestGenerateFromSpecificationToJSON(t *testing.T) {
 	// Test with nil service

--- a/testdata/school-management-api-expected.json
+++ b/testdata/school-management-api-expected.json
@@ -19,7 +19,7 @@
         ],
         "summary": "Bulk Import Students",
         "description": "Import multiple students from a CSV file or structured data",
-        "operationId": "BulkImport",
+        "operationId": "StudentsBulkImport",
         "parameters": [
           {
             "name": "validateOnly",
@@ -176,7 +176,7 @@
         ],
         "summary": "Generate Student Report",
         "description": "Generate a comprehensive report for students based on filters",
-        "operationId": "GenerateReport",
+        "operationId": "StudentsGenerateReport",
         "parameters": [
           {
             "name": "format",
@@ -348,7 +348,7 @@
         ],
         "summary": "Advanced Student Search",
         "description": "Search students with advanced filtering and sorting options",
-        "operationId": "AdvancedSearch",
+        "operationId": "StudentsAdvancedSearch",
         "parameters": [
           {
             "name": "limit",
@@ -561,7 +561,7 @@
         ],
         "summary": "List all Students",
         "description": "Returns a paginated list of all `Students` in your organization.",
-        "operationId": "List",
+        "operationId": "StudentsList",
         "parameters": [
           {
             "name": "limit",
@@ -695,7 +695,7 @@
         ],
         "summary": "Create Students",
         "description": "Create a new Students",
-        "operationId": "Create",
+        "operationId": "StudentsCreate",
         "parameters": [],
         "requestBody": {
           "description": "Request body",
@@ -853,7 +853,7 @@
         ],
         "summary": "Retrieve an existing Students",
         "description": "Retrieves the `Students` with the given ID.",
-        "operationId": "Get",
+        "operationId": "StudentsGet",
         "parameters": [
           {
             "name": "id",
@@ -956,7 +956,7 @@
         ],
         "summary": "Delete Students",
         "description": "Delete a Students",
-        "operationId": "Delete",
+        "operationId": "StudentsDelete",
         "parameters": [
           {
             "name": "id",
@@ -1052,7 +1052,7 @@
         ],
         "summary": "Update Students",
         "description": "Update a Students",
-        "operationId": "Update",
+        "operationId": "StudentsUpdate",
         "parameters": [
           {
             "name": "id",
@@ -1217,7 +1217,7 @@
         ],
         "summary": "Search Students",
         "description": "Search for `Students` with filtering capabilities.",
-        "operationId": "Search",
+        "operationId": "StudentsSearch",
         "parameters": [
           {
             "name": "limit",


### PR DESCRIPTION
Prefix OpenAPI operation IDs with the resource name to resolve duplicate ID issues and generate valid OpenAPI documents.

The previous implementation used only the endpoint name for `operationId`, leading to duplicates when multiple resources had endpoints with the same name (e.g., `Get` for both `User` and `Product`). This caused invalid OpenAPI documents. By prepending the resource name (e.g., `UserGet`, `ProductGet`), we ensure uniqueness across all operations.

---
Linear Issue: [INF-266](https://linear.app/meitner-se/issue/INF-266/when-generating-openapi-document-add-resource-name-as-prefix-to)

<a href="https://cursor.com/background-agent?bcId=bc-c4fc45ec-51c3-4063-8d1e-23fdbf153548">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c4fc45ec-51c3-4063-8d1e-23fdbf153548">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

