### PR TITLE
Update openapi pagination configuration

### DIFF
--- a/specification/openapi/openapi_test.go
+++ b/specification/openapi/openapi_test.go
@@ -1045,11 +1045,15 @@ func TestSpeakeasyPaginationExtension(t *testing.T) {
 
 	// Verify that the Speakeasy pagination extension is present in paginated operations
 	assert.Contains(t, jsonString, "\"x-speakeasy-pagination\"", "Should contain x-speakeasy-pagination extension")
-	assert.Contains(t, jsonString, "\"strategy\": \"offsetLimit\"", "Should contain offsetLimit strategy")
-	assert.Contains(t, jsonString, "\"offsetParam\": \"offset\"", "Should contain offset parameter name")
-	assert.Contains(t, jsonString, "\"limitParam\": \"limit\"", "Should contain limit parameter name")
-	assert.Contains(t, jsonString, "\"totalField\": \"pagination.total\"", "Should contain total field path")
-	assert.Contains(t, jsonString, "\"dataField\": \"data\"", "Should contain data field name")
+	assert.Contains(t, jsonString, "\"type\": \"offsetLimit\"", "Should contain offsetLimit type")
+	assert.Contains(t, jsonString, "\"inputs\":", "Should contain inputs array")
+	assert.Contains(t, jsonString, "\"name\": \"offset\"", "Should contain offset input name")
+	assert.Contains(t, jsonString, "\"name\": \"limit\"", "Should contain limit input name")
+	assert.Contains(t, jsonString, "\"in\": \"parameters\"", "Should contain parameters location")
+	assert.Contains(t, jsonString, "\"type\": \"offset\"", "Should contain offset input type")
+	assert.Contains(t, jsonString, "\"type\": \"limit\"", "Should contain limit input type")
+	assert.Contains(t, jsonString, "\"outputs\":", "Should contain outputs object")
+	assert.Contains(t, jsonString, "\"results\": \"$.data.resultArray\"", "Should contain results field path")
 
 	// Count the occurrences of the pagination extension - should appear twice (List and Search operations)
 	paginationExtensionCount := countSubstring(jsonString, "\"x-speakeasy-pagination\"")

--- a/testdata/school-management-api-expected.json
+++ b/testdata/school-management-api-expected.json
@@ -296,11 +296,22 @@
           }
         },
         "x-speakeasy-pagination": {
-          "strategy": "offsetLimit",
-          "offsetParam": "offset",
-          "limitParam": "limit",
-          "totalField": "pagination.total",
-          "dataField": "data"
+          "type": "offsetLimit",
+          "inputs": [
+            {
+              "name": "offset",
+              "in": "parameters",
+              "type": "offset"
+            },
+            {
+              "name": "limit",
+              "in": "parameters",
+              "type": "limit"
+            }
+          ],
+          "outputs": {
+            "results": "$.data.resultArray"
+          }
         }
       },
       "post": {
@@ -596,11 +607,22 @@
           }
         },
         "x-speakeasy-pagination": {
-          "strategy": "offsetLimit",
-          "offsetParam": "offset",
-          "limitParam": "limit",
-          "totalField": "pagination.total",
-          "dataField": "data"
+          "type": "offsetLimit",
+          "inputs": [
+            {
+              "name": "offset",
+              "in": "parameters",
+              "type": "offset"
+            },
+            {
+              "name": "limit",
+              "in": "parameters",
+              "type": "limit"
+            }
+          ],
+          "outputs": {
+            "results": "$.data.resultArray"
+          }
         }
       }
     }


### PR DESCRIPTION
Update the `x-speakeasy-pagination` OpenAPI extension format to align with the new required pagination metadata structure.

---
Linear Issue: [INF-297](https://linear.app/meitner-se/issue/INF-297/fix-pagination-when-generating-openapi-doc)

<a href="https://cursor.com/background-agent?bcId=bc-61ce5eea-8c26-4361-8162-a9a21c56be38">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-61ce5eea-8c26-4361-8162-a9a21c56be38">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

