### PR TITLE
Implement api security schemes

### DIFF
--- a/specification/specification.go
+++ b/specification/specification.go
@@ -334,6 +334,52 @@ const (
 	extJSON = ".json"
 )
 
+// Security scheme types
+const (
+	SecurityTypeMutualTLS = "mutualTLS"
+	SecurityTypeHTTP      = "http"
+	SecurityTypeAPIKey    = "apiKey"
+)
+
+// Security scheme HTTP schemes
+const (
+	SecuritySchemeBearer = "bearer"
+)
+
+// Security scheme bearer formats
+const (
+	SecurityBearerFormatJWT = "JWT"
+)
+
+// Security scheme locations for API key
+const (
+	SecurityLocationHeader = "header"
+	SecurityLocationQuery  = "query"
+	SecurityLocationCookie = "cookie"
+)
+
+// Standard security scheme names
+const (
+	SecuritySchemeMTLSName      = "mtls"
+	SecuritySchemeBearerName    = "bearerAuth"
+	SecuritySchemeClientIDName  = "clientId"
+	SecuritySchemeClientSecName = "clientSecret"
+)
+
+// Standard API key header names
+const (
+	HeaderXClientID     = "X-Client-Id"
+	HeaderXClientSecret = "X-Client-Secret"
+)
+
+// Standard security descriptions
+const (
+	SecurityDescMTLS         = "Client TLS certificate required."
+	SecurityDescBearer       = "Bearer access token in Authorization header."
+	SecurityDescClientID     = "Your client identifier."
+	SecurityDescClientSecret = "Your client secret."
+)
+
 // ServiceServer represents a server in the API service.
 type ServiceServer struct {
 	// URL of the server
@@ -368,6 +414,40 @@ type ServiceLicense struct {
 
 	// SPDX license identifier for the license used for the API
 	Identifier string `json:"identifier,omitempty"`
+}
+
+// SecurityScheme represents a security scheme definition.
+type SecurityScheme struct {
+	// Type of the security scheme (mutualTLS, http, apiKey)
+	Type string `json:"type"`
+
+	// Description of the security scheme
+	Description string `json:"description,omitempty"`
+
+	// Scheme for HTTP-based security (e.g., "bearer")
+	Scheme string `json:"scheme,omitempty"`
+
+	// BearerFormat for HTTP bearer token authentication
+	BearerFormat string `json:"bearerFormat,omitempty"`
+
+	// Name of the header, query or cookie parameter for apiKey
+	Name string `json:"name,omitempty"`
+
+	// Location of the API key (header, query, cookie)
+	In string `json:"in,omitempty"`
+}
+
+// SecurityRequirement represents which security schemes apply to a particular operation.
+// The key is the security scheme name and the value is a list of scope names (empty for non-OAuth2/OpenID Connect schemes).
+type SecurityRequirement map[string][]string
+
+// ServiceSecurity represents the security configuration for the service.
+type ServiceSecurity struct {
+	// SecuritySchemes defines the security schemes available
+	SecuritySchemes map[string]SecurityScheme `json:"securitySchemes,omitempty"`
+
+	// Security defines which security schemes are required by default
+	Security []SecurityRequirement `json:"security,omitempty"`
 }
 
 // RetryBackoffConfiguration defines the backoff behavior for retry attempts.
@@ -422,6 +502,9 @@ type Service struct {
 
 	// Servers that are part of the service
 	Servers []ServiceServer `json:"servers,omitempty"`
+
+	// Security configuration for the service
+	Security *ServiceSecurity `json:"security,omitempty"`
 
 	// Retry configuration for the service
 	Retry *RetryConfiguration `json:"retry,omitempty"`
@@ -606,6 +689,7 @@ func ApplyOverlay(input *Service) *Service {
 		Contact:   input.Contact,                               // Copy contact information
 		License:   input.License,                               // Copy license information
 		Servers:   append([]ServiceServer{}, input.Servers...), // Copy servers slice
+		Security:  input.Security,                              // Copy security configuration
 		Retry:     input.Retry,                                 // Copy retry configuration
 		Timeout:   input.Timeout,                               // Copy timeout configuration
 		Enums:     make([]Enum, 0, len(input.Enums)+2),         // +2 for ErrorCode and ErrorFieldCode enums
@@ -1223,6 +1307,7 @@ func ApplyFilterOverlay(input *Service) *Service {
 		Contact:   input.Contact,                               // Copy contact information
 		License:   input.License,                               // Copy license information
 		Servers:   append([]ServiceServer{}, input.Servers...), // Copy servers slice
+		Security:  input.Security,                              // Copy security configuration
 		Retry:     input.Retry,                                 // Copy retry configuration
 		Timeout:   input.Timeout,                               // Copy timeout configuration
 		Enums:     make([]Enum, len(input.Enums)),


### PR DESCRIPTION
Add security scheme and requirement definitions to the OpenAPI specification to support mTLS & access token and clientID & clientSecret authentication types.

---
Linear Issue: [INF-304](https://linear.app/meitner-se/issue/INF-304/add-security)

<a href="https://cursor.com/background-agent?bcId=bc-315a1075-1a1d-4a69-85b3-5c552e9ec7a4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-315a1075-1a1d-4a69-85b3-5c552e9ec7a4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

