### PR TITLE
Fix openapi type mismatch

### DIFF
--- a/specification/openapi/openapi.go
+++ b/specification/openapi/openapi.go
@@ -705,10 +705,7 @@ func (g *Generator) createFieldSchema(field specification.Field, service *specif
 
 	// Add example if present
 	if field.Example != "" {
-		exampleNode := &yaml.Node{
-			Kind:  yaml.ScalarNode,
-			Value: field.Example,
-		}
+		exampleNode := g.createTypedExampleNode(field.Type, field.Example)
 		schema.Examples = []*yaml.Node{exampleNode}
 	}
 
@@ -754,10 +751,7 @@ func (g *Generator) createParameterSchema(field specification.Field, service *sp
 
 	// Add example if present
 	if field.Example != "" {
-		exampleNode := &yaml.Node{
-			Kind:  yaml.ScalarNode,
-			Value: field.Example,
-		}
+		exampleNode := g.createTypedExampleNode(field.Type, field.Example)
 		schema.Examples = []*yaml.Node{exampleNode}
 	}
 


### PR DESCRIPTION
Fix OpenAPI example generation to correctly type string fields with numeric examples as strings.

Previously, `createFieldSchema` and `createParameterSchema` created untyped YAML scalar nodes for examples, leading to the YAML serializer inferring an incorrect integer type for string examples like "184". By using `createTypedExampleNode`, the examples now explicitly carry their correct string type (`!!str`), resolving the type mismatch.

---
Linear Issue: [INF-306](https://linear.app/meitner-se/issue/INF-306/fix-type-in-openapi-example)

<a href="https://cursor.com/background-agent?bcId=bc-c0b13093-f5fe-4c7a-b77e-39dafe64bb32">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c0b13093-f5fe-4c7a-b77e-39dafe64bb32">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

