### PR TITLE
Fix schema reference in openapi document

### DIFF
--- a/specification/openapi/openapi.go
+++ b/specification/openapi/openapi.go
@@ -551,16 +551,13 @@ func (g *Generator) getTypeSchema(fieldType string, service *specification.Servi
 	default:
 		// Check if it's a custom object or enum
 		if service.HasObject(fieldType) || service.HasEnum(fieldType) {
-			// Create a proper $ref schema reference
+			// Create a proper $ref schema reference using allOf
 			refString := schemaReferencePrefix + fieldType
-			proxy := base.CreateSchemaProxyRef(refString)
-			schema := proxy.Schema()
-			if schema != nil {
-				return schema
-			}
-			// Fallback to Title-based reference if proxy resolution fails
+			refProxy := base.CreateSchemaProxyRef(refString)
+
+			// Return a schema with AllOf that contains the reference
 			return &base.Schema{
-				Title: fieldType,
+				AllOf: []*base.SchemaProxy{refProxy},
 			}
 		}
 		// Default to string if unknown type
@@ -719,15 +716,11 @@ func (g *Generator) createResponse(response specification.EndpointResponse, serv
 
 		var schema *base.Schema
 		if response.BodyObject != nil {
-			// Create a proper $ref schema reference
+			// Create a proper $ref schema reference using allOf
 			refString := schemaReferencePrefix + *response.BodyObject
-			proxy := base.CreateSchemaProxyRef(refString)
-			schema = proxy.Schema()
-			if schema == nil {
-				// Fallback to Title-based reference if proxy resolution fails
-				schema = &base.Schema{
-					Title: *response.BodyObject,
-				}
+			refProxy := base.CreateSchemaProxyRef(refString)
+			schema = &base.Schema{
+				AllOf: []*base.SchemaProxy{refProxy},
 			}
 		} else if len(response.BodyFields) > 0 {
 			// Inline schema from body fields
@@ -760,15 +753,11 @@ func (g *Generator) addErrorResponses(responses *orderedmap.Map[string, *v3.Resp
 	// Create error schema
 	var errorSchema *base.Schema
 	if service.HasObject(errorObjectName) {
-		// Create a proper $ref schema reference
+		// Create a proper $ref schema reference using allOf
 		refString := schemaReferencePrefix + errorObjectName
-		proxy := base.CreateSchemaProxyRef(refString)
-		errorSchema = proxy.Schema()
-		if errorSchema == nil {
-			// Fallback to Title-based reference if proxy resolution fails
-			errorSchema = &base.Schema{
-				Title: errorObjectName,
-			}
+		refProxy := base.CreateSchemaProxyRef(refString)
+		errorSchema = &base.Schema{
+			AllOf: []*base.SchemaProxy{refProxy},
 		}
 	} else {
 		// Fallback generic error schema

--- a/testdata/school-management-api-expected.json
+++ b/testdata/school-management-api-expected.json
@@ -12,6 +12,212 @@
     }
   ],
   "paths": {
+    "/students/_search": {
+      "post": {
+        "tags": [
+          "Students"
+        ],
+        "summary": "Search Students",
+        "description": "Search for `Students` with filtering capabilities.",
+        "operationId": "StudentsSearch",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "The maximum number of items to return (default: 50)",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "description": "The maximum number of items to return (default: 50)",
+              "default": 50
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "description": "The number of items to skip before starting to return results (default: 0)",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "description": "The number of items to skip before starting to return results (default: 0)",
+              "default": 0
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Request body",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "filter": {
+                    "type": "string",
+                    "description": "Filter criteria to search for specific records"
+                  }
+                },
+                "required": [
+                  "filter"
+                ]
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/Students"
+                          }
+                        ]
+                      },
+                      "description": "Array of Students objects"
+                    },
+                    "pagination": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/Pagination"
+                        }
+                      ],
+                      "description": "Pagination information"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The request was malformed or contained invalid parameters. 400 status code",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The request is missing valid authentication credentials. 401 status code",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Request is authenticated, but the user is not allowed to perform the operation. 403 status code",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The requested resource or endpoint does not exist. This can happen if a resource ID is invalid or the route is unknown. 404 status code",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The request could not be completed due to a conflict, such as a resource with dependencies that prevent deletion. 409 status code",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "The request was well-formed but failed validation (e.g. invalid field format or constraints), 422 status code",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "When the rate limit has been exceeded, 429 status code",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Some serverside issue, 5xx status code",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "x-speakeasy-pagination": {
+          "strategy": "offsetLimit",
+          "offsetParam": "offset",
+          "limitParam": "limit",
+          "totalField": "pagination.total",
+          "dataField": "data"
+        }
+      }
+    },
     "/students/bulk-import": {
       "post": {
         "tags": [
@@ -43,7 +249,11 @@
                   "students": {
                     "type": "array",
                     "items": {
-                      "title": "Student"
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/Student"
+                        }
+                      ]
                     },
                     "description": "Array of student data to import"
                   },
@@ -91,7 +301,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Error"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
                 }
               }
             }
@@ -101,7 +315,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Error"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
                 }
               }
             }
@@ -111,7 +329,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Error"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
                 }
               }
             }
@@ -121,7 +343,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Error"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
                 }
               }
             }
@@ -131,7 +357,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Error"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
                 }
               }
             }
@@ -141,7 +371,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Error"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
                 }
               }
             }
@@ -151,7 +385,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Error"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
                 }
               }
             }
@@ -161,7 +399,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Error"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
                 }
               }
             }
@@ -198,12 +440,20 @@
                 "type": "object",
                 "properties": {
                   "gradeLevel": {
-                    "title": "GradeLevel",
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/GradeLevel"
+                      }
+                    ],
                     "description": "Filter by specific grade level",
                     "nullable": true
                   },
                   "status": {
-                    "title": "StudentStatus",
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/StudentStatus"
+                      }
+                    ],
                     "description": "Filter by student status",
                     "nullable": true
                   },
@@ -263,7 +513,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Error"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
                 }
               }
             }
@@ -273,7 +527,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Error"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
                 }
               }
             }
@@ -283,7 +541,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Error"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
                 }
               }
             }
@@ -293,7 +555,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Error"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
                 }
               }
             }
@@ -303,7 +569,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Error"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
                 }
               }
             }
@@ -313,7 +583,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Error"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
                 }
               }
             }
@@ -323,7 +597,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Error"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
                 }
               }
             }
@@ -333,7 +611,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Error"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
                 }
               }
             }
@@ -410,7 +692,11 @@
                   "gradeLevel": {
                     "type": "array",
                     "items": {
-                      "title": "GradeLevel"
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/GradeLevel"
+                        }
+                      ]
                     },
                     "description": "Filter by one or more grade levels",
                     "nullable": true
@@ -418,7 +704,11 @@
                   "status": {
                     "type": "array",
                     "items": {
-                      "title": "StudentStatus"
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/StudentStatus"
+                        }
+                      ]
                     },
                     "description": "Filter by one or more statuses",
                     "nullable": true
@@ -454,7 +744,11 @@
                     "students": {
                       "type": "array",
                       "items": {
-                        "title": "Student"
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/Student"
+                          }
+                        ]
                       },
                       "description": "Array of matching students"
                     },
@@ -476,7 +770,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Error"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
                 }
               }
             }
@@ -486,7 +784,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Error"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
                 }
               }
             }
@@ -496,7 +798,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Error"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
                 }
               }
             }
@@ -506,7 +812,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Error"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
                 }
               }
             }
@@ -516,7 +826,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Error"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
                 }
               }
             }
@@ -526,7 +840,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Error"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
                 }
               }
             }
@@ -536,7 +854,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Error"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
                 }
               }
             }
@@ -546,7 +868,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Error"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
                 }
               }
             }
@@ -597,12 +923,20 @@
                     "data": {
                       "type": "array",
                       "items": {
-                        "title": "Students"
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/Students"
+                          }
+                        ]
                       },
                       "description": "Array of Students objects"
                     },
                     "pagination": {
-                      "title": "Pagination",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/Pagination"
+                        }
+                      ],
                       "description": "Pagination information"
                     }
                   }
@@ -615,7 +949,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Error"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
                 }
               }
             }
@@ -625,7 +963,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Error"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
                 }
               }
             }
@@ -635,7 +977,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Error"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
                 }
               }
             }
@@ -645,7 +991,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Error"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
                 }
               }
             }
@@ -655,7 +1005,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Error"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
                 }
               }
             }
@@ -665,7 +1019,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Error"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
                 }
               }
             }
@@ -675,7 +1033,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Error"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
                 }
               }
             }
@@ -717,20 +1079,36 @@
                     "description": "School-assigned student ID"
                   },
                   "status": {
-                    "title": "StudentStatus",
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/StudentStatus"
+                      }
+                    ],
                     "description": "Current status of the student",
                     "default": "Active"
                   },
                   "gradeLevel": {
-                    "title": "GradeLevel",
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/GradeLevel"
+                      }
+                    ],
                     "description": "Current grade level"
                   },
                   "contact": {
-                    "title": "Contact",
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/Contact"
+                      }
+                    ],
                     "description": "Student contact information"
                   },
                   "address": {
-                    "title": "Address",
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/Address"
+                      }
+                    ],
                     "description": "Student home address",
                     "nullable": true
                   },
@@ -758,7 +1136,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Students"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Students"
+                    }
+                  ]
                 }
               }
             }
@@ -768,7 +1150,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Error"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
                 }
               }
             }
@@ -778,7 +1164,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Error"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
                 }
               }
             }
@@ -788,7 +1178,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Error"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
                 }
               }
             }
@@ -798,7 +1192,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Error"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
                 }
               }
             }
@@ -808,7 +1206,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Error"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
                 }
               }
             }
@@ -818,7 +1220,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Error"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
                 }
               }
             }
@@ -828,7 +1234,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Error"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
                 }
               }
             }
@@ -838,7 +1248,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Error"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
                 }
               }
             }
@@ -873,7 +1287,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Students"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Students"
+                    }
+                  ]
                 }
               }
             }
@@ -883,7 +1301,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Error"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
                 }
               }
             }
@@ -893,7 +1315,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Error"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
                 }
               }
             }
@@ -903,7 +1329,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Error"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
                 }
               }
             }
@@ -913,7 +1343,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Error"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
                 }
               }
             }
@@ -923,7 +1357,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Error"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
                 }
               }
             }
@@ -933,7 +1371,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Error"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
                 }
               }
             }
@@ -943,7 +1385,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Error"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
                 }
               }
             }
@@ -979,7 +1425,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Error"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
                 }
               }
             }
@@ -989,7 +1439,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Error"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
                 }
               }
             }
@@ -999,7 +1453,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Error"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
                 }
               }
             }
@@ -1009,7 +1467,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Error"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
                 }
               }
             }
@@ -1019,7 +1481,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Error"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
                 }
               }
             }
@@ -1029,7 +1495,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Error"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
                 }
               }
             }
@@ -1039,7 +1509,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Error"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
                 }
               }
             }
@@ -1082,20 +1556,36 @@
                     "description": "Student's last name"
                   },
                   "status": {
-                    "title": "StudentStatus",
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/StudentStatus"
+                      }
+                    ],
                     "description": "Current status of the student",
                     "default": "Active"
                   },
                   "gradeLevel": {
-                    "title": "GradeLevel",
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/GradeLevel"
+                      }
+                    ],
                     "description": "Current grade level"
                   },
                   "contact": {
-                    "title": "Contact",
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/Contact"
+                      }
+                    ],
                     "description": "Student contact information"
                   },
                   "address": {
-                    "title": "Address",
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/Address"
+                      }
+                    ],
                     "description": "Student home address",
                     "nullable": true
                   },
@@ -1122,166 +1612,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Students"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "The request was malformed or contained invalid parameters. 400 status code",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "title": "Error"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "The request is missing valid authentication credentials. 401 status code",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "title": "Error"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Request is authenticated, but the user is not allowed to perform the operation. 403 status code",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "title": "Error"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "The requested resource or endpoint does not exist. This can happen if a resource ID is invalid or the route is unknown. 404 status code",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "title": "Error"
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "The request could not be completed due to a conflict, such as a resource with dependencies that prevent deletion. 409 status code",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "title": "Error"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "The request was well-formed but failed validation (e.g. invalid field format or constraints), 422 status code",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "title": "Error"
-                }
-              }
-            }
-          },
-          "429": {
-            "description": "When the rate limit has been exceeded, 429 status code",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "title": "Error"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Some serverside issue, 5xx status code",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "title": "Error"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/students/_search": {
-      "post": {
-        "tags": [
-          "Students"
-        ],
-        "summary": "Search Students",
-        "description": "Search for `Students` with filtering capabilities.",
-        "operationId": "StudentsSearch",
-        "parameters": [
-          {
-            "name": "limit",
-            "in": "query",
-            "description": "The maximum number of items to return (default: 50)",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "description": "The maximum number of items to return (default: 50)",
-              "default": 50
-            }
-          },
-          {
-            "name": "offset",
-            "in": "query",
-            "description": "The number of items to skip before starting to return results (default: 0)",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "description": "The number of items to skip before starting to return results (default: 0)",
-              "default": 0
-            }
-          }
-        ],
-        "requestBody": {
-          "description": "Request body",
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "filter": {
-                    "type": "string",
-                    "description": "Filter criteria to search for specific records"
-                  }
-                },
-                "required": [
-                  "filter"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "type": "array",
-                      "items": {
-                        "title": "Students"
-                      },
-                      "description": "Array of Students objects"
-                    },
-                    "pagination": {
-                      "title": "Pagination",
-                      "description": "Pagination information"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Students"
                     }
-                  }
+                  ]
                 }
               }
             }
@@ -1291,7 +1626,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Error"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
                 }
               }
             }
@@ -1301,7 +1640,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Error"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
                 }
               }
             }
@@ -1311,7 +1654,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Error"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
                 }
               }
             }
@@ -1321,7 +1668,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Error"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
                 }
               }
             }
@@ -1331,7 +1682,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Error"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
                 }
               }
             }
@@ -1341,7 +1696,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Error"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
                 }
               }
             }
@@ -1351,7 +1710,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Error"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
                 }
               }
             }
@@ -1361,18 +1724,15 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Error"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ]
                 }
               }
             }
           }
-        },
-        "x-speakeasy-pagination": {
-          "strategy": "offsetLimit",
-          "offsetParam": "offset",
-          "limitParam": "limit",
-          "totalField": "pagination.total",
-          "dataField": "data"
         }
       }
     }
@@ -1483,11 +1843,19 @@
             "description": "School-assigned student ID"
           },
           "status": {
-            "title": "StudentStatus",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/StudentStatus"
+              }
+            ],
             "description": "Current status of the student"
           },
           "gradeLevel": {
-            "title": "GradeLevel",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GradeLevel"
+              }
+            ],
             "description": "Current grade level"
           }
         },
@@ -1504,7 +1872,11 @@
         "type": "object",
         "properties": {
           "code": {
-            "title": "ErrorCode",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorCode"
+              }
+            ],
             "description": "The specific error code indicating the type of error"
           },
           "message": {
@@ -1522,7 +1894,11 @@
         "type": "object",
         "properties": {
           "code": {
-            "title": "ErrorFieldCode",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorFieldCode"
+              }
+            ],
             "description": "The specific error code indicating the type of field validation error"
           },
           "message": {
@@ -1600,7 +1976,11 @@
             "description": "Unique student identifier"
           },
           "meta": {
-            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Meta"
+              }
+            ],
             "description": "Metadata information for the Students"
           },
           "firstName": {
@@ -1616,20 +1996,36 @@
             "description": "School-assigned student ID"
           },
           "status": {
-            "title": "StudentStatus",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/StudentStatus"
+              }
+            ],
             "description": "Current status of the student",
             "default": "Active"
           },
           "gradeLevel": {
-            "title": "GradeLevel",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GradeLevel"
+              }
+            ],
             "description": "Current grade level"
           },
           "contact": {
-            "title": "Contact",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Contact"
+              }
+            ],
             "description": "Student contact information"
           },
           "address": {
-            "title": "Address",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Address"
+              }
+            ],
             "description": "Student home address",
             "nullable": true
           },
@@ -1656,16 +2052,75 @@
         ],
         "description": "Student management resource"
       },
+      "StudentRequestError": {
+        "type": "object",
+        "properties": {
+          "firstName": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
+            "description": "Student's first name",
+            "nullable": true
+          },
+          "lastName": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
+            "description": "Student's last name",
+            "nullable": true
+          },
+          "studentId": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
+            "description": "School-assigned student ID",
+            "nullable": true
+          },
+          "status": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
+            "description": "Current status of the student",
+            "nullable": true
+          },
+          "gradeLevel": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
+            "description": "Current grade level",
+            "nullable": true
+          }
+        },
+        "description": "Request error object for Student"
+      },
       "ContactRequestError": {
         "type": "object",
         "properties": {
           "email": {
-            "title": "ErrorField",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
             "description": "Email address",
             "nullable": true
           },
           "phone": {
-            "title": "ErrorField",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
             "description": "Phone number",
             "nullable": true
           }
@@ -1676,69 +2131,62 @@
         "type": "object",
         "properties": {
           "street": {
-            "title": "ErrorField",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
             "description": "Street address",
             "nullable": true
           },
           "city": {
-            "title": "ErrorField",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
             "description": "City",
             "nullable": true
           },
           "state": {
-            "title": "ErrorField",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
             "description": "State or province",
             "nullable": true
           },
           "zipCode": {
-            "title": "ErrorField",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
             "description": "ZIP or postal code",
             "nullable": true
           }
         },
         "description": "Request error object for Address"
       },
-      "StudentRequestError": {
-        "type": "object",
-        "properties": {
-          "firstName": {
-            "title": "ErrorField",
-            "description": "Student's first name",
-            "nullable": true
-          },
-          "lastName": {
-            "title": "ErrorField",
-            "description": "Student's last name",
-            "nullable": true
-          },
-          "studentId": {
-            "title": "ErrorField",
-            "description": "School-assigned student ID",
-            "nullable": true
-          },
-          "status": {
-            "title": "ErrorField",
-            "description": "Current status of the student",
-            "nullable": true
-          },
-          "gradeLevel": {
-            "title": "ErrorField",
-            "description": "Current grade level",
-            "nullable": true
-          }
-        },
-        "description": "Request error object for Student"
-      },
       "StudentsBulkImportRequestError": {
         "type": "object",
         "properties": {
           "students": {
-            "title": "StudentRequestError",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/StudentRequestError"
+              }
+            ],
             "description": "Array of student data to import",
             "nullable": true
           },
           "overwriteExisting": {
-            "title": "ErrorField",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
             "description": "Whether to overwrite existing student records",
             "nullable": true
           }
@@ -1749,27 +2197,47 @@
         "type": "object",
         "properties": {
           "gradeLevel": {
-            "title": "ErrorField",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
             "description": "Filter by specific grade level",
             "nullable": true
           },
           "status": {
-            "title": "ErrorField",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
             "description": "Filter by student status",
             "nullable": true
           },
           "enrollmentDateFrom": {
-            "title": "ErrorField",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
             "description": "Filter students enrolled after this date",
             "nullable": true
           },
           "enrollmentDateTo": {
-            "title": "ErrorField",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
             "description": "Filter students enrolled before this date",
             "nullable": true
           },
           "includeInactive": {
-            "title": "ErrorField",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
             "description": "Include inactive students in report",
             "nullable": true
           }
@@ -1780,27 +2248,47 @@
         "type": "object",
         "properties": {
           "nameQuery": {
-            "title": "ErrorField",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
             "description": "Search in first name and last name",
             "nullable": true
           },
           "gradeLevel": {
-            "title": "ErrorField",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
             "description": "Filter by one or more grade levels",
             "nullable": true
           },
           "status": {
-            "title": "ErrorField",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
             "description": "Filter by one or more statuses",
             "nullable": true
           },
           "enrollmentDateRange": {
-            "title": "ErrorField",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
             "description": "Date range filter [from, to]",
             "nullable": true
           },
           "hasGraduationDate": {
-            "title": "ErrorField",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
             "description": "Filter students with or without graduation date",
             "nullable": true
           }
@@ -1811,42 +2299,74 @@
         "type": "object",
         "properties": {
           "firstName": {
-            "title": "ErrorField",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
             "description": "Student's first name",
             "nullable": true
           },
           "lastName": {
-            "title": "ErrorField",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
             "description": "Student's last name",
             "nullable": true
           },
           "studentId": {
-            "title": "ErrorField",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
             "description": "School-assigned student ID",
             "nullable": true
           },
           "status": {
-            "title": "ErrorField",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
             "description": "Current status of the student",
             "nullable": true
           },
           "gradeLevel": {
-            "title": "ErrorField",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
             "description": "Current grade level",
             "nullable": true
           },
           "contact": {
-            "title": "ContactRequestError",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ContactRequestError"
+              }
+            ],
             "description": "Student contact information",
             "nullable": true
           },
           "address": {
-            "title": "AddressRequestError",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AddressRequestError"
+              }
+            ],
             "description": "Student home address",
             "nullable": true
           },
           "enrollmentDate": {
-            "title": "ErrorField",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
             "description": "Date when student was enrolled",
             "nullable": true
           }
@@ -1857,37 +2377,65 @@
         "type": "object",
         "properties": {
           "firstName": {
-            "title": "ErrorField",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
             "description": "Student's first name",
             "nullable": true
           },
           "lastName": {
-            "title": "ErrorField",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
             "description": "Student's last name",
             "nullable": true
           },
           "status": {
-            "title": "ErrorField",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
             "description": "Current status of the student",
             "nullable": true
           },
           "gradeLevel": {
-            "title": "ErrorField",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
             "description": "Current grade level",
             "nullable": true
           },
           "contact": {
-            "title": "ContactRequestError",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ContactRequestError"
+              }
+            ],
             "description": "Student contact information",
             "nullable": true
           },
           "address": {
-            "title": "AddressRequestError",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AddressRequestError"
+              }
+            ],
             "description": "Student home address",
             "nullable": true
           },
           "graduationDate": {
-            "title": "ErrorField",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
             "description": "Expected or actual graduation date",
             "nullable": true
           }
@@ -1909,62 +2457,110 @@
         "type": "object",
         "properties": {
           "equals": {
-            "title": "ContactFilterEquals",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ContactFilterEquals"
+              }
+            ],
             "description": "Equality filters for Contact",
             "nullable": true
           },
           "notEquals": {
-            "title": "ContactFilterEquals",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ContactFilterEquals"
+              }
+            ],
             "description": "Inequality filters for Contact",
             "nullable": true
           },
           "greaterThan": {
-            "title": "ContactFilterRange",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ContactFilterRange"
+              }
+            ],
             "description": "Greater than filters for Contact",
             "nullable": true
           },
           "smallerThan": {
-            "title": "ContactFilterRange",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ContactFilterRange"
+              }
+            ],
             "description": "Smaller than filters for Contact",
             "nullable": true
           },
           "greaterOrEqual": {
-            "title": "ContactFilterRange",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ContactFilterRange"
+              }
+            ],
             "description": "Greater than or equal filters for Contact",
             "nullable": true
           },
           "smallerOrEqual": {
-            "title": "ContactFilterRange",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ContactFilterRange"
+              }
+            ],
             "description": "Smaller than or equal filters for Contact",
             "nullable": true
           },
           "contains": {
-            "title": "ContactFilterContains",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ContactFilterContains"
+              }
+            ],
             "description": "Contains filters for Contact",
             "nullable": true
           },
           "notContains": {
-            "title": "ContactFilterContains",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ContactFilterContains"
+              }
+            ],
             "description": "Not contains filters for Contact",
             "nullable": true
           },
           "like": {
-            "title": "ContactFilterLike",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ContactFilterLike"
+              }
+            ],
             "description": "LIKE filters for Contact",
             "nullable": true
           },
           "notLike": {
-            "title": "ContactFilterLike",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ContactFilterLike"
+              }
+            ],
             "description": "NOT LIKE filters for Contact",
             "nullable": true
           },
           "null": {
-            "title": "ContactFilterNull",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ContactFilterNull"
+              }
+            ],
             "description": "Null filters for Contact",
             "nullable": true
           },
           "notNull": {
-            "title": "ContactFilterNull",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ContactFilterNull"
+              }
+            ],
             "description": "Not null filters for Contact",
             "nullable": true
           },
@@ -1975,7 +2571,11 @@
           "nestedFilters": {
             "type": "array",
             "items": {
-              "title": "ContactFilter"
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/ContactFilter"
+                }
+              ]
             },
             "description": "NestedFilters of the Contact, useful for more complex filters"
           }
@@ -2056,62 +2656,110 @@
         "type": "object",
         "properties": {
           "equals": {
-            "title": "AddressFilterEquals",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AddressFilterEquals"
+              }
+            ],
             "description": "Equality filters for Address",
             "nullable": true
           },
           "notEquals": {
-            "title": "AddressFilterEquals",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AddressFilterEquals"
+              }
+            ],
             "description": "Inequality filters for Address",
             "nullable": true
           },
           "greaterThan": {
-            "title": "AddressFilterRange",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AddressFilterRange"
+              }
+            ],
             "description": "Greater than filters for Address",
             "nullable": true
           },
           "smallerThan": {
-            "title": "AddressFilterRange",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AddressFilterRange"
+              }
+            ],
             "description": "Smaller than filters for Address",
             "nullable": true
           },
           "greaterOrEqual": {
-            "title": "AddressFilterRange",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AddressFilterRange"
+              }
+            ],
             "description": "Greater than or equal filters for Address",
             "nullable": true
           },
           "smallerOrEqual": {
-            "title": "AddressFilterRange",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AddressFilterRange"
+              }
+            ],
             "description": "Smaller than or equal filters for Address",
             "nullable": true
           },
           "contains": {
-            "title": "AddressFilterContains",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AddressFilterContains"
+              }
+            ],
             "description": "Contains filters for Address",
             "nullable": true
           },
           "notContains": {
-            "title": "AddressFilterContains",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AddressFilterContains"
+              }
+            ],
             "description": "Not contains filters for Address",
             "nullable": true
           },
           "like": {
-            "title": "AddressFilterLike",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AddressFilterLike"
+              }
+            ],
             "description": "LIKE filters for Address",
             "nullable": true
           },
           "notLike": {
-            "title": "AddressFilterLike",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AddressFilterLike"
+              }
+            ],
             "description": "NOT LIKE filters for Address",
             "nullable": true
           },
           "null": {
-            "title": "AddressFilterNull",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AddressFilterNull"
+              }
+            ],
             "description": "Null filters for Address",
             "nullable": true
           },
           "notNull": {
-            "title": "AddressFilterNull",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AddressFilterNull"
+              }
+            ],
             "description": "Not null filters for Address",
             "nullable": true
           },
@@ -2122,7 +2770,11 @@
           "nestedFilters": {
             "type": "array",
             "items": {
-              "title": "AddressFilter"
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/AddressFilter"
+                }
+              ]
             },
             "description": "NestedFilters of the Address, useful for more complex filters"
           }
@@ -2230,62 +2882,110 @@
         "type": "object",
         "properties": {
           "equals": {
-            "title": "StudentFilterEquals",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/StudentFilterEquals"
+              }
+            ],
             "description": "Equality filters for Student",
             "nullable": true
           },
           "notEquals": {
-            "title": "StudentFilterEquals",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/StudentFilterEquals"
+              }
+            ],
             "description": "Inequality filters for Student",
             "nullable": true
           },
           "greaterThan": {
-            "title": "StudentFilterRange",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/StudentFilterRange"
+              }
+            ],
             "description": "Greater than filters for Student",
             "nullable": true
           },
           "smallerThan": {
-            "title": "StudentFilterRange",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/StudentFilterRange"
+              }
+            ],
             "description": "Smaller than filters for Student",
             "nullable": true
           },
           "greaterOrEqual": {
-            "title": "StudentFilterRange",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/StudentFilterRange"
+              }
+            ],
             "description": "Greater than or equal filters for Student",
             "nullable": true
           },
           "smallerOrEqual": {
-            "title": "StudentFilterRange",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/StudentFilterRange"
+              }
+            ],
             "description": "Smaller than or equal filters for Student",
             "nullable": true
           },
           "contains": {
-            "title": "StudentFilterContains",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/StudentFilterContains"
+              }
+            ],
             "description": "Contains filters for Student",
             "nullable": true
           },
           "notContains": {
-            "title": "StudentFilterContains",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/StudentFilterContains"
+              }
+            ],
             "description": "Not contains filters for Student",
             "nullable": true
           },
           "like": {
-            "title": "StudentFilterLike",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/StudentFilterLike"
+              }
+            ],
             "description": "LIKE filters for Student",
             "nullable": true
           },
           "notLike": {
-            "title": "StudentFilterLike",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/StudentFilterLike"
+              }
+            ],
             "description": "NOT LIKE filters for Student",
             "nullable": true
           },
           "null": {
-            "title": "StudentFilterNull",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/StudentFilterNull"
+              }
+            ],
             "description": "Null filters for Student",
             "nullable": true
           },
           "notNull": {
-            "title": "StudentFilterNull",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/StudentFilterNull"
+              }
+            ],
             "description": "Not null filters for Student",
             "nullable": true
           },
@@ -2296,7 +2996,11 @@
           "nestedFilters": {
             "type": "array",
             "items": {
-              "title": "StudentFilter"
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/StudentFilter"
+                }
+              ]
             },
             "description": "NestedFilters of the Student, useful for more complex filters"
           }
@@ -2325,12 +3029,20 @@
             "nullable": true
           },
           "status": {
-            "title": "StudentStatus",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/StudentStatus"
+              }
+            ],
             "description": "Current status of the student",
             "nullable": true
           },
           "gradeLevel": {
-            "title": "GradeLevel",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GradeLevel"
+              }
+            ],
             "description": "Current grade level",
             "nullable": true
           }
@@ -2368,14 +3080,22 @@
           "status": {
             "type": "array",
             "items": {
-              "title": "StudentStatus"
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/StudentStatus"
+                }
+              ]
             },
             "description": "Current status of the student"
           },
           "gradeLevel": {
             "type": "array",
             "items": {
-              "title": "GradeLevel"
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/GradeLevel"
+                }
+              ]
             },
             "description": "Current grade level"
           }


### PR DESCRIPTION
Update OpenAPI document generation to use `allOf` with `$ref` for component schemas to correctly reference them.

Previously, fields referencing other component schemas were incorrectly inlined or used a `title`-based fallback, leading to invalid OpenAPI specifications. This change ensures proper OpenAPI 3.1 schema referencing using the `allOf` pattern.

---
Linear Issue: [INF-267](https://linear.app/meitner-se/issue/INF-267/fix-schema-reference-in-openapi-document)

<a href="https://cursor.com/background-agent?bcId=bc-5fadf17e-72d0-4928-b0df-722df6a29ba4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5fadf17e-72d0-4928-b0df-722df6a29ba4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

