### PR TITLE
Add description field to endpoint response

### DIFF
--- a/specification/openapi/openapi.go
+++ b/specification/openapi/openapi.go
@@ -767,7 +767,7 @@ func (g *Generator) createRequestBody(bodyParams []specification.Field, service 
 // createResponse creates a v3.Response from an endpoint response using native types.
 func (g *Generator) createResponse(response specification.EndpointResponse, service *specification.Service) *v3.Response {
 	openAPIResponse := &v3.Response{
-		Description: successDescription,
+		Description: response.Description,
 	}
 
 	// Add response content if present

--- a/specification/schema/schema_test.go
+++ b/specification/schema/schema_test.go
@@ -996,6 +996,7 @@ func TestValidateEndpoint(t *testing.T) {
 		"response": {
 			"content_type": "",
 			"status_code": 200,
+			"description": "Successfully retrieved the user",
 			"headers": [],
 			"body_fields": []
 		}
@@ -1064,6 +1065,7 @@ func TestValidateEndpointResponse(t *testing.T) {
 	validEndpointResponseJSON := `{
 		"content_type": "application/json",
 		"status_code": 200,
+		"description": "Successful response",
 		"headers": [],
 		"body_fields": []
 	}`
@@ -1075,6 +1077,7 @@ func TestValidateEndpointResponse(t *testing.T) {
 	validEndpointResponseWithBodyObjectJSON := `{
 		"content_type": "application/json",
 		"status_code": 201,
+		"description": "Successfully created the user",
 		"headers": [],
 		"body_fields": [],
 		"body_object": "User"
@@ -1178,6 +1181,7 @@ func TestParseServiceFromJSON(t *testing.T) {
 						"response": {
 							"content_type": "application/json",
 							"status_code": 200,
+							"description": "Successfully retrieved the user",
 							"headers": [],
 							"body_fields": []
 						}
@@ -1268,6 +1272,7 @@ resources:
         response:
           content_type: application/json
           status_code: 200
+          description: Successfully retrieved the user
           headers: []
           body_fields: []
 `
@@ -1468,6 +1473,7 @@ func TestParseResourceFromJSON(t *testing.T) {
 				"response": {
 					"content_type": "application/json",
 					"status_code": 200,
+					"description": "Successfully retrieved the user",
 					"headers": [],
 					"body_fields": []
 				}
@@ -1527,6 +1533,7 @@ endpoints:
     response:
       content_type: application/json
       status_code: 200
+      description: Successfully retrieved the user
       headers: []
       body_fields: []
 `
@@ -1655,6 +1662,7 @@ func TestValidationWithComplexStructures(t *testing.T) {
 						"response": {
 							"content_type": "application/json",
 							"status_code": 201,
+							"description": "Successfully created the user",
 							"headers": [
 								{"name": "Location", "type": "String", "description": "Created resource URL"}
 							],

--- a/specification/specification.go
+++ b/specification/specification.go
@@ -284,6 +284,16 @@ const (
 	searchFilterParamDesc      = "Filter criteria to search for specific records"
 )
 
+// Response Description Constants
+const (
+	createResponseDescTemplate = "Successfully created the %s"
+	updateResponseDescTemplate = "Successfully updated the %s"
+	deleteResponseDescTemplate = "Successfully deleted the %s"
+	getResponseDescTemplate    = "Successfully retrieved the %s"
+	listResponseDescTemplate   = "Successfully retrieved the list of %s"
+	searchResponseDescTemplate = "Successfully searched for %s"
+)
+
 // Request Error Constants
 const (
 	requestErrorSuffix            = "RequestError"
@@ -543,6 +553,9 @@ type EndpointResponse struct {
 	// HTTP status code this response represents (e.g. 200, 201, 400)
 	StatusCode int `json:"status_code"`
 
+	// Description of the response
+	Description string `json:"description"`
+
 	// Headers returned in the response
 	Headers []Field `json:"headers"`
 
@@ -795,7 +808,7 @@ func generateCreateEndpoint(result *Service, resource Resource) {
 			Method:      httpMethodPost,
 			Path:        createEndpointPath,
 			Request:     createStandardRequest([]Field{}, []Field{}, bodyParams),
-			Response:    createStandardResponse(createResponseStatusCode, &resourceName),
+			Response:    createStandardResponse(createResponseStatusCode, fmt.Sprintf(createResponseDescTemplate, resourceName), &resourceName),
 		}
 
 		addEndpointToResource(result, resource.Name, createEndpoint)
@@ -819,7 +832,7 @@ func generateUpdateEndpoint(result *Service, resource Resource) {
 			Method:      httpMethodPatch,
 			Path:        updateEndpointPath,
 			Request:     createStandardRequest([]Field{idParam}, []Field{}, bodyParams),
-			Response:    createStandardResponse(updateResponseStatusCode, &resourceName),
+			Response:    createStandardResponse(updateResponseStatusCode, fmt.Sprintf(updateResponseDescTemplate, resourceName), &resourceName),
 		}
 
 		addEndpointToResource(result, resource.Name, updateEndpoint)
@@ -841,7 +854,7 @@ func generateDeleteEndpoint(result *Service, resource Resource) {
 			Method:      httpMethodDelete,
 			Path:        deleteEndpointPath,
 			Request:     createStandardRequest([]Field{idParam}, []Field{}, []Field{}),
-			Response:    createStandardResponse(deleteResponseStatusCode, nil), // No body object for delete
+			Response:    createStandardResponse(deleteResponseStatusCode, fmt.Sprintf(deleteResponseDescTemplate, resource.Name), nil), // No body object for delete
 		}
 
 		addEndpointToResource(result, resource.Name, deleteEndpoint)
@@ -864,7 +877,7 @@ func generateGetEndpoint(result *Service, resource Resource) {
 			Method:      httpMethodGet,
 			Path:        getEndpointPath,
 			Request:     createStandardRequest([]Field{idParam}, []Field{}, []Field{}),
-			Response:    createStandardResponse(getResponseStatusCode, &resourceName),
+			Response:    createStandardResponse(getResponseStatusCode, fmt.Sprintf(getResponseDescTemplate, resourceName), &resourceName),
 		}
 
 		addEndpointToResource(result, resource.Name, getEndpoint)
@@ -887,7 +900,7 @@ func generateListEndpoint(result *Service, resource Resource) {
 			Method:      httpMethodGet,
 			Path:        listEndpointPath,
 			Request:     createStandardRequest([]Field{}, []Field{limitParam, offsetParam}, []Field{}),
-			Response:    createListResponse(listResponseStatusCode, dataField, paginationField),
+			Response:    createListResponse(listResponseStatusCode, fmt.Sprintf(listResponseDescTemplate, pluralResourceName), dataField, paginationField),
 		}
 
 		addEndpointToResource(result, resource.Name, listEndpoint)
@@ -915,7 +928,7 @@ func generateSearchEndpoint(result *Service, resource Resource) {
 			Method:      httpMethodPost,
 			Path:        searchEndpointPath,
 			Request:     createStandardRequest([]Field{}, []Field{limitParam, offsetParam}, []Field{filterParam}),
-			Response:    createListResponse(searchResponseStatusCode, dataField, paginationField),
+			Response:    createListResponse(searchResponseStatusCode, fmt.Sprintf(searchResponseDescTemplate, pluralResourceName), dataField, paginationField),
 		}
 
 		addEndpointToResource(result, resource.Name, searchEndpoint)
@@ -943,11 +956,12 @@ func createStandardRequest(pathParams []Field, queryParams []Field, bodyParams [
 	}
 }
 
-// createStandardResponse creates a standard endpoint response with the given status code and optional body object.
-func createStandardResponse(statusCode int, bodyObject *string) EndpointResponse {
+// createStandardResponse creates a standard endpoint response with the given status code, description, and optional body object.
+func createStandardResponse(statusCode int, description string, bodyObject *string) EndpointResponse {
 	return EndpointResponse{
 		ContentType: contentTypeJSON,
 		StatusCode:  statusCode,
+		Description: description,
 		Headers:     []Field{},
 		BodyFields:  []Field{},
 		BodyObject:  bodyObject,
@@ -955,10 +969,11 @@ func createStandardResponse(statusCode int, bodyObject *string) EndpointResponse
 }
 
 // createListResponse creates a standard list endpoint response with pagination and data fields.
-func createListResponse(statusCode int, dataField Field, paginationField Field) EndpointResponse {
+func createListResponse(statusCode int, description string, dataField Field, paginationField Field) EndpointResponse {
 	return EndpointResponse{
 		ContentType: contentTypeJSON,
 		StatusCode:  statusCode,
+		Description: description,
 		Headers:     []Field{},
 		BodyFields:  []Field{dataField, paginationField},
 		BodyObject:  nil,

--- a/testdata/school-management-api-expected.json
+++ b/testdata/school-management-api-expected.json
@@ -89,7 +89,7 @@
         },
         "responses": {
           "202": {
-            "description": "Successful response",
+            "description": "Successfully queued report generation",
             "content": {
               "application/json": {
                 "schema": {
@@ -342,7 +342,7 @@
         },
         "responses": {
           "200": {
-            "description": "Successful response",
+            "description": "Successfully performed advanced search",
             "content": {
               "application/json": {
                 "schema": {
@@ -521,7 +521,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Successful response",
+            "description": "Successfully retrieved the list of Students",
             "content": {
               "application/json": {
                 "schema": {
@@ -739,7 +739,7 @@
         },
         "responses": {
           "201": {
-            "description": "Successful response",
+            "description": "Successfully created the Students",
             "content": {
               "application/json": {
                 "schema": {
@@ -890,7 +890,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Successful response",
+            "description": "Successfully retrieved the Students",
             "content": {
               "application/json": {
                 "schema": {
@@ -1025,7 +1025,7 @@
         ],
         "responses": {
           "204": {
-            "description": "Successful response"
+            "description": "Successfully deleted the Students"
           },
           "400": {
             "description": "The request was malformed or contained invalid parameters. 400 status code",
@@ -1215,7 +1215,7 @@
         },
         "responses": {
           "200": {
-            "description": "Successful response",
+            "description": "Successfully updated the Students",
             "content": {
               "application/json": {
                 "schema": {
@@ -1397,7 +1397,7 @@
         },
         "responses": {
           "200": {
-            "description": "Successful response",
+            "description": "Successfully searched for Students",
             "content": {
               "application/json": {
                 "schema": {
@@ -1601,7 +1601,7 @@
         },
         "responses": {
           "200": {
-            "description": "Successful response",
+            "description": "Successfully imported students",
             "content": {
               "application/json": {
                 "schema": {

--- a/testdata/school-management-api-overlay.yaml
+++ b/testdata/school-management-api-overlay.yaml
@@ -1120,6 +1120,7 @@ resources:
     response:
       content_type: application/json
       status_code: 201
+      description: Successfully created the Students
       headers: []
       body_fields: []
       body_object: Students
@@ -1166,6 +1167,7 @@ resources:
     response:
       content_type: application/json
       status_code: 200
+      description: Successfully updated the Students
       headers: []
       body_fields: []
       body_object: Students
@@ -1186,6 +1188,7 @@ resources:
     response:
       content_type: application/json
       status_code: 204
+      description: Successfully deleted the Students
       headers: []
       body_fields: []
   - name: Get
@@ -1205,6 +1208,7 @@ resources:
     response:
       content_type: application/json
       status_code: 200
+      description: Successfully retrieved the Students
       headers: []
       body_fields: []
       body_object: Students
@@ -1230,6 +1234,7 @@ resources:
     response:
       content_type: application/json
       status_code: 200
+      description: Successfully retrieved the list of Students
       headers: []
       body_fields:
       - name: data
@@ -1265,6 +1270,7 @@ resources:
     response:
       content_type: application/json
       status_code: 200
+      description: Successfully searched for Students
       headers: []
       body_fields:
       - name: data

--- a/testdata/school-management-api.yaml
+++ b/testdata/school-management-api.yaml
@@ -149,6 +149,7 @@ resources:
         response:
           content_type: "application/json"
           status_code: 200
+          description: "Successfully imported students"
           body_fields:
             - name: "imported"
               type: "Int"
@@ -197,6 +198,7 @@ resources:
         response:
           content_type: "application/json"
           status_code: 202
+          description: "Successfully queued report generation"
           body_fields:
             - name: "reportId"
               type: "UUID"
@@ -257,6 +259,7 @@ resources:
         response:
           content_type: "application/json"
           status_code: 200
+          description: "Successfully performed advanced search"
           body_fields:
             - name: "students"
               type: "Student"


### PR DESCRIPTION
Add a `description` field to `EndpointResponse` and populate it for all auto-generated endpoints to improve OpenAPI documentation.

This change addresses Linear issue INF-273 by ensuring that all auto-generated API endpoints have meaningful, resource-specific response descriptions, which are then correctly reflected in the generated OpenAPI specification. This enhances the clarity and usability of the API documentation for third-party developers.

---
Linear Issue: [INF-273](https://linear.app/meitner-se/issue/INF-273/add-description-field-to-the-endpointresponse-in-specificationgo)

<a href="https://cursor.com/background-agent?bcId=bc-ddaa4f8e-9f8e-4ffc-98b2-23df78e73b65">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ddaa4f8e-9f8e-4ffc-98b2-23df78e73b65">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

