### PR TITLE
Update openapi document with contact details

### DIFF
--- a/specification/openapi/openapi.go
+++ b/specification/openapi/openapi.go
@@ -362,6 +362,24 @@ func (g *Generator) buildV3Document(service *specification.Service) *v3.Document
 		Version:     version,
 	}
 
+	// Add contact information if available in the service
+	if service.Contact != nil {
+		contact := &base.Contact{}
+		if service.Contact.Name != "" {
+			contact.Name = service.Contact.Name
+		}
+		if service.Contact.URL != "" {
+			contact.URL = service.Contact.URL
+		}
+		if service.Contact.Email != "" {
+			contact.Email = service.Contact.Email
+		}
+		// Only set contact if at least one field is provided
+		if service.Contact.Name != "" || service.Contact.URL != "" || service.Contact.Email != "" {
+			info.Contact = contact
+		}
+	}
+
 	// Create Document
 	document := &v3.Document{
 		Version: g.Version,

--- a/specification/specification.go
+++ b/specification/specification.go
@@ -329,6 +329,18 @@ type ServiceServer struct {
 	Description string `json:"description,omitempty"`
 }
 
+// ServiceContact represents the contact information for the API service.
+type ServiceContact struct {
+	// Name of the contact person/organization
+	Name string `json:"name,omitempty"`
+
+	// URL pointing to the contact information
+	URL string `json:"url,omitempty"`
+
+	// Email address of the contact person/organization
+	Email string `json:"email,omitempty"`
+}
+
 // RetryBackoffConfiguration defines the backoff behavior for retry attempts.
 type RetryBackoffConfiguration struct {
 	// InitialInterval is the initial interval between retries in milliseconds
@@ -372,6 +384,9 @@ type Service struct {
 
 	// Version of the service
 	Version string `json:"version,omitempty"`
+
+	// Contact information for the service
+	Contact *ServiceContact `json:"contact,omitempty"`
 
 	// Servers that are part of the service
 	Servers []ServiceServer `json:"servers,omitempty"`
@@ -553,6 +568,7 @@ func ApplyOverlay(input *Service) *Service {
 	result := &Service{
 		Name:      input.Name,
 		Version:   input.Version,
+		Contact:   input.Contact,                               // Copy contact information
 		Servers:   append([]ServiceServer{}, input.Servers...), // Copy servers slice
 		Retry:     input.Retry,                                 // Copy retry configuration
 		Timeout:   input.Timeout,                               // Copy timeout configuration
@@ -1163,6 +1179,7 @@ func ApplyFilterOverlay(input *Service) *Service {
 	result := &Service{
 		Name:      input.Name,
 		Version:   input.Version,
+		Contact:   input.Contact,                               // Copy contact information
 		Servers:   append([]ServiceServer{}, input.Servers...), // Copy servers slice
 		Retry:     input.Retry,                                 // Copy retry configuration
 		Timeout:   input.Timeout,                               // Copy timeout configuration


### PR DESCRIPTION
Add contact details to the OpenAPI document to comply with OAS and provide support information.

The `ApplyOverlay` and `ApplyFilterOverlay` functions were not copying the `Contact` field, which caused contact details to be lost during specification processing. This PR includes a fix to ensure contact information is correctly propagated.

---
Linear Issue: [INF-269](https://linear.app/meitner-se/issue/INF-269/add-contact-details-to-openapi-document)

<a href="https://cursor.com/background-agent?bcId=bc-1863560b-441a-46da-879e-dc97ea742212">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1863560b-441a-46da-879e-dc97ea742212">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

