### PR TITLE
Add 422 error examples to openapi

### DIFF
--- a/specification/openapi/openapi.go
+++ b/specification/openapi/openapi.go
@@ -1323,17 +1323,13 @@ func (g *Generator) generate422ErrorExample(resourceName, endpointName string, s
 		Kind: yaml.MappingNode,
 	}
 
-	// Add error field with UnprocessableEntity value
+	// Add error field as Error object with code and message
 	errorKeyNode := &yaml.Node{
 		Kind:  yaml.ScalarNode,
 		Tag:   "!!str",
 		Value: errorFieldName,
 	}
-	errorValueNode := &yaml.Node{
-		Kind:  yaml.ScalarNode,
-		Tag:   "!!str",
-		Value: errorCodeUnprocessableEntity,
-	}
+	errorValueNode := g.generateErrorObjectExample(resourceName, endpointName)
 	rootNode.Content = append(rootNode.Content, errorKeyNode, errorValueNode)
 
 	// Add errorFields field with validation examples
@@ -1362,6 +1358,41 @@ func (g *Generator) generate422ErrorExample(resourceName, endpointName string, s
 	rootNode.Content = append(rootNode.Content, errorFieldsKeyNode, errorFieldsValueNode)
 
 	return rootNode
+}
+
+// generateErrorObjectExample generates an Error object example with code and message fields.
+func (g *Generator) generateErrorObjectExample(resourceName, endpointName string) *yaml.Node {
+	errorObjectNode := &yaml.Node{
+		Kind: yaml.MappingNode,
+	}
+
+	// Add code field
+	codeKeyNode := &yaml.Node{
+		Kind:  yaml.ScalarNode,
+		Tag:   "!!str",
+		Value: codeFieldName,
+	}
+	codeValueNode := &yaml.Node{
+		Kind:  yaml.ScalarNode,
+		Tag:   "!!str",
+		Value: errorCodeUnprocessableEntity,
+	}
+	errorObjectNode.Content = append(errorObjectNode.Content, codeKeyNode, codeValueNode)
+
+	// Add message field
+	messageKeyNode := &yaml.Node{
+		Kind:  yaml.ScalarNode,
+		Tag:   "!!str",
+		Value: messageFieldName,
+	}
+	messageValueNode := &yaml.Node{
+		Kind:  yaml.ScalarNode,
+		Tag:   "!!str",
+		Value: fmt.Sprintf("Validation failed for %s %s endpoint", resourceName, endpointName),
+	}
+	errorObjectNode.Content = append(errorObjectNode.Content, messageKeyNode, messageValueNode)
+
+	return errorObjectNode
 }
 
 // generateErrorFieldsExample generates errorFields examples from RequestError object fields.

--- a/testdata/school-management-api-expected.json
+++ b/testdata/school-management-api-expected.json
@@ -18,6 +18,71 @@
     }
   ],
   "paths": {
+    "/students/bulk-import": {
+      "post": {
+        "tags": [
+          "Students"
+        ],
+        "summary": "Bulk Import Students",
+        "description": "Import multiple students from a CSV file or structured data",
+        "operationId": "StudentsBulkImport",
+        "parameters": [
+          {
+            "name": "validateOnly",
+            "in": "query",
+            "description": "Only validate data without importing",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/StudentsBulkImport"
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully imported students",
+            "$ref": "#/components/responses/StudentsBulkImport"
+          },
+          "400": {
+            "description": "Bad Request error for Students BulkImport operation - request contains invalid parameters",
+            "$ref": "#/components/responses/Error400ResponseBody"
+          },
+          "401": {
+            "description": "Unauthorized error for Students BulkImport operation - authentication required",
+            "$ref": "#/components/responses/Error401ResponseBody"
+          },
+          "403": {
+            "description": "Forbidden error for Students BulkImport operation - insufficient permissions",
+            "$ref": "#/components/responses/Error403ResponseBody"
+          },
+          "404": {
+            "description": "Not Found error for Students BulkImport operation - resource does not exist",
+            "$ref": "#/components/responses/Error404ResponseBody"
+          },
+          "409": {
+            "description": "Conflict error for Students BulkImport operation - request conflicts with current state",
+            "$ref": "#/components/responses/Error409ResponseBody"
+          },
+          "422": {
+            "description": "Validation error for Students BulkImport operation - request data failed validation",
+            "$ref": "#/components/responses/StudentsBulkImport422ResponseBody"
+          },
+          "429": {
+            "description": "Rate Limit error for Students BulkImport operation - too many requests",
+            "$ref": "#/components/responses/Error429ResponseBody"
+          },
+          "500": {
+            "description": "Internal Server error for Students BulkImport operation - unexpected server error",
+            "$ref": "#/components/responses/Error500ResponseBody"
+          }
+        },
+        "x-speakeasy-group": "students",
+        "x-speakeasy-name-override": "bulkImport"
+      }
+    },
     "/students/reports/generate": {
       "post": {
         "tags": [
@@ -584,71 +649,6 @@
         "x-speakeasy-group": "students",
         "x-speakeasy-name-override": "search"
       }
-    },
-    "/students/bulk-import": {
-      "post": {
-        "tags": [
-          "Students"
-        ],
-        "summary": "Bulk Import Students",
-        "description": "Import multiple students from a CSV file or structured data",
-        "operationId": "StudentsBulkImport",
-        "parameters": [
-          {
-            "name": "validateOnly",
-            "in": "query",
-            "description": "Only validate data without importing",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": false
-            }
-          }
-        ],
-        "requestBody": {
-          "$ref": "#/components/requestBodies/StudentsBulkImport"
-        },
-        "responses": {
-          "200": {
-            "description": "Successfully imported students",
-            "$ref": "#/components/responses/StudentsBulkImport"
-          },
-          "400": {
-            "description": "Bad Request error for Students BulkImport operation - request contains invalid parameters",
-            "$ref": "#/components/responses/Error400ResponseBody"
-          },
-          "401": {
-            "description": "Unauthorized error for Students BulkImport operation - authentication required",
-            "$ref": "#/components/responses/Error401ResponseBody"
-          },
-          "403": {
-            "description": "Forbidden error for Students BulkImport operation - insufficient permissions",
-            "$ref": "#/components/responses/Error403ResponseBody"
-          },
-          "404": {
-            "description": "Not Found error for Students BulkImport operation - resource does not exist",
-            "$ref": "#/components/responses/Error404ResponseBody"
-          },
-          "409": {
-            "description": "Conflict error for Students BulkImport operation - request conflicts with current state",
-            "$ref": "#/components/responses/Error409ResponseBody"
-          },
-          "422": {
-            "description": "Validation error for Students BulkImport operation - request data failed validation",
-            "$ref": "#/components/responses/StudentsBulkImport422ResponseBody"
-          },
-          "429": {
-            "description": "Rate Limit error for Students BulkImport operation - too many requests",
-            "$ref": "#/components/responses/Error429ResponseBody"
-          },
-          "500": {
-            "description": "Internal Server error for Students BulkImport operation - unexpected server error",
-            "$ref": "#/components/responses/Error500ResponseBody"
-          }
-        },
-        "x-speakeasy-group": "students",
-        "x-speakeasy-name-override": "bulkImport"
-      }
     }
   },
   "components": {
@@ -987,48 +987,6 @@
         ],
         "description": "Student management resource"
       },
-      "AddressRequestError": {
-        "type": "object",
-        "properties": {
-          "street": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ErrorField"
-              }
-            ],
-            "description": "Street address",
-            "nullable": true
-          },
-          "city": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ErrorField"
-              }
-            ],
-            "description": "City",
-            "nullable": true
-          },
-          "state": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ErrorField"
-              }
-            ],
-            "description": "State or province",
-            "nullable": true
-          },
-          "zipCode": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ErrorField"
-              }
-            ],
-            "description": "ZIP or postal code",
-            "nullable": true
-          }
-        },
-        "description": "Request error object for Address"
-      },
       "StudentRequestError": {
         "type": "object",
         "properties": {
@@ -1103,6 +1061,48 @@
           }
         },
         "description": "Request error object for Contact"
+      },
+      "AddressRequestError": {
+        "type": "object",
+        "properties": {
+          "street": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
+            "description": "Street address",
+            "nullable": true
+          },
+          "city": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
+            "description": "City",
+            "nullable": true
+          },
+          "state": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
+            "description": "State or province",
+            "nullable": true
+          },
+          "zipCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
+            "description": "ZIP or postal code",
+            "nullable": true
+          }
+        },
+        "description": "Request error object for Address"
       },
       "StudentsBulkImportRequestError": {
         "type": "object",
@@ -2119,7 +2119,10 @@
               ]
             },
             "example": {
-              "error": "UnprocessableEntity",
+              "error": {
+                "code": "UnprocessableEntity",
+                "message": "Validation failed for Students BulkImport endpoint"
+              },
               "errorFields": {
                 "students": {
                   "firstName": {
@@ -2195,7 +2198,10 @@
               ]
             },
             "example": {
-              "error": "UnprocessableEntity",
+              "error": {
+                "code": "UnprocessableEntity",
+                "message": "Validation failed for Students GenerateReport endpoint"
+              },
               "errorFields": {
                 "gradeLevel": {
                   "code": "Required",
@@ -2269,7 +2275,10 @@
               ]
             },
             "example": {
-              "error": "UnprocessableEntity",
+              "error": {
+                "code": "UnprocessableEntity",
+                "message": "Validation failed for Students AdvancedSearch endpoint"
+              },
               "errorFields": {
                 "nameQuery": {
                   "code": "Required",
@@ -2335,7 +2344,10 @@
               ]
             },
             "example": {
-              "error": "UnprocessableEntity",
+              "error": {
+                "code": "UnprocessableEntity",
+                "message": "Validation failed for Students Create endpoint"
+              },
               "errorFields": {
                 "firstName": {
                   "code": "Required",
@@ -2401,7 +2413,10 @@
               ]
             },
             "example": {
-              "error": "UnprocessableEntity",
+              "error": {
+                "code": "UnprocessableEntity",
+                "message": "Validation failed for Students Update endpoint"
+              },
               "errorFields": {
                 "firstName": {
                   "code": "Required",
@@ -2565,7 +2580,10 @@
               ]
             },
             "example": {
-              "error": "UnprocessableEntity",
+              "error": {
+                "code": "UnprocessableEntity",
+                "message": "Validation failed for Students Search endpoint"
+              },
               "errorFields": {
                 "filter": {
                   "code": "Required",

--- a/testdata/school-management-api-openapi.json
+++ b/testdata/school-management-api-openapi.json
@@ -18,6 +18,71 @@
     }
   ],
   "paths": {
+    "/students/bulk-import": {
+      "post": {
+        "tags": [
+          "Students"
+        ],
+        "summary": "Bulk Import Students",
+        "description": "Import multiple students from a CSV file or structured data",
+        "operationId": "StudentsBulkImport",
+        "parameters": [
+          {
+            "name": "validateOnly",
+            "in": "query",
+            "description": "Only validate data without importing",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/StudentsBulkImport"
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully imported students",
+            "$ref": "#/components/responses/StudentsBulkImport"
+          },
+          "400": {
+            "description": "Bad Request error for Students BulkImport operation - request contains invalid parameters",
+            "$ref": "#/components/responses/Error400ResponseBody"
+          },
+          "401": {
+            "description": "Unauthorized error for Students BulkImport operation - authentication required",
+            "$ref": "#/components/responses/Error401ResponseBody"
+          },
+          "403": {
+            "description": "Forbidden error for Students BulkImport operation - insufficient permissions",
+            "$ref": "#/components/responses/Error403ResponseBody"
+          },
+          "404": {
+            "description": "Not Found error for Students BulkImport operation - resource does not exist",
+            "$ref": "#/components/responses/Error404ResponseBody"
+          },
+          "409": {
+            "description": "Conflict error for Students BulkImport operation - request conflicts with current state",
+            "$ref": "#/components/responses/Error409ResponseBody"
+          },
+          "422": {
+            "description": "Validation error for Students BulkImport operation - request data failed validation",
+            "$ref": "#/components/responses/StudentsBulkImport422ResponseBody"
+          },
+          "429": {
+            "description": "Rate Limit error for Students BulkImport operation - too many requests",
+            "$ref": "#/components/responses/Error429ResponseBody"
+          },
+          "500": {
+            "description": "Internal Server error for Students BulkImport operation - unexpected server error",
+            "$ref": "#/components/responses/Error500ResponseBody"
+          }
+        },
+        "x-speakeasy-group": "students",
+        "x-speakeasy-name-override": "bulkImport"
+      }
+    },
     "/students/reports/generate": {
       "post": {
         "tags": [
@@ -584,71 +649,6 @@
         "x-speakeasy-group": "students",
         "x-speakeasy-name-override": "search"
       }
-    },
-    "/students/bulk-import": {
-      "post": {
-        "tags": [
-          "Students"
-        ],
-        "summary": "Bulk Import Students",
-        "description": "Import multiple students from a CSV file or structured data",
-        "operationId": "StudentsBulkImport",
-        "parameters": [
-          {
-            "name": "validateOnly",
-            "in": "query",
-            "description": "Only validate data without importing",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": false
-            }
-          }
-        ],
-        "requestBody": {
-          "$ref": "#/components/requestBodies/StudentsBulkImport"
-        },
-        "responses": {
-          "200": {
-            "description": "Successfully imported students",
-            "$ref": "#/components/responses/StudentsBulkImport"
-          },
-          "400": {
-            "description": "Bad Request error for Students BulkImport operation - request contains invalid parameters",
-            "$ref": "#/components/responses/Error400ResponseBody"
-          },
-          "401": {
-            "description": "Unauthorized error for Students BulkImport operation - authentication required",
-            "$ref": "#/components/responses/Error401ResponseBody"
-          },
-          "403": {
-            "description": "Forbidden error for Students BulkImport operation - insufficient permissions",
-            "$ref": "#/components/responses/Error403ResponseBody"
-          },
-          "404": {
-            "description": "Not Found error for Students BulkImport operation - resource does not exist",
-            "$ref": "#/components/responses/Error404ResponseBody"
-          },
-          "409": {
-            "description": "Conflict error for Students BulkImport operation - request conflicts with current state",
-            "$ref": "#/components/responses/Error409ResponseBody"
-          },
-          "422": {
-            "description": "Validation error for Students BulkImport operation - request data failed validation",
-            "$ref": "#/components/responses/StudentsBulkImport422ResponseBody"
-          },
-          "429": {
-            "description": "Rate Limit error for Students BulkImport operation - too many requests",
-            "$ref": "#/components/responses/Error429ResponseBody"
-          },
-          "500": {
-            "description": "Internal Server error for Students BulkImport operation - unexpected server error",
-            "$ref": "#/components/responses/Error500ResponseBody"
-          }
-        },
-        "x-speakeasy-group": "students",
-        "x-speakeasy-name-override": "bulkImport"
-      }
     }
   },
   "components": {
@@ -987,48 +987,6 @@
         ],
         "description": "Student management resource"
       },
-      "AddressRequestError": {
-        "type": "object",
-        "properties": {
-          "street": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ErrorField"
-              }
-            ],
-            "description": "Street address",
-            "nullable": true
-          },
-          "city": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ErrorField"
-              }
-            ],
-            "description": "City",
-            "nullable": true
-          },
-          "state": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ErrorField"
-              }
-            ],
-            "description": "State or province",
-            "nullable": true
-          },
-          "zipCode": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ErrorField"
-              }
-            ],
-            "description": "ZIP or postal code",
-            "nullable": true
-          }
-        },
-        "description": "Request error object for Address"
-      },
       "StudentRequestError": {
         "type": "object",
         "properties": {
@@ -1103,6 +1061,48 @@
           }
         },
         "description": "Request error object for Contact"
+      },
+      "AddressRequestError": {
+        "type": "object",
+        "properties": {
+          "street": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
+            "description": "Street address",
+            "nullable": true
+          },
+          "city": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
+            "description": "City",
+            "nullable": true
+          },
+          "state": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
+            "description": "State or province",
+            "nullable": true
+          },
+          "zipCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
+            "description": "ZIP or postal code",
+            "nullable": true
+          }
+        },
+        "description": "Request error object for Address"
       },
       "StudentsBulkImportRequestError": {
         "type": "object",
@@ -2119,7 +2119,10 @@
               ]
             },
             "example": {
-              "error": "UnprocessableEntity",
+              "error": {
+                "code": "UnprocessableEntity",
+                "message": "Validation failed for Students BulkImport endpoint"
+              },
               "errorFields": {
                 "students": {
                   "firstName": {
@@ -2195,7 +2198,10 @@
               ]
             },
             "example": {
-              "error": "UnprocessableEntity",
+              "error": {
+                "code": "UnprocessableEntity",
+                "message": "Validation failed for Students GenerateReport endpoint"
+              },
               "errorFields": {
                 "gradeLevel": {
                   "code": "Required",
@@ -2269,7 +2275,10 @@
               ]
             },
             "example": {
-              "error": "UnprocessableEntity",
+              "error": {
+                "code": "UnprocessableEntity",
+                "message": "Validation failed for Students AdvancedSearch endpoint"
+              },
               "errorFields": {
                 "nameQuery": {
                   "code": "Required",
@@ -2335,7 +2344,10 @@
               ]
             },
             "example": {
-              "error": "UnprocessableEntity",
+              "error": {
+                "code": "UnprocessableEntity",
+                "message": "Validation failed for Students Create endpoint"
+              },
               "errorFields": {
                 "firstName": {
                   "code": "Required",
@@ -2401,7 +2413,10 @@
               ]
             },
             "example": {
-              "error": "UnprocessableEntity",
+              "error": {
+                "code": "UnprocessableEntity",
+                "message": "Validation failed for Students Update endpoint"
+              },
               "errorFields": {
                 "firstName": {
                   "code": "Required",
@@ -2565,7 +2580,10 @@
               ]
             },
             "example": {
-              "error": "UnprocessableEntity",
+              "error": {
+                "code": "UnprocessableEntity",
+                "message": "Validation failed for Students Search endpoint"
+              },
               "errorFields": {
                 "filter": {
                   "code": "Required",


### PR DESCRIPTION
Add realistic response examples for 422 errors to the OpenAPI specification to enhance API documentation.

This change provides concrete examples of validation error responses, making it easier for third-party developers to understand and integrate with the API by showing the expected structure and content of 422 errors.

---
Linear Issue: [INF-305](https://linear.app/meitner-se/issue/INF-305/add-response-examples-for-422-errors-in-openapi)

<a href="https://cursor.com/background-agent?bcId=bc-c8e8b747-0901-454f-b365-c4926bd70ee3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c8e8b747-0901-454f-b365-c4926bd70ee3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

