### PR TITLE
Quote enum values unless null

### DIFF
--- a/specification/openapi/openapi.go
+++ b/specification/openapi/openapi.go
@@ -96,6 +96,11 @@ const (
 	schemaTypeObject  = "object"
 )
 
+// YAML tag constants
+const (
+	tagString = "!!str"
+)
+
 // Schema formats
 const (
 	schemaFormatUUID     = "uuid"
@@ -494,6 +499,7 @@ func (g *Generator) createEnumSchema(enum specification.Enum) *base.Schema {
 		node := &yaml.Node{
 			Kind:  yaml.ScalarNode,
 			Value: value.Name,
+			Tag:   tagString, // Ensure enum values are treated as strings
 		}
 		enumValues[i] = node
 	}


### PR DESCRIPTION
Wrap OpenAPI enum values in quotes to ensure they are treated as strings, as required by INF-280.

---
Linear Issue: [INF-280](https://linear.app/meitner-se/issue/INF-280/wrap-enum-values-in-quotes-unless-it-is-null)

<a href="https://cursor.com/background-agent?bcId=bc-122b6b05-cdd9-4b18-80be-b9ef1fa75963">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-122b6b05-cdd9-4b18-80be-b9ef1fa75963">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

