### PR TITLE
Update openapi spec for sdk naming

### DIFF
--- a/specification/openapi/openapi.go
+++ b/specification/openapi/openapi.go
@@ -390,16 +390,16 @@ func (g *Generator) addSpeakeasyOperationNamingExtensions(operation *v3.Operatio
 		operation.Extensions = orderedmap.New[string, *yaml.Node]()
 	}
 
-	// Add x-speakeasy-group extension (resource name in lowercase and plural)
-	groupValue := strings.ToLower(resource.GetPluralName())
+	// Add x-speakeasy-group extension (resource name in camelCase and plural)
+	groupValue := specification.CamelCase(resource.GetPluralName())
 	groupNode := &yaml.Node{
 		Kind:  yaml.ScalarNode,
 		Value: groupValue,
 	}
 	operation.Extensions.Set(speakeasyGroupExtension, groupNode)
 
-	// Add x-speakeasy-name-override extension (method name in lowercase)
-	nameOverrideValue := strings.ToLower(endpoint.Name)
+	// Add x-speakeasy-name-override extension (method name in camelCase)
+	nameOverrideValue := specification.CamelCase(endpoint.Name)
 	nameOverrideNode := &yaml.Node{
 		Kind:  yaml.ScalarNode,
 		Value: nameOverrideValue,

--- a/specification/specification.go
+++ b/specification/specification.go
@@ -1469,7 +1469,7 @@ func (t Field) IsNullable() bool {
 
 // TagJSON returns the JSON tag name for the field in camelCase.
 func (t Field) TagJSON() string {
-	return camelCase(t.Name)
+	return CamelCase(t.Name)
 }
 
 // GetComment returns a formatted comment for the field.
@@ -1895,11 +1895,11 @@ func getComment(tabs string, description string, name string) string {
 	return comment
 }
 
-// camelCase converts a string to camelCase format.
+// CamelCase converts a string to camelCase format.
 // Special cases:
 // - "ID" becomes "id" instead of "iD"
 // - Consecutive capital letters at the start are lowercased (e.g., "CSNSchoolCode" -> "csnSchoolCode")
-func camelCase(s string) string {
+func CamelCase(s string) string {
 	if s == "ID" {
 		return "id"
 	}

--- a/specification/specification_test.go
+++ b/specification/specification_test.go
@@ -1388,7 +1388,7 @@ func TestCamelCase(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.input, func(t *testing.T) {
-			result := camelCase(tc.input)
+			result := CamelCase(tc.input)
 			assert.Equal(t, tc.expected, result, "CamelCase conversion for '%s' should be '%s'", tc.input, tc.expected)
 		})
 	}
@@ -1410,7 +1410,7 @@ func TestCamelCase(t *testing.T) {
 
 		for _, tc := range edgeCases {
 			t.Run("camelCase_"+tc.input, func(t *testing.T) {
-				result := camelCase(tc.input)
+				result := CamelCase(tc.input)
 				assert.Equal(t, tc.expected, result, "CamelCase of '%s' should be '%s'", tc.input, tc.expected)
 			})
 		}

--- a/testdata/school-management-api-expected.json
+++ b/testdata/school-management-api-expected.json
@@ -18,6 +18,99 @@
     }
   ],
   "paths": {
+    "/students/_search": {
+      "post": {
+        "tags": [
+          "Students"
+        ],
+        "summary": "Search Students",
+        "description": "Search for `Students` with filtering capabilities.",
+        "operationId": "StudentsSearch",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "The maximum number of Students to return (default: 50) when searching Students",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 50
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "description": "The number of Students to skip before starting to return results (default: 0) when searching Students",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 0
+            }
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/StudentsSearch"
+        },
+        "responses": {
+          "200": {
+            "description": "Response for Students Search operation - returns filtered Students results",
+            "$ref": "#/components/responses/StudentsSearch"
+          },
+          "400": {
+            "description": "Bad Request error for Students Search operation - request contains invalid parameters",
+            "$ref": "#/components/responses/Error400ResponseBody"
+          },
+          "401": {
+            "description": "Unauthorized error for Students Search operation - authentication required",
+            "$ref": "#/components/responses/Error401ResponseBody"
+          },
+          "403": {
+            "description": "Forbidden error for Students Search operation - insufficient permissions",
+            "$ref": "#/components/responses/Error403ResponseBody"
+          },
+          "404": {
+            "description": "Not Found error for Students Search operation - resource does not exist",
+            "$ref": "#/components/responses/Error404ResponseBody"
+          },
+          "409": {
+            "description": "Conflict error for Students Search operation - request conflicts with current state",
+            "$ref": "#/components/responses/Error409ResponseBody"
+          },
+          "422": {
+            "description": "Validation error for Students Search operation - request data failed validation",
+            "$ref": "#/components/responses/StudentsSearch422ResponseBody"
+          },
+          "429": {
+            "description": "Rate Limit error for Students Search operation - too many requests",
+            "$ref": "#/components/responses/Error429ResponseBody"
+          },
+          "500": {
+            "description": "Internal Server error for Students Search operation - unexpected server error",
+            "$ref": "#/components/responses/Error500ResponseBody"
+          }
+        },
+        "x-speakeasy-pagination": {
+          "type": "offsetLimit",
+          "inputs": [
+            {
+              "name": "offset",
+              "in": "parameters",
+              "type": "offset"
+            },
+            {
+              "name": "limit",
+              "in": "parameters",
+              "type": "limit"
+            }
+          ],
+          "outputs": {
+            "results": "$.data.resultArray"
+          }
+        },
+        "x-speakeasy-group": "students",
+        "x-speakeasy-name-override": "search"
+      }
+    },
     "/students/bulk-import": {
       "post": {
         "tags": [
@@ -78,7 +171,9 @@
             "description": "Internal Server error for Students BulkImport operation - unexpected server error",
             "$ref": "#/components/responses/Error500ResponseBody"
           }
-        }
+        },
+        "x-speakeasy-group": "students",
+        "x-speakeasy-name-override": "bulkimport"
       }
     },
     "/students/reports/generate": {
@@ -141,7 +236,9 @@
             "description": "Internal Server error for Students GenerateReport operation - unexpected server error",
             "$ref": "#/components/responses/Error500ResponseBody"
           }
-        }
+        },
+        "x-speakeasy-group": "students",
+        "x-speakeasy-name-override": "generatereport"
       }
     },
     "/students/advanced-search": {
@@ -234,7 +331,9 @@
             "description": "Internal Server error for Students AdvancedSearch operation - unexpected server error",
             "$ref": "#/components/responses/Error500ResponseBody"
           }
-        }
+        },
+        "x-speakeasy-group": "students",
+        "x-speakeasy-name-override": "advancedsearch"
       }
     },
     "/students": {
@@ -318,7 +417,9 @@
           "outputs": {
             "results": "$.data.resultArray"
           }
-        }
+        },
+        "x-speakeasy-group": "students",
+        "x-speakeasy-name-override": "list"
       },
       "post": {
         "tags": [
@@ -368,7 +469,9 @@
             "description": "Internal Server error for Students Create operation - unexpected server error",
             "$ref": "#/components/responses/Error500ResponseBody"
           }
-        }
+        },
+        "x-speakeasy-group": "students",
+        "x-speakeasy-name-override": "create"
       }
     },
     "/students/{id}": {
@@ -424,7 +527,9 @@
             "description": "Internal Server error for Students Get operation - unexpected server error",
             "$ref": "#/components/responses/Error500ResponseBody"
           }
-        }
+        },
+        "x-speakeasy-group": "students",
+        "x-speakeasy-name-override": "get"
       },
       "delete": {
         "tags": [
@@ -477,7 +582,9 @@
             "description": "Internal Server error for Students Delete operation - unexpected server error",
             "$ref": "#/components/responses/Error500ResponseBody"
           }
-        }
+        },
+        "x-speakeasy-group": "students",
+        "x-speakeasy-name-override": "delete"
       },
       "patch": {
         "tags": [
@@ -538,98 +645,9 @@
             "description": "Internal Server error for Students Update operation - unexpected server error",
             "$ref": "#/components/responses/Error500ResponseBody"
           }
-        }
-      }
-    },
-    "/students/_search": {
-      "post": {
-        "tags": [
-          "Students"
-        ],
-        "summary": "Search Students",
-        "description": "Search for `Students` with filtering capabilities.",
-        "operationId": "StudentsSearch",
-        "parameters": [
-          {
-            "name": "limit",
-            "in": "query",
-            "description": "The maximum number of Students to return (default: 50) when searching Students",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 50
-            }
-          },
-          {
-            "name": "offset",
-            "in": "query",
-            "description": "The number of Students to skip before starting to return results (default: 0) when searching Students",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 0
-            }
-          }
-        ],
-        "requestBody": {
-          "$ref": "#/components/requestBodies/StudentsSearch"
         },
-        "responses": {
-          "200": {
-            "description": "Response for Students Search operation - returns filtered Students results",
-            "$ref": "#/components/responses/StudentsSearch"
-          },
-          "400": {
-            "description": "Bad Request error for Students Search operation - request contains invalid parameters",
-            "$ref": "#/components/responses/Error400ResponseBody"
-          },
-          "401": {
-            "description": "Unauthorized error for Students Search operation - authentication required",
-            "$ref": "#/components/responses/Error401ResponseBody"
-          },
-          "403": {
-            "description": "Forbidden error for Students Search operation - insufficient permissions",
-            "$ref": "#/components/responses/Error403ResponseBody"
-          },
-          "404": {
-            "description": "Not Found error for Students Search operation - resource does not exist",
-            "$ref": "#/components/responses/Error404ResponseBody"
-          },
-          "409": {
-            "description": "Conflict error for Students Search operation - request conflicts with current state",
-            "$ref": "#/components/responses/Error409ResponseBody"
-          },
-          "422": {
-            "description": "Validation error for Students Search operation - request data failed validation",
-            "$ref": "#/components/responses/StudentsSearch422ResponseBody"
-          },
-          "429": {
-            "description": "Rate Limit error for Students Search operation - too many requests",
-            "$ref": "#/components/responses/Error429ResponseBody"
-          },
-          "500": {
-            "description": "Internal Server error for Students Search operation - unexpected server error",
-            "$ref": "#/components/responses/Error500ResponseBody"
-          }
-        },
-        "x-speakeasy-pagination": {
-          "type": "offsetLimit",
-          "inputs": [
-            {
-              "name": "offset",
-              "in": "parameters",
-              "type": "offset"
-            },
-            {
-              "name": "limit",
-              "in": "parameters",
-              "type": "limit"
-            }
-          ],
-          "outputs": {
-            "results": "$.data.resultArray"
-          }
-        }
+        "x-speakeasy-group": "students",
+        "x-speakeasy-name-override": "update"
       }
     }
   },
@@ -969,29 +987,47 @@
         ],
         "description": "Student management resource"
       },
-      "ContactRequestError": {
+      "AddressRequestError": {
         "type": "object",
         "properties": {
-          "email": {
+          "street": {
             "allOf": [
               {
                 "$ref": "#/components/schemas/ErrorField"
               }
             ],
-            "description": "Email address",
+            "description": "Street address",
             "nullable": true
           },
-          "phone": {
+          "city": {
             "allOf": [
               {
                 "$ref": "#/components/schemas/ErrorField"
               }
             ],
-            "description": "Phone number",
+            "description": "City",
+            "nullable": true
+          },
+          "state": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
+            "description": "State or province",
+            "nullable": true
+          },
+          "zipCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
+            "description": "ZIP or postal code",
             "nullable": true
           }
         },
-        "description": "Request error object for Contact"
+        "description": "Request error object for Address"
       },
       "StudentRequestError": {
         "type": "object",
@@ -1044,47 +1080,29 @@
         },
         "description": "Request error object for Student"
       },
-      "AddressRequestError": {
+      "ContactRequestError": {
         "type": "object",
         "properties": {
-          "street": {
+          "email": {
             "allOf": [
               {
                 "$ref": "#/components/schemas/ErrorField"
               }
             ],
-            "description": "Street address",
+            "description": "Email address",
             "nullable": true
           },
-          "city": {
+          "phone": {
             "allOf": [
               {
                 "$ref": "#/components/schemas/ErrorField"
               }
             ],
-            "description": "City",
-            "nullable": true
-          },
-          "state": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ErrorField"
-              }
-            ],
-            "description": "State or province",
-            "nullable": true
-          },
-          "zipCode": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ErrorField"
-              }
-            ],
-            "description": "ZIP or postal code",
+            "description": "Phone number",
             "nullable": true
           }
         },
-        "description": "Request error object for Address"
+        "description": "Request error object for Contact"
       },
       "StudentsBulkImportRequestError": {
         "type": "object",

--- a/testdata/school-management-api-expected.json
+++ b/testdata/school-management-api-expected.json
@@ -18,99 +18,6 @@
     }
   ],
   "paths": {
-    "/students/_search": {
-      "post": {
-        "tags": [
-          "Students"
-        ],
-        "summary": "Search Students",
-        "description": "Search for `Students` with filtering capabilities.",
-        "operationId": "StudentsSearch",
-        "parameters": [
-          {
-            "name": "limit",
-            "in": "query",
-            "description": "The maximum number of Students to return (default: 50) when searching Students",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 50
-            }
-          },
-          {
-            "name": "offset",
-            "in": "query",
-            "description": "The number of Students to skip before starting to return results (default: 0) when searching Students",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 0
-            }
-          }
-        ],
-        "requestBody": {
-          "$ref": "#/components/requestBodies/StudentsSearch"
-        },
-        "responses": {
-          "200": {
-            "description": "Response for Students Search operation - returns filtered Students results",
-            "$ref": "#/components/responses/StudentsSearch"
-          },
-          "400": {
-            "description": "Bad Request error for Students Search operation - request contains invalid parameters",
-            "$ref": "#/components/responses/Error400ResponseBody"
-          },
-          "401": {
-            "description": "Unauthorized error for Students Search operation - authentication required",
-            "$ref": "#/components/responses/Error401ResponseBody"
-          },
-          "403": {
-            "description": "Forbidden error for Students Search operation - insufficient permissions",
-            "$ref": "#/components/responses/Error403ResponseBody"
-          },
-          "404": {
-            "description": "Not Found error for Students Search operation - resource does not exist",
-            "$ref": "#/components/responses/Error404ResponseBody"
-          },
-          "409": {
-            "description": "Conflict error for Students Search operation - request conflicts with current state",
-            "$ref": "#/components/responses/Error409ResponseBody"
-          },
-          "422": {
-            "description": "Validation error for Students Search operation - request data failed validation",
-            "$ref": "#/components/responses/StudentsSearch422ResponseBody"
-          },
-          "429": {
-            "description": "Rate Limit error for Students Search operation - too many requests",
-            "$ref": "#/components/responses/Error429ResponseBody"
-          },
-          "500": {
-            "description": "Internal Server error for Students Search operation - unexpected server error",
-            "$ref": "#/components/responses/Error500ResponseBody"
-          }
-        },
-        "x-speakeasy-pagination": {
-          "type": "offsetLimit",
-          "inputs": [
-            {
-              "name": "offset",
-              "in": "parameters",
-              "type": "offset"
-            },
-            {
-              "name": "limit",
-              "in": "parameters",
-              "type": "limit"
-            }
-          ],
-          "outputs": {
-            "results": "$.data.resultArray"
-          }
-        },
-        "x-speakeasy-group": "students",
-        "x-speakeasy-name-override": "search"
-      }
-    },
     "/students/bulk-import": {
       "post": {
         "tags": [
@@ -173,7 +80,7 @@
           }
         },
         "x-speakeasy-group": "students",
-        "x-speakeasy-name-override": "bulkimport"
+        "x-speakeasy-name-override": "bulkImport"
       }
     },
     "/students/reports/generate": {
@@ -238,7 +145,7 @@
           }
         },
         "x-speakeasy-group": "students",
-        "x-speakeasy-name-override": "generatereport"
+        "x-speakeasy-name-override": "generateReport"
       }
     },
     "/students/advanced-search": {
@@ -333,7 +240,7 @@
           }
         },
         "x-speakeasy-group": "students",
-        "x-speakeasy-name-override": "advancedsearch"
+        "x-speakeasy-name-override": "advancedSearch"
       }
     },
     "/students": {
@@ -648,6 +555,99 @@
         },
         "x-speakeasy-group": "students",
         "x-speakeasy-name-override": "update"
+      }
+    },
+    "/students/_search": {
+      "post": {
+        "tags": [
+          "Students"
+        ],
+        "summary": "Search Students",
+        "description": "Search for `Students` with filtering capabilities.",
+        "operationId": "StudentsSearch",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "The maximum number of Students to return (default: 50) when searching Students",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 50
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "description": "The number of Students to skip before starting to return results (default: 0) when searching Students",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 0
+            }
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/StudentsSearch"
+        },
+        "responses": {
+          "200": {
+            "description": "Response for Students Search operation - returns filtered Students results",
+            "$ref": "#/components/responses/StudentsSearch"
+          },
+          "400": {
+            "description": "Bad Request error for Students Search operation - request contains invalid parameters",
+            "$ref": "#/components/responses/Error400ResponseBody"
+          },
+          "401": {
+            "description": "Unauthorized error for Students Search operation - authentication required",
+            "$ref": "#/components/responses/Error401ResponseBody"
+          },
+          "403": {
+            "description": "Forbidden error for Students Search operation - insufficient permissions",
+            "$ref": "#/components/responses/Error403ResponseBody"
+          },
+          "404": {
+            "description": "Not Found error for Students Search operation - resource does not exist",
+            "$ref": "#/components/responses/Error404ResponseBody"
+          },
+          "409": {
+            "description": "Conflict error for Students Search operation - request conflicts with current state",
+            "$ref": "#/components/responses/Error409ResponseBody"
+          },
+          "422": {
+            "description": "Validation error for Students Search operation - request data failed validation",
+            "$ref": "#/components/responses/StudentsSearch422ResponseBody"
+          },
+          "429": {
+            "description": "Rate Limit error for Students Search operation - too many requests",
+            "$ref": "#/components/responses/Error429ResponseBody"
+          },
+          "500": {
+            "description": "Internal Server error for Students Search operation - unexpected server error",
+            "$ref": "#/components/responses/Error500ResponseBody"
+          }
+        },
+        "x-speakeasy-pagination": {
+          "type": "offsetLimit",
+          "inputs": [
+            {
+              "name": "offset",
+              "in": "parameters",
+              "type": "offset"
+            },
+            {
+              "name": "limit",
+              "in": "parameters",
+              "type": "limit"
+            }
+          ],
+          "outputs": {
+            "results": "$.data.resultArray"
+          }
+        },
+        "x-speakeasy-group": "students",
+        "x-speakeasy-name-override": "search"
       }
     }
   },
@@ -987,48 +987,6 @@
         ],
         "description": "Student management resource"
       },
-      "AddressRequestError": {
-        "type": "object",
-        "properties": {
-          "street": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ErrorField"
-              }
-            ],
-            "description": "Street address",
-            "nullable": true
-          },
-          "city": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ErrorField"
-              }
-            ],
-            "description": "City",
-            "nullable": true
-          },
-          "state": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ErrorField"
-              }
-            ],
-            "description": "State or province",
-            "nullable": true
-          },
-          "zipCode": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ErrorField"
-              }
-            ],
-            "description": "ZIP or postal code",
-            "nullable": true
-          }
-        },
-        "description": "Request error object for Address"
-      },
       "StudentRequestError": {
         "type": "object",
         "properties": {
@@ -1103,6 +1061,48 @@
           }
         },
         "description": "Request error object for Contact"
+      },
+      "AddressRequestError": {
+        "type": "object",
+        "properties": {
+          "street": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
+            "description": "Street address",
+            "nullable": true
+          },
+          "city": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
+            "description": "City",
+            "nullable": true
+          },
+          "state": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
+            "description": "State or province",
+            "nullable": true
+          },
+          "zipCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
+            "description": "ZIP or postal code",
+            "nullable": true
+          }
+        },
+        "description": "Request error object for Address"
       },
       "StudentsBulkImportRequestError": {
         "type": "object",


### PR DESCRIPTION
Add `x-speakeasy-group` and `x-speakeasy-name-override` extensions to OpenAPI operation objects to enable cleaner SDK method naming.

---
Linear Issue: [INF-303](https://linear.app/meitner-se/issue/INF-303/fix-openapi-naming-for-operations)

<a href="https://cursor.com/background-agent?bcId=bc-76de6186-c4e9-42d2-a0a3-ce1c8f6919f9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-76de6186-c4e9-42d2-a0a3-ce1c8f6919f9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

