### PR TITLE
Add license to api spec and openapi

### DIFF
--- a/specification/openapi/openapi.go
+++ b/specification/openapi/openapi.go
@@ -415,6 +415,20 @@ func (g *Generator) buildV3Document(service *specification.Service) *v3.Document
 		}
 	}
 
+	// Add license information if available in the service
+	if service.License != nil && service.License.Name != "" {
+		license := &base.License{
+			Name: service.License.Name,
+		}
+		if service.License.URL != "" {
+			license.URL = service.License.URL
+		}
+		if service.License.Identifier != "" {
+			license.Identifier = service.License.Identifier
+		}
+		info.License = license
+	}
+
 	// Create Document
 	document := &v3.Document{
 		Version: g.Version,

--- a/specification/openapi/openapi_test.go
+++ b/specification/openapi/openapi_test.go
@@ -2050,6 +2050,124 @@ func TestGenerator_GenerateFromService_ContactDetails(t *testing.T) {
 	})
 }
 
+// TestGenerator_GenerateFromService_WithLicense tests OpenAPI document generation with license information.
+func TestGenerator_GenerateFromService_WithLicense(t *testing.T) {
+	// Test with complete license information
+	t.Run("complete license information is included", func(t *testing.T) {
+		generator := newGenerator()
+		service := &specification.Service{
+			Name:    "TestService",
+			Version: "1.0.0",
+			License: &specification.ServiceLicense{
+				Name:       "MIT License",
+				URL:        "https://opensource.org/licenses/MIT",
+				Identifier: "MIT",
+			},
+		}
+
+		document, err := generator.GenerateFromService(service)
+		assert.NoError(t, err, "Should generate document successfully")
+		assert.NotNil(t, document, "Document should not be nil")
+		assert.NotNil(t, document.Info, "Document Info should not be nil")
+		assert.NotNil(t, document.Info.License, "Document Info License should not be nil")
+
+		// Check license details
+		assert.Equal(t, "MIT License", document.Info.License.Name, "License name should match service license")
+		assert.Equal(t, "https://opensource.org/licenses/MIT", document.Info.License.URL, "License URL should match service license")
+		assert.Equal(t, "MIT", document.Info.License.Identifier, "License identifier should match service license")
+
+		// Generate JSON to verify structure
+		jsonBytes, err := generator.ToJSON(document)
+		assert.NoError(t, err, "Should convert to JSON successfully")
+		jsonString := string(jsonBytes)
+
+		assert.Contains(t, jsonString, "\"license\"", "JSON should contain license field")
+		assert.Contains(t, jsonString, "\"MIT License\"", "JSON should contain license name")
+		assert.Contains(t, jsonString, "\"https://opensource.org/licenses/MIT\"", "JSON should contain license URL")
+		assert.Contains(t, jsonString, "\"MIT\"", "JSON should contain license identifier")
+	})
+
+	// Test with partial license information (name only)
+	t.Run("partial license information with name only", func(t *testing.T) {
+		generator := newGenerator()
+		service := &specification.Service{
+			Name:    "TestService",
+			Version: "1.0.0",
+			License: &specification.ServiceLicense{
+				Name: "Apache License 2.0",
+			},
+		}
+
+		document, err := generator.GenerateFromService(service)
+		assert.NoError(t, err, "Should generate document successfully")
+		assert.NotNil(t, document, "Document should not be nil")
+		assert.NotNil(t, document.Info.License, "Document Info License should not be nil")
+
+		// Check provided license details
+		assert.Equal(t, "Apache License 2.0", document.Info.License.Name, "License name should match service license")
+		assert.Equal(t, "", document.Info.License.URL, "License URL should be empty when not provided")
+		assert.Equal(t, "", document.Info.License.Identifier, "License identifier should be empty when not provided")
+
+		// Generate JSON to verify structure
+		jsonBytes, err := generator.ToJSON(document)
+		assert.NoError(t, err, "Should convert to JSON successfully")
+		jsonString := string(jsonBytes)
+
+		assert.Contains(t, jsonString, "\"license\"", "JSON should contain license field")
+		assert.Contains(t, jsonString, "\"Apache License 2.0\"", "JSON should contain license name")
+	})
+
+	// Test with nil license
+	t.Run("nil license is not included", func(t *testing.T) {
+		generator := newGenerator()
+		service := &specification.Service{
+			Name:    "TestService",
+			Version: "1.0.0",
+			License: nil,
+		}
+
+		document, err := generator.GenerateFromService(service)
+		assert.NoError(t, err, "Should generate document successfully")
+		assert.NotNil(t, document, "Document should not be nil")
+		assert.NotNil(t, document.Info, "Document Info should not be nil")
+		assert.Nil(t, document.Info.License, "Document Info License should be nil when not provided")
+
+		// Generate JSON to verify structure
+		jsonBytes, err := generator.ToJSON(document)
+		assert.NoError(t, err, "Should convert to JSON successfully")
+		jsonString := string(jsonBytes)
+
+		assert.NotContains(t, jsonString, "\"license\"", "JSON should not contain license field when not provided")
+	})
+
+	// Test with empty license name
+	t.Run("empty license name is not included", func(t *testing.T) {
+		generator := newGenerator()
+		service := &specification.Service{
+			Name:    "TestService",
+			Version: "1.0.0",
+			License: &specification.ServiceLicense{
+				Name:       "",
+				URL:        "https://example.com/license",
+				Identifier: "EXAMPLE",
+			},
+		}
+
+		document, err := generator.GenerateFromService(service)
+		assert.NoError(t, err, "Should generate document successfully")
+		assert.NotNil(t, document, "Document should not be nil")
+		assert.NotNil(t, document.Info, "Document Info should not be nil")
+		assert.Nil(t, document.Info.License, "Document Info License should be nil when name is empty")
+
+		// Generate JSON to verify structure
+		jsonBytes, err := generator.ToJSON(document)
+		assert.NoError(t, err, "Should convert to JSON successfully")
+		jsonString := string(jsonBytes)
+
+		assert.NotContains(t, jsonString, "\"license\"", "JSON should not contain license field when name is empty")
+	})
+}
+
 // TestParameterDescriptionNotDuplicated verifies that parameter descriptions are not duplicated in schema objects
 func TestParameterDescriptionNotDuplicated(t *testing.T) {
 	generator := newGenerator()

--- a/specification/specification.go
+++ b/specification/specification.go
@@ -355,6 +355,18 @@ type ServiceContact struct {
 	Email string `json:"email,omitempty"`
 }
 
+// ServiceLicense represents the license information for the API service.
+type ServiceLicense struct {
+	// Name of the license used for the API (required)
+	Name string `json:"name"`
+
+	// URL pointing to the license used for the API
+	URL string `json:"url,omitempty"`
+
+	// SPDX license identifier for the license used for the API
+	Identifier string `json:"identifier,omitempty"`
+}
+
 // RetryBackoffConfiguration defines the backoff behavior for retry attempts.
 type RetryBackoffConfiguration struct {
 	// InitialInterval is the initial interval between retries in milliseconds
@@ -401,6 +413,9 @@ type Service struct {
 
 	// Contact information for the service
 	Contact *ServiceContact `json:"contact,omitempty"`
+
+	// License information for the service
+	License *ServiceLicense `json:"license,omitempty"`
 
 	// Servers that are part of the service
 	Servers []ServiceServer `json:"servers,omitempty"`
@@ -586,6 +601,7 @@ func ApplyOverlay(input *Service) *Service {
 		Name:      input.Name,
 		Version:   input.Version,
 		Contact:   input.Contact,                               // Copy contact information
+		License:   input.License,                               // Copy license information
 		Servers:   append([]ServiceServer{}, input.Servers...), // Copy servers slice
 		Retry:     input.Retry,                                 // Copy retry configuration
 		Timeout:   input.Timeout,                               // Copy timeout configuration
@@ -1199,6 +1215,7 @@ func ApplyFilterOverlay(input *Service) *Service {
 		Name:      input.Name,
 		Version:   input.Version,
 		Contact:   input.Contact,                               // Copy contact information
+		License:   input.License,                               // Copy license information
 		Servers:   append([]ServiceServer{}, input.Servers...), // Copy servers slice
 		Retry:     input.Retry,                                 // Copy retry configuration
 		Timeout:   input.Timeout,                               // Copy timeout configuration

--- a/specification/specification_test.go
+++ b/specification/specification_test.go
@@ -303,6 +303,50 @@ func TestService(t *testing.T) {
 		assert.Equal(t, len(service.Objects), len(unmarshaledService.Objects))
 		assert.Equal(t, len(service.Resources), len(unmarshaledService.Resources))
 	})
+
+	t.Run("with license information", func(t *testing.T) {
+		service := Service{
+			Name:    "TestService",
+			Version: "1.0.0",
+			License: &ServiceLicense{
+				Name:       "MIT License",
+				URL:        "https://opensource.org/licenses/MIT",
+				Identifier: "MIT",
+			},
+		}
+
+		// Test JSON marshaling
+		jsonData, err := json.Marshal(service)
+		require.NoError(t, err)
+		assert.NotEmpty(t, jsonData)
+
+		// Test JSON unmarshaling
+		var unmarshaledService Service
+		err = json.Unmarshal(jsonData, &unmarshaledService)
+		require.NoError(t, err)
+		assert.Equal(t, service.Name, unmarshaledService.Name)
+		assert.Equal(t, service.Version, unmarshaledService.Version)
+		require.NotNil(t, unmarshaledService.License)
+		assert.Equal(t, service.License.Name, unmarshaledService.License.Name)
+		assert.Equal(t, service.License.URL, unmarshaledService.License.URL)
+		assert.Equal(t, service.License.Identifier, unmarshaledService.License.Identifier)
+
+		// Test YAML marshaling
+		yamlData, err := yaml.Marshal(service)
+		require.NoError(t, err)
+		assert.NotEmpty(t, yamlData)
+
+		// Test YAML unmarshaling
+		var unmarshaledYAMLService Service
+		err = yaml.Unmarshal(yamlData, &unmarshaledYAMLService)
+		require.NoError(t, err)
+		assert.Equal(t, service.Name, unmarshaledYAMLService.Name)
+		assert.Equal(t, service.Version, unmarshaledYAMLService.Version)
+		require.NotNil(t, unmarshaledYAMLService.License)
+		assert.Equal(t, service.License.Name, unmarshaledYAMLService.License.Name)
+		assert.Equal(t, service.License.URL, unmarshaledYAMLService.License.URL)
+		assert.Equal(t, service.License.Identifier, unmarshaledYAMLService.License.Identifier)
+	})
 }
 
 func TestService_IsObject(t *testing.T) {


### PR DESCRIPTION
Add license information to the API specification and ensure it is generated in the OpenAPI document to fulfill documentation requirements.

---
Linear Issue: [INF-288](https://linear.app/meitner-se/issue/INF-288/add-license-to-specification-and-generate-it-to-openapi-document)

<a href="https://cursor.com/background-agent?bcId=bc-6fec05af-1d99-417e-953b-81bbbad0f57c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6fec05af-1d99-417e-953b-81bbbad0f57c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

