### PR TITLE
Fix csnSchoolCode naming convention

### DIFF
--- a/specification/specification.go
+++ b/specification/specification.go
@@ -1836,12 +1836,48 @@ func getComment(tabs string, description string, name string) string {
 }
 
 // camelCase converts a string to camelCase format.
-// Special case: "ID" becomes "id" instead of "iD"
+// Special cases:
+// - "ID" becomes "id" instead of "iD"
+// - Consecutive capital letters at the start are lowercased (e.g., "CSNSchoolCode" -> "csnSchoolCode")
 func camelCase(s string) string {
 	if s == "ID" {
 		return "id"
 	}
-	return strmangle.CamelCase(s)
+
+	result := strmangle.CamelCase(s)
+
+	// Handle consecutive capital letters at the beginning
+	// Convert sequences like "cSNSchool" to "csnSchool"
+	if len(result) > 1 {
+		runes := []rune(result)
+
+		// Find the end of consecutive uppercase letters at the beginning (after first char)
+		consecutiveEnd := 1
+		for consecutiveEnd < len(runes) && runes[consecutiveEnd] >= 'A' && runes[consecutiveEnd] <= 'Z' {
+			consecutiveEnd++
+		}
+
+		// If we have consecutive uppercase letters, convert them to lowercase
+		// except possibly the last one if it's followed by lowercase letters
+		if consecutiveEnd > 2 {
+			// If the sequence is followed by lowercase letters, keep the last uppercase letter
+			// Example: "cSNSchool" -> "csnSchool" (convert "SN" to "sn", keep "S" before "chool")
+			if consecutiveEnd < len(runes) && runes[consecutiveEnd] >= 'a' && runes[consecutiveEnd] <= 'z' {
+				consecutiveEnd--
+			}
+
+			// Convert consecutive uppercase letters to lowercase
+			for i := 1; i < consecutiveEnd; i++ {
+				if runes[i] >= 'A' && runes[i] <= 'Z' {
+					runes[i] = runes[i] - 'A' + 'a'
+				}
+			}
+
+			result = string(runes)
+		}
+	}
+
+	return result
 }
 
 // toKebabCase converts a string to kebab-case format.

--- a/specification/specification_test.go
+++ b/specification/specification_test.go
@@ -1336,7 +1336,10 @@ func TestCamelCase(t *testing.T) {
 		{"user_id", "userID"},
 		{"api_key", "apiKey"},
 		{"username", "username"},
-		{"ID", "id"}, // Special case: ID should become id, not iD
+		{"ID", "id"},                           // Special case: ID should become id, not iD
+		{"CSNSchoolCode", "csnSchoolCode"},     // Special case: consecutive capitals should be lowercased
+		{"APIKey", "apiKey"},                   // Another case with consecutive capitals
+		{"HTTPSConnection", "httpsConnection"}, // Multiple consecutive capitals
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Fix `camelCase` function to correctly handle consecutive capital letters at the start of a string (e.g., "CSNSchoolCode" to "csnSchoolCode").

The previous `strmangle.CamelCase` conversion resulted in incorrect camelCasing for strings starting with multiple capital letters (e.g., "CSNSchoolCode" became "cSNSchoolCode"). This change introduces custom logic to properly lowercase such initial sequences, ensuring adherence to the desired naming convention.

---
Linear Issue: [INF-287](https://linear.app/meitner-se/issue/INF-287/fix-camelcase-for-csnschoolcode)

<a href="https://cursor.com/background-agent?bcId=bc-fa5f1f9e-ee9b-424a-9b46-91a0822e1ae9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fa5f1f9e-ee9b-424a-9b46-91a0822e1ae9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

