### PR TITLE
Autogenerate response examples in openapi document

### DIFF
--- a/specification/openapi/openapi_test.go
+++ b/specification/openapi/openapi_test.go
@@ -1922,23 +1922,27 @@ func TestResponseBodyExamples(t *testing.T) {
 						Name:        "createdAt",
 						Description: "Timestamp when the resource was created",
 						Type:        specification.FieldTypeTimestamp,
+						Example:     "2024-01-15T10:30:00Z",
 					},
 					{
 						Name:        "createdBy",
 						Description: "User who created the resource",
 						Type:        specification.FieldTypeUUID,
 						Modifiers:   []string{specification.ModifierNullable},
+						Example:     "987fcdeb-51a2-43d1-b567-123456789abc",
 					},
 					{
 						Name:        "updatedAt",
 						Description: "Timestamp when the resource was last updated",
 						Type:        specification.FieldTypeTimestamp,
+						Example:     "2024-01-15T14:45:00Z",
 					},
 					{
 						Name:        "updatedBy",
 						Description: "User who last updated the resource",
 						Type:        specification.FieldTypeUUID,
 						Modifiers:   []string{specification.ModifierNullable},
+						Example:     "987fcdeb-51a2-43d1-b567-123456789abc",
 					},
 				},
 			},
@@ -1950,16 +1954,19 @@ func TestResponseBodyExamples(t *testing.T) {
 						Name:        "offset",
 						Description: "Number of items to skip from the beginning of the result set",
 						Type:        specification.FieldTypeInt,
+						Example:     "0",
 					},
 					{
 						Name:        "limit",
 						Description: "Maximum number of items to return in the result set",
 						Type:        specification.FieldTypeInt,
+						Example:     "1",
 					},
 					{
 						Name:        "total",
 						Description: "Total number of items available for pagination",
 						Type:        specification.FieldTypeInt,
+						Example:     "100",
 					},
 				},
 			},
@@ -2082,7 +2089,7 @@ func TestResponseBodyExamples(t *testing.T) {
 
 	// Verify pagination fields are present with default examples
 	assert.Contains(t, jsonString, "\"offset\": 0", "Should contain default pagination offset")
-	assert.Contains(t, jsonString, "\"limit\": 50", "Should contain default pagination limit")
+	assert.Contains(t, jsonString, "\"limit\": 1", "Should contain default pagination limit")
 	assert.Contains(t, jsonString, "\"total\": 100", "Should contain default pagination total")
 
 	// Verify meta object is nested within user objects

--- a/specification/specification.go
+++ b/specification/specification.go
@@ -751,16 +751,19 @@ func addDefaultEnumsAndObjects(result *Service, input *Service) {
 					Name:        offsetFieldName,
 					Description: offsetFieldDescription,
 					Type:        FieldTypeInt,
+					Example:     "0",
 				},
 				{
 					Name:        limitFieldName,
 					Description: limitFieldDescription,
 					Type:        FieldTypeInt,
+					Example:     "1",
 				},
 				{
 					Name:        totalFieldName,
 					Description: totalFieldDescription,
 					Type:        FieldTypeInt,
+					Example:     "100",
 				},
 			},
 		}
@@ -1762,6 +1765,7 @@ func createAutoColumnID(resourceName string) Field {
 		Name:        autoColumnIDName,
 		Description: fmt.Sprintf(autoColumnIDDescTemplate, resourceName),
 		Type:        FieldTypeUUID,
+		Example:     "123e4567-e89b-12d3-a456-426614174000",
 	}
 }
 
@@ -1771,6 +1775,7 @@ func createAutoColumnCreatedAt(resourceName string) Field {
 		Name:        autoColumnCreatedAtName,
 		Description: fmt.Sprintf(autoColumnCreatedAtTemplate, resourceName),
 		Type:        FieldTypeTimestamp,
+		Example:     "2024-01-15T10:30:00Z",
 	}
 }
 
@@ -1781,6 +1786,7 @@ func createAutoColumnCreatedBy(resourceName string) Field {
 		Description: fmt.Sprintf(autoColumnCreatedByTemplate, resourceName),
 		Type:        FieldTypeUUID,
 		Modifiers:   []string{ModifierNullable},
+		Example:     "987fcdeb-51a2-43d1-b567-123456789abc",
 	}
 }
 
@@ -1790,6 +1796,7 @@ func createAutoColumnUpdatedAt(resourceName string) Field {
 		Name:        autoColumnUpdatedAtName,
 		Description: fmt.Sprintf(autoColumnUpdatedAtTemplate, resourceName),
 		Type:        FieldTypeTimestamp,
+		Example:     "2024-01-15T14:45:00Z",
 	}
 }
 
@@ -1800,6 +1807,7 @@ func createAutoColumnUpdatedBy(resourceName string) Field {
 		Description: fmt.Sprintf(autoColumnUpdatedByTemplate, resourceName),
 		Type:        FieldTypeUUID,
 		Modifiers:   []string{ModifierNullable},
+		Example:     "987fcdeb-51a2-43d1-b567-123456789abc",
 	}
 }
 
@@ -1824,23 +1832,27 @@ func createDefaultMeta() Object {
 				Name:        autoColumnCreatedAtName,
 				Description: "Timestamp when the resource was created",
 				Type:        FieldTypeTimestamp,
+				Example:     "2024-01-15T10:30:00Z",
 			},
 			{
 				Name:        autoColumnCreatedByName,
 				Description: "User who created the resource",
 				Type:        FieldTypeUUID,
 				Modifiers:   []string{ModifierNullable},
+				Example:     "987fcdeb-51a2-43d1-b567-123456789abc",
 			},
 			{
 				Name:        autoColumnUpdatedAtName,
 				Description: "Timestamp when the resource was last updated",
 				Type:        FieldTypeTimestamp,
+				Example:     "2024-01-15T14:45:00Z",
 			},
 			{
 				Name:        autoColumnUpdatedByName,
 				Description: "User who last updated the resource",
 				Type:        FieldTypeUUID,
 				Modifiers:   []string{ModifierNullable},
+				Example:     "987fcdeb-51a2-43d1-b567-123456789abc",
 			},
 		},
 	}

--- a/specification/specification_test.go
+++ b/specification/specification_test.go
@@ -1141,7 +1141,7 @@ func TestCreateAutoColumnID(t *testing.T) {
 	assert.Equal(t, FieldTypeUUID, idField.Type, "Auto-column ID should have UUID type")
 	assert.Empty(t, idField.Modifiers, "Auto-column ID should have no modifiers")
 	assert.Empty(t, idField.Default, "Auto-column ID should have no default value")
-	assert.Empty(t, idField.Example, "Auto-column ID should have no example")
+	assert.Equal(t, "123e4567-e89b-12d3-a456-426614174000", idField.Example, "Auto-column ID should have example UUID")
 
 	t.Run("consistency", func(t *testing.T) {
 		id1 := createAutoColumnID(resourceName)
@@ -1165,7 +1165,7 @@ func TestCreateAutoColumnCreatedAt(t *testing.T) {
 	assert.Equal(t, FieldTypeTimestamp, createdAtField.Type, "Auto-column CreatedAt should have Timestamp type")
 	assert.Empty(t, createdAtField.Modifiers, "Auto-column CreatedAt should have no modifiers")
 	assert.Empty(t, createdAtField.Default, "Auto-column CreatedAt should have no default value")
-	assert.Empty(t, createdAtField.Example, "Auto-column CreatedAt should have no example")
+	assert.Equal(t, "2024-01-15T10:30:00Z", createdAtField.Example, "Auto-column CreatedAt should have example timestamp")
 
 	t.Run("consistency", func(t *testing.T) {
 		createdAt1 := createAutoColumnCreatedAt(resourceName)
@@ -1189,7 +1189,7 @@ func TestCreateAutoColumnCreatedBy(t *testing.T) {
 	assert.Equal(t, FieldTypeUUID, createdByField.Type, "Auto-column CreatedBy should have UUID type")
 	assert.Equal(t, []string{ModifierNullable}, createdByField.Modifiers, "Auto-column CreatedBy should have nullable modifier")
 	assert.Empty(t, createdByField.Default, "Auto-column CreatedBy should have no default value")
-	assert.Empty(t, createdByField.Example, "Auto-column CreatedBy should have no example")
+	assert.Equal(t, "987fcdeb-51a2-43d1-b567-123456789abc", createdByField.Example, "Auto-column CreatedBy should have example UUID")
 
 	t.Run("consistency", func(t *testing.T) {
 		createdBy1 := createAutoColumnCreatedBy(resourceName)
@@ -1213,7 +1213,7 @@ func TestCreateAutoColumnUpdatedAt(t *testing.T) {
 	assert.Equal(t, FieldTypeTimestamp, updatedAtField.Type, "Auto-column UpdatedAt should have Timestamp type")
 	assert.Empty(t, updatedAtField.Modifiers, "Auto-column UpdatedAt should have no modifiers")
 	assert.Empty(t, updatedAtField.Default, "Auto-column UpdatedAt should have no default value")
-	assert.Empty(t, updatedAtField.Example, "Auto-column UpdatedAt should have no example")
+	assert.Equal(t, "2024-01-15T14:45:00Z", updatedAtField.Example, "Auto-column UpdatedAt should have example timestamp")
 
 	t.Run("consistency", func(t *testing.T) {
 		updatedAt1 := createAutoColumnUpdatedAt(resourceName)
@@ -1237,7 +1237,7 @@ func TestCreateAutoColumnUpdatedBy(t *testing.T) {
 	assert.Equal(t, FieldTypeUUID, updatedByField.Type, "Auto-column UpdatedBy should have UUID type")
 	assert.Equal(t, []string{ModifierNullable}, updatedByField.Modifiers, "Auto-column UpdatedBy should have nullable modifier")
 	assert.Empty(t, updatedByField.Default, "Auto-column UpdatedBy should have no default value")
-	assert.Empty(t, updatedByField.Example, "Auto-column UpdatedBy should have no example")
+	assert.Equal(t, "987fcdeb-51a2-43d1-b567-123456789abc", updatedByField.Example, "Auto-column UpdatedBy should have example UUID")
 
 	t.Run("consistency", func(t *testing.T) {
 		updatedBy1 := createAutoColumnUpdatedBy(resourceName)

--- a/testdata/school-management-api-expected.json
+++ b/testdata/school-management-api-expected.json
@@ -785,14 +785,23 @@
         "properties": {
           "offset": {
             "type": "integer",
+            "examples": [
+              0
+            ],
             "description": "Number of items to skip from the beginning of the result set"
           },
           "limit": {
             "type": "integer",
+            "examples": [
+              1
+            ],
             "description": "Maximum number of items to return in the result set"
           },
           "total": {
             "type": "integer",
+            "examples": [
+              100
+            ],
             "description": "Total number of items available for pagination"
           }
         },
@@ -808,22 +817,34 @@
         "properties": {
           "createdAt": {
             "type": "string",
+            "examples": [
+              "2024-01-15T10:30:00Z"
+            ],
             "format": "date-time",
             "description": "Timestamp when the resource was created"
           },
           "createdBy": {
             "type": "string",
+            "examples": [
+              "987fcdeb-51a2-43d1-b567-123456789abc"
+            ],
             "format": "uuid",
             "description": "User who created the resource",
             "nullable": true
           },
           "updatedAt": {
             "type": "string",
+            "examples": [
+              "2024-01-15T14:45:00Z"
+            ],
             "format": "date-time",
             "description": "Timestamp when the resource was last updated"
           },
           "updatedBy": {
             "type": "string",
+            "examples": [
+              "987fcdeb-51a2-43d1-b567-123456789abc"
+            ],
             "format": "uuid",
             "description": "User who last updated the resource",
             "nullable": true
@@ -2020,13 +2041,6 @@
                   "description": "List of import error messages"
                 }
               }
-            },
-            "example": {
-              "imported": 42,
-              "failed": 42,
-              "errors": [
-                "example value"
-              ]
             }
           }
         }
@@ -2084,11 +2098,6 @@
                   "nullable": true
                 }
               }
-            },
-            "example": {
-              "reportId": "123e4567-e89b-12d3-a456-426614174000",
-              "estimatedCompletionTime": "2024-01-15T10:30:00Z",
-              "downloadUrl": "example value"
             }
           }
         }
@@ -2150,19 +2159,6 @@
                   "description": "Search facets and counts"
                 }
               }
-            },
-            "example": {
-              "students": [
-                {
-                  "firstName": "example value",
-                  "lastName": "example value",
-                  "studentId": "example value",
-                  "status": "example",
-                  "gradeLevel": "example"
-                }
-              ],
-              "totalCount": 42,
-              "facets": "example value"
             }
           }
         }
@@ -2215,24 +2211,7 @@
                 "createdBy": "987fcdeb-51a2-43d1-b567-123456789abc",
                 "updatedAt": "2024-01-15T14:45:00Z",
                 "updatedBy": "987fcdeb-51a2-43d1-b567-123456789abc"
-              },
-              "firstName": "example value",
-              "lastName": "example value",
-              "studentId": "example value",
-              "status": "example",
-              "gradeLevel": "example",
-              "contact": {
-                "email": "example value",
-                "phone": "example value"
-              },
-              "address": {
-                "street": "example value",
-                "city": "example value",
-                "state": "example value",
-                "zipCode": "example value"
-              },
-              "enrollmentDate": "2024-01-15",
-              "graduationDate": "2024-01-15"
+              }
             }
           }
         }
@@ -2285,24 +2264,7 @@
                 "createdBy": "987fcdeb-51a2-43d1-b567-123456789abc",
                 "updatedAt": "2024-01-15T14:45:00Z",
                 "updatedBy": "987fcdeb-51a2-43d1-b567-123456789abc"
-              },
-              "firstName": "example value",
-              "lastName": "example value",
-              "studentId": "example value",
-              "status": "example",
-              "gradeLevel": "example",
-              "contact": {
-                "email": "example value",
-                "phone": "example value"
-              },
-              "address": {
-                "street": "example value",
-                "city": "example value",
-                "state": "example value",
-                "zipCode": "example value"
-              },
-              "enrollmentDate": "2024-01-15",
-              "graduationDate": "2024-01-15"
+              }
             }
           }
         }
@@ -2355,24 +2317,7 @@
                 "createdBy": "987fcdeb-51a2-43d1-b567-123456789abc",
                 "updatedAt": "2024-01-15T14:45:00Z",
                 "updatedBy": "987fcdeb-51a2-43d1-b567-123456789abc"
-              },
-              "firstName": "example value",
-              "lastName": "example value",
-              "studentId": "example value",
-              "status": "example",
-              "gradeLevel": "example",
-              "contact": {
-                "email": "example value",
-                "phone": "example value"
-              },
-              "address": {
-                "street": "example value",
-                "city": "example value",
-                "state": "example value",
-                "zipCode": "example value"
-              },
-              "enrollmentDate": "2024-01-15",
-              "graduationDate": "2024-01-15"
+              }
             }
           }
         }
@@ -2414,29 +2359,12 @@
                     "createdBy": "987fcdeb-51a2-43d1-b567-123456789abc",
                     "updatedAt": "2024-01-15T14:45:00Z",
                     "updatedBy": "987fcdeb-51a2-43d1-b567-123456789abc"
-                  },
-                  "firstName": "example value",
-                  "lastName": "example value",
-                  "studentId": "example value",
-                  "status": "example",
-                  "gradeLevel": "example",
-                  "contact": {
-                    "email": "example value",
-                    "phone": "example value"
-                  },
-                  "address": {
-                    "street": "example value",
-                    "city": "example value",
-                    "state": "example value",
-                    "zipCode": "example value"
-                  },
-                  "enrollmentDate": "2024-01-15",
-                  "graduationDate": "2024-01-15"
+                  }
                 }
               ],
               "pagination": {
                 "offset": 0,
-                "limit": 50,
+                "limit": 1,
                 "total": 100
               }
             }
@@ -2480,29 +2408,12 @@
                     "createdBy": "987fcdeb-51a2-43d1-b567-123456789abc",
                     "updatedAt": "2024-01-15T14:45:00Z",
                     "updatedBy": "987fcdeb-51a2-43d1-b567-123456789abc"
-                  },
-                  "firstName": "example value",
-                  "lastName": "example value",
-                  "studentId": "example value",
-                  "status": "example",
-                  "gradeLevel": "example",
-                  "contact": {
-                    "email": "example value",
-                    "phone": "example value"
-                  },
-                  "address": {
-                    "street": "example value",
-                    "city": "example value",
-                    "state": "example value",
-                    "zipCode": "example value"
-                  },
-                  "enrollmentDate": "2024-01-15",
-                  "graduationDate": "2024-01-15"
+                  }
                 }
               ],
               "pagination": {
                 "offset": 0,
-                "limit": 50,
+                "limit": 1,
                 "total": 100
               }
             }
@@ -2719,18 +2630,6 @@
                   "default": false
                 }
               }
-            },
-            "example": {
-              "students": [
-                {
-                  "firstName": "example value",
-                  "lastName": "example value",
-                  "studentId": "example value",
-                  "status": "example",
-                  "gradeLevel": "example"
-                }
-              ],
-              "overwriteExisting": true
             }
           }
         },
@@ -2779,13 +2678,6 @@
                   "default": false
                 }
               }
-            },
-            "example": {
-              "gradeLevel": "example",
-              "status": "example",
-              "enrollmentDateFrom": "2024-01-15",
-              "enrollmentDateTo": "2024-01-15",
-              "includeInactive": true
             }
           }
         },
@@ -2842,19 +2734,6 @@
                   "nullable": true
                 }
               }
-            },
-            "example": {
-              "nameQuery": "example value",
-              "gradeLevel": [
-                "example"
-              ],
-              "status": [
-                "example"
-              ],
-              "enrollmentDateRange": [
-                "2024-01-15"
-              ],
-              "hasGraduationDate": true
             }
           }
         },
@@ -2926,24 +2805,6 @@
                 "gradeLevel",
                 "enrollmentDate"
               ]
-            },
-            "example": {
-              "firstName": "example value",
-              "lastName": "example value",
-              "studentId": "example value",
-              "status": "example",
-              "gradeLevel": "example",
-              "contact": {
-                "email": "example value",
-                "phone": "example value"
-              },
-              "address": {
-                "street": "example value",
-                "city": "example value",
-                "state": "example value",
-                "zipCode": "example value"
-              },
-              "enrollmentDate": "2024-01-15"
             }
           }
         },
@@ -3010,23 +2871,6 @@
                 "lastName",
                 "gradeLevel"
               ]
-            },
-            "example": {
-              "firstName": "example value",
-              "lastName": "example value",
-              "status": "example",
-              "gradeLevel": "example",
-              "contact": {
-                "email": "example value",
-                "phone": "example value"
-              },
-              "address": {
-                "street": "example value",
-                "city": "example value",
-                "state": "example value",
-                "zipCode": "example value"
-              },
-              "graduationDate": "2024-01-15"
             }
           }
         },


### PR DESCRIPTION
Add automatic generation of response body examples to the OpenAPI document to improve API documentation.

---
Linear Issue: [INF-272](https://linear.app/meitner-se/issue/INF-272/autogenerate-response-examples-in-openapi-document)

<a href="https://cursor.com/background-agent?bcId=bc-2232b77f-5c9b-419f-a06a-d366f1ca2c54">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2232b77f-5c9b-419f-a06a-d366f1ca2c54">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

