### PR TITLE
Fix openapi example warnings

### DIFF
--- a/specification/openapi/openapi.go
+++ b/specification/openapi/openapi.go
@@ -1314,6 +1314,39 @@ func (g *Generator) createComponentResponse(response specification.EndpointRespo
 
 			for _, field := range response.BodyFields {
 				fieldSchema := g.createFieldSchema(field, service)
+
+				// Add example to field property if field has example
+				if field.Example != "" {
+					exampleNode := g.createTypedExampleNode(field.Type, field.Example)
+					// Handle array modifier - wrap the value in an array if needed
+					if field.IsArray() {
+						arrayNode := &yaml.Node{
+							Kind: yaml.SequenceNode,
+						}
+						arrayNode.Content = append(arrayNode.Content, exampleNode)
+						exampleNode = arrayNode
+					}
+					fieldSchema.Examples = []*yaml.Node{exampleNode}
+				} else if field.IsArray() && service.HasObject(field.Type) {
+					// Generate example array from object definition
+					if obj := service.GetObject(field.Type); obj != nil {
+						if objectExample := g.generateObjectExample(*obj, service); objectExample != nil {
+							arrayNode := &yaml.Node{
+								Kind: yaml.SequenceNode,
+							}
+							arrayNode.Content = append(arrayNode.Content, objectExample)
+							fieldSchema.Examples = []*yaml.Node{arrayNode}
+						}
+					}
+				} else if service.HasObject(field.Type) {
+					// Generate example from object definition
+					if obj := service.GetObject(field.Type); obj != nil {
+						if objectExample := g.generateObjectExample(*obj, service); objectExample != nil {
+							fieldSchema.Examples = []*yaml.Node{objectExample}
+						}
+					}
+				}
+
 				proxy := base.CreateSchemaProxy(fieldSchema)
 				schema.Properties.Set(field.TagJSON(), proxy)
 			}
@@ -1783,6 +1816,39 @@ func (g *Generator) createResponse(response specification.EndpointResponse, reso
 
 			for _, field := range response.BodyFields {
 				fieldSchema := g.createFieldSchema(field, service)
+
+				// Add example to field property if field has example
+				if field.Example != "" {
+					exampleNode := g.createTypedExampleNode(field.Type, field.Example)
+					// Handle array modifier - wrap the value in an array if needed
+					if field.IsArray() {
+						arrayNode := &yaml.Node{
+							Kind: yaml.SequenceNode,
+						}
+						arrayNode.Content = append(arrayNode.Content, exampleNode)
+						exampleNode = arrayNode
+					}
+					fieldSchema.Examples = []*yaml.Node{exampleNode}
+				} else if field.IsArray() && service.HasObject(field.Type) {
+					// Generate example array from object definition
+					if obj := service.GetObject(field.Type); obj != nil {
+						if objectExample := g.generateObjectExample(*obj, service); objectExample != nil {
+							arrayNode := &yaml.Node{
+								Kind: yaml.SequenceNode,
+							}
+							arrayNode.Content = append(arrayNode.Content, objectExample)
+							fieldSchema.Examples = []*yaml.Node{arrayNode}
+						}
+					}
+				} else if service.HasObject(field.Type) {
+					// Generate example from object definition
+					if obj := service.GetObject(field.Type); obj != nil {
+						if objectExample := g.generateObjectExample(*obj, service); objectExample != nil {
+							fieldSchema.Examples = []*yaml.Node{objectExample}
+						}
+					}
+				}
+
 				proxy := base.CreateSchemaProxy(fieldSchema)
 				schema.Properties.Set(field.TagJSON(), proxy)
 			}

--- a/specification/openapi/openapi.go
+++ b/specification/openapi/openapi.go
@@ -1170,7 +1170,13 @@ func (g *Generator) createComponentRequestBody(bodyParams []specification.Field,
 
 	// Generate examples for the request body
 	if example := g.generateRequestBodyExample(bodyParams, service); example != nil {
-		mediaType.Example = example
+		// Use Examples (plural) for complex objects per OpenAPI 3.0+ specification
+		examples := orderedmap.New[string, *base.Example]()
+		examples.Set("requestExample", &base.Example{
+			Summary: "Request body example",
+			Value:   example,
+		})
+		mediaType.Examples = examples
 	}
 
 	content := orderedmap.New[string, *v3.MediaType]()
@@ -1319,7 +1325,13 @@ func (g *Generator) createComponentResponse(response specification.EndpointRespo
 
 			// Generate response example
 			if responseExample := g.generateResponseBodyExample(response, service); responseExample != nil {
-				mediaType.Example = responseExample
+				// Use Examples (plural) for complex objects per OpenAPI 3.0+ specification
+				examples := orderedmap.New[string, *base.Example]()
+				examples.Set("responseExample", &base.Example{
+					Summary: "Response body example",
+					Value:   responseExample,
+				})
+				mediaType.Examples = examples
 			}
 
 			content.Set(contentTypeJSON, mediaType)
@@ -1560,7 +1572,13 @@ func (g *Generator) createEndpointSpecific422ErrorResponse(resourceName, endpoin
 
 	// Generate 422 error response example
 	if errorExample := g.generate422ErrorExample(resourceName, endpointName, service); errorExample != nil {
-		mediaType.Example = errorExample
+		// Use Examples (plural) for complex objects per OpenAPI 3.0+ specification
+		examples := orderedmap.New[string, *base.Example]()
+		examples.Set("validationError", &base.Example{
+			Summary: "Validation error example",
+			Value:   errorExample,
+		})
+		mediaType.Examples = examples
 	}
 
 	content.Set(contentTypeJSON, mediaType)
@@ -1715,7 +1733,13 @@ func (g *Generator) createResponse(response specification.EndpointResponse, reso
 
 			// Generate response example
 			if responseExample := g.generateResponseBodyExample(response, service); responseExample != nil {
-				mediaType.Example = responseExample
+				// Use Examples (plural) for complex objects per OpenAPI 3.0+ specification
+				examples := orderedmap.New[string, *base.Example]()
+				examples.Set("responseExample", &base.Example{
+					Summary: "Response body example",
+					Value:   responseExample,
+				})
+				mediaType.Examples = examples
 			}
 
 			content.Set(contentTypeJSON, mediaType)

--- a/specification/openapi/openapi_test.go
+++ b/specification/openapi/openapi_test.go
@@ -2128,7 +2128,7 @@ func TestResponseBodyExamples(t *testing.T) {
 	jsonString := string(jsonBytes)
 
 	// Verify that examples exist in response bodies
-	assert.Contains(t, jsonString, "\"example\"", "Response bodies should contain examples")
+	assert.Contains(t, jsonString, "\"examples\"", "Response bodies should contain examples")
 
 	// Verify string types are quoted in response examples
 	assert.Contains(t, jsonString, "\"John Doe\"", "Should contain string field example with quotes in response")
@@ -3048,17 +3048,22 @@ func TestStringFieldsWithNumericExamples(t *testing.T) {
 	generatedJSONStr := string(generatedJSON)
 	t.Logf("Generated OpenAPI JSON for string field example verification:\n%s", generatedJSONStr)
 
-	// Verify the fix: Examples should have proper YAML tags indicating correct type
-	// This is the key evidence that our createTypedExampleNode fix is working
+	// Verify the fix: Examples should be structured using the new Examples format
+	// and contain proper typing for different field types
 
-	// municipalityCode should have string tag !!str with value "184"
-	assert.Contains(t, generatedJSONStr, `"Tag":"!!str","Value":"184"`, "municipalityCode example should be properly typed as string with !!str tag")
+	// Verify examples structure is used (not the old example structure)
+	assert.Contains(t, generatedJSONStr, `"examples"`, "Should use examples (plural) structure for complex objects")
+	assert.Contains(t, generatedJSONStr, `"requestExample"`, "Should contain requestExample key")
+	assert.Contains(t, generatedJSONStr, `"responseExample"`, "Should contain responseExample key")
 
-	// zipCode should have string tag !!str with value "12345"
-	assert.Contains(t, generatedJSONStr, `"Tag":"!!str","Value":"12345"`, "zipCode example should be properly typed as string with !!str tag")
+	// municipalityCode should be a string value "184" in the example
+	assert.Contains(t, generatedJSONStr, `"municipalityCode":"184"`, "municipalityCode example should be properly typed as string")
 
-	// houseNumber should have integer tag !!int with value "42" (for contrast)
-	assert.Contains(t, generatedJSONStr, `"Tag":"!!int","Value":"42"`, "houseNumber example should be properly typed as integer with !!int tag")
+	// zipCode should be a string value "12345" in the example
+	assert.Contains(t, generatedJSONStr, `"zipCode":"12345"`, "zipCode example should be properly typed as string")
+
+	// houseNumber should be an integer value 42 in the example (no quotes for integers)
+	assert.Contains(t, generatedJSONStr, `"houseNumber":42`, "houseNumber example should be properly typed as integer")
 
 	// Verify that municipalityCode field is present
 	assert.Contains(t, generatedJSONStr, `"municipalityCode"`, "Should contain municipalityCode field")

--- a/testdata/school-management-api-expected.json
+++ b/testdata/school-management-api-expected.json
@@ -2101,7 +2101,13 @@
                 "error": {
                   "allOf": [
                     {
-                      "$ref": "#/components/schemas/ErrorCode"
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ],
+                  "examples": [
+                    {
+                      "code": "UnprocessableEntity",
+                      "message": "Validation failed for Students BulkImport endpoint"
                     }
                   ]
                 },
@@ -2109,6 +2115,24 @@
                   "allOf": [
                     {
                       "$ref": "#/components/schemas/StudentsBulkImportRequestError"
+                    }
+                  ],
+                  "examples": [
+                    {
+                      "students": {
+                        "firstName": {
+                          "code": "Required",
+                          "message": "firstName is required"
+                        },
+                        "lastName": {
+                          "code": "Required",
+                          "message": "lastName is required"
+                        }
+                      },
+                      "overwriteExisting": {
+                        "code": "Required",
+                        "message": "overwriteExisting is required"
+                      }
                     }
                   ]
                 }
@@ -2118,25 +2142,30 @@
                 "errorFields"
               ]
             },
-            "example": {
-              "error": {
-                "code": "UnprocessableEntity",
-                "message": "Validation failed for Students BulkImport endpoint"
-              },
-              "errorFields": {
-                "students": {
-                  "firstName": {
-                    "code": "Required",
-                    "message": "firstName is required"
+            "examples": {
+              "validationError": {
+                "summary": "Validation error example",
+                "value": {
+                  "error": {
+                    "code": "UnprocessableEntity",
+                    "message": "Validation failed for Students BulkImport endpoint"
                   },
-                  "lastName": {
-                    "code": "Required",
-                    "message": "lastName is required"
+                  "errorFields": {
+                    "students": {
+                      "firstName": {
+                        "code": "Required",
+                        "message": "firstName is required"
+                      },
+                      "lastName": {
+                        "code": "Required",
+                        "message": "lastName is required"
+                      }
+                    },
+                    "overwriteExisting": {
+                      "code": "Required",
+                      "message": "overwriteExisting is required"
+                    }
                   }
-                },
-                "overwriteExisting": {
-                  "code": "Required",
-                  "message": "overwriteExisting is required"
                 }
               }
             }
@@ -2180,7 +2209,13 @@
                 "error": {
                   "allOf": [
                     {
-                      "$ref": "#/components/schemas/ErrorCode"
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ],
+                  "examples": [
+                    {
+                      "code": "UnprocessableEntity",
+                      "message": "Validation failed for Students GenerateReport endpoint"
                     }
                   ]
                 },
@@ -2188,6 +2223,18 @@
                   "allOf": [
                     {
                       "$ref": "#/components/schemas/StudentsGenerateReportRequestError"
+                    }
+                  ],
+                  "examples": [
+                    {
+                      "gradeLevel": {
+                        "code": "Required",
+                        "message": "gradeLevel is required"
+                      },
+                      "status": {
+                        "code": "Required",
+                        "message": "status is required"
+                      }
                     }
                   ]
                 }
@@ -2197,19 +2244,24 @@
                 "errorFields"
               ]
             },
-            "example": {
-              "error": {
-                "code": "UnprocessableEntity",
-                "message": "Validation failed for Students GenerateReport endpoint"
-              },
-              "errorFields": {
-                "gradeLevel": {
-                  "code": "Required",
-                  "message": "gradeLevel is required"
-                },
-                "status": {
-                  "code": "Required",
-                  "message": "status is required"
+            "examples": {
+              "validationError": {
+                "summary": "Validation error example",
+                "value": {
+                  "error": {
+                    "code": "UnprocessableEntity",
+                    "message": "Validation failed for Students GenerateReport endpoint"
+                  },
+                  "errorFields": {
+                    "gradeLevel": {
+                      "code": "Required",
+                      "message": "gradeLevel is required"
+                    },
+                    "status": {
+                      "code": "Required",
+                      "message": "status is required"
+                    }
+                  }
                 }
               }
             }
@@ -2257,7 +2309,13 @@
                 "error": {
                   "allOf": [
                     {
-                      "$ref": "#/components/schemas/ErrorCode"
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ],
+                  "examples": [
+                    {
+                      "code": "UnprocessableEntity",
+                      "message": "Validation failed for Students AdvancedSearch endpoint"
                     }
                   ]
                 },
@@ -2265,6 +2323,18 @@
                   "allOf": [
                     {
                       "$ref": "#/components/schemas/StudentsAdvancedSearchRequestError"
+                    }
+                  ],
+                  "examples": [
+                    {
+                      "nameQuery": {
+                        "code": "Required",
+                        "message": "nameQuery is required"
+                      },
+                      "gradeLevel": {
+                        "code": "Required",
+                        "message": "gradeLevel is required"
+                      }
                     }
                   ]
                 }
@@ -2274,19 +2344,24 @@
                 "errorFields"
               ]
             },
-            "example": {
-              "error": {
-                "code": "UnprocessableEntity",
-                "message": "Validation failed for Students AdvancedSearch endpoint"
-              },
-              "errorFields": {
-                "nameQuery": {
-                  "code": "Required",
-                  "message": "nameQuery is required"
-                },
-                "gradeLevel": {
-                  "code": "Required",
-                  "message": "gradeLevel is required"
+            "examples": {
+              "validationError": {
+                "summary": "Validation error example",
+                "value": {
+                  "error": {
+                    "code": "UnprocessableEntity",
+                    "message": "Validation failed for Students AdvancedSearch endpoint"
+                  },
+                  "errorFields": {
+                    "nameQuery": {
+                      "code": "Required",
+                      "message": "nameQuery is required"
+                    },
+                    "gradeLevel": {
+                      "code": "Required",
+                      "message": "gradeLevel is required"
+                    }
+                  }
                 }
               }
             }
@@ -2304,13 +2379,18 @@
                 }
               ]
             },
-            "example": {
-              "id": "123e4567-e89b-12d3-a456-426614174000",
-              "meta": {
-                "createdAt": "2024-01-15T10:30:00Z",
-                "createdBy": "987fcdeb-51a2-43d1-b567-123456789abc",
-                "updatedAt": "2024-01-15T14:45:00Z",
-                "updatedBy": "987fcdeb-51a2-43d1-b567-123456789abc"
+            "examples": {
+              "responseExample": {
+                "summary": "Response body example",
+                "value": {
+                  "id": "123e4567-e89b-12d3-a456-426614174000",
+                  "meta": {
+                    "createdAt": "2024-01-15T10:30:00Z",
+                    "createdBy": "987fcdeb-51a2-43d1-b567-123456789abc",
+                    "updatedAt": "2024-01-15T14:45:00Z",
+                    "updatedBy": "987fcdeb-51a2-43d1-b567-123456789abc"
+                  }
+                }
               }
             }
           }
@@ -2326,7 +2406,13 @@
                 "error": {
                   "allOf": [
                     {
-                      "$ref": "#/components/schemas/ErrorCode"
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ],
+                  "examples": [
+                    {
+                      "code": "UnprocessableEntity",
+                      "message": "Validation failed for Students Create endpoint"
                     }
                   ]
                 },
@@ -2334,6 +2420,18 @@
                   "allOf": [
                     {
                       "$ref": "#/components/schemas/StudentsCreateRequestError"
+                    }
+                  ],
+                  "examples": [
+                    {
+                      "firstName": {
+                        "code": "Required",
+                        "message": "firstName is required"
+                      },
+                      "lastName": {
+                        "code": "Required",
+                        "message": "lastName is required"
+                      }
                     }
                   ]
                 }
@@ -2343,19 +2441,24 @@
                 "errorFields"
               ]
             },
-            "example": {
-              "error": {
-                "code": "UnprocessableEntity",
-                "message": "Validation failed for Students Create endpoint"
-              },
-              "errorFields": {
-                "firstName": {
-                  "code": "Required",
-                  "message": "firstName is required"
-                },
-                "lastName": {
-                  "code": "Required",
-                  "message": "lastName is required"
+            "examples": {
+              "validationError": {
+                "summary": "Validation error example",
+                "value": {
+                  "error": {
+                    "code": "UnprocessableEntity",
+                    "message": "Validation failed for Students Create endpoint"
+                  },
+                  "errorFields": {
+                    "firstName": {
+                      "code": "Required",
+                      "message": "firstName is required"
+                    },
+                    "lastName": {
+                      "code": "Required",
+                      "message": "lastName is required"
+                    }
+                  }
                 }
               }
             }
@@ -2373,13 +2476,18 @@
                 }
               ]
             },
-            "example": {
-              "id": "123e4567-e89b-12d3-a456-426614174000",
-              "meta": {
-                "createdAt": "2024-01-15T10:30:00Z",
-                "createdBy": "987fcdeb-51a2-43d1-b567-123456789abc",
-                "updatedAt": "2024-01-15T14:45:00Z",
-                "updatedBy": "987fcdeb-51a2-43d1-b567-123456789abc"
+            "examples": {
+              "responseExample": {
+                "summary": "Response body example",
+                "value": {
+                  "id": "123e4567-e89b-12d3-a456-426614174000",
+                  "meta": {
+                    "createdAt": "2024-01-15T10:30:00Z",
+                    "createdBy": "987fcdeb-51a2-43d1-b567-123456789abc",
+                    "updatedAt": "2024-01-15T14:45:00Z",
+                    "updatedBy": "987fcdeb-51a2-43d1-b567-123456789abc"
+                  }
+                }
               }
             }
           }
@@ -2395,7 +2503,13 @@
                 "error": {
                   "allOf": [
                     {
-                      "$ref": "#/components/schemas/ErrorCode"
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ],
+                  "examples": [
+                    {
+                      "code": "UnprocessableEntity",
+                      "message": "Validation failed for Students Update endpoint"
                     }
                   ]
                 },
@@ -2403,6 +2517,18 @@
                   "allOf": [
                     {
                       "$ref": "#/components/schemas/StudentsUpdateRequestError"
+                    }
+                  ],
+                  "examples": [
+                    {
+                      "firstName": {
+                        "code": "Required",
+                        "message": "firstName is required"
+                      },
+                      "lastName": {
+                        "code": "Required",
+                        "message": "lastName is required"
+                      }
                     }
                   ]
                 }
@@ -2412,19 +2538,24 @@
                 "errorFields"
               ]
             },
-            "example": {
-              "error": {
-                "code": "UnprocessableEntity",
-                "message": "Validation failed for Students Update endpoint"
-              },
-              "errorFields": {
-                "firstName": {
-                  "code": "Required",
-                  "message": "firstName is required"
-                },
-                "lastName": {
-                  "code": "Required",
-                  "message": "lastName is required"
+            "examples": {
+              "validationError": {
+                "summary": "Validation error example",
+                "value": {
+                  "error": {
+                    "code": "UnprocessableEntity",
+                    "message": "Validation failed for Students Update endpoint"
+                  },
+                  "errorFields": {
+                    "firstName": {
+                      "code": "Required",
+                      "message": "firstName is required"
+                    },
+                    "lastName": {
+                      "code": "Required",
+                      "message": "lastName is required"
+                    }
+                  }
                 }
               }
             }
@@ -2442,13 +2573,18 @@
                 }
               ]
             },
-            "example": {
-              "id": "123e4567-e89b-12d3-a456-426614174000",
-              "meta": {
-                "createdAt": "2024-01-15T10:30:00Z",
-                "createdBy": "987fcdeb-51a2-43d1-b567-123456789abc",
-                "updatedAt": "2024-01-15T14:45:00Z",
-                "updatedBy": "987fcdeb-51a2-43d1-b567-123456789abc"
+            "examples": {
+              "responseExample": {
+                "summary": "Response body example",
+                "value": {
+                  "id": "123e4567-e89b-12d3-a456-426614174000",
+                  "meta": {
+                    "createdAt": "2024-01-15T10:30:00Z",
+                    "createdBy": "987fcdeb-51a2-43d1-b567-123456789abc",
+                    "updatedAt": "2024-01-15T14:45:00Z",
+                    "updatedBy": "987fcdeb-51a2-43d1-b567-123456789abc"
+                  }
+                }
               }
             }
           }
@@ -2463,6 +2599,19 @@
               "properties": {
                 "data": {
                   "type": "array",
+                  "examples": [
+                    [
+                      {
+                        "id": "123e4567-e89b-12d3-a456-426614174000",
+                        "meta": {
+                          "createdAt": "2024-01-15T10:30:00Z",
+                          "createdBy": "987fcdeb-51a2-43d1-b567-123456789abc",
+                          "updatedAt": "2024-01-15T14:45:00Z",
+                          "updatedBy": "987fcdeb-51a2-43d1-b567-123456789abc"
+                        }
+                      }
+                    ]
+                  ],
                   "items": {
                     "allOf": [
                       {
@@ -2478,26 +2627,38 @@
                       "$ref": "#/components/schemas/Pagination"
                     }
                   ],
+                  "examples": [
+                    {
+                      "offset": 0,
+                      "limit": 1,
+                      "total": 100
+                    }
+                  ],
                   "description": "Pagination information"
                 }
               }
             },
-            "example": {
-              "data": [
-                {
-                  "id": "123e4567-e89b-12d3-a456-426614174000",
-                  "meta": {
-                    "createdAt": "2024-01-15T10:30:00Z",
-                    "createdBy": "987fcdeb-51a2-43d1-b567-123456789abc",
-                    "updatedAt": "2024-01-15T14:45:00Z",
-                    "updatedBy": "987fcdeb-51a2-43d1-b567-123456789abc"
+            "examples": {
+              "responseExample": {
+                "summary": "Response body example",
+                "value": {
+                  "data": [
+                    {
+                      "id": "123e4567-e89b-12d3-a456-426614174000",
+                      "meta": {
+                        "createdAt": "2024-01-15T10:30:00Z",
+                        "createdBy": "987fcdeb-51a2-43d1-b567-123456789abc",
+                        "updatedAt": "2024-01-15T14:45:00Z",
+                        "updatedBy": "987fcdeb-51a2-43d1-b567-123456789abc"
+                      }
+                    }
+                  ],
+                  "pagination": {
+                    "offset": 0,
+                    "limit": 1,
+                    "total": 100
                   }
                 }
-              ],
-              "pagination": {
-                "offset": 0,
-                "limit": 1,
-                "total": 100
               }
             }
           }
@@ -2512,6 +2673,19 @@
               "properties": {
                 "data": {
                   "type": "array",
+                  "examples": [
+                    [
+                      {
+                        "id": "123e4567-e89b-12d3-a456-426614174000",
+                        "meta": {
+                          "createdAt": "2024-01-15T10:30:00Z",
+                          "createdBy": "987fcdeb-51a2-43d1-b567-123456789abc",
+                          "updatedAt": "2024-01-15T14:45:00Z",
+                          "updatedBy": "987fcdeb-51a2-43d1-b567-123456789abc"
+                        }
+                      }
+                    ]
+                  ],
                   "items": {
                     "allOf": [
                       {
@@ -2527,26 +2701,38 @@
                       "$ref": "#/components/schemas/Pagination"
                     }
                   ],
+                  "examples": [
+                    {
+                      "offset": 0,
+                      "limit": 1,
+                      "total": 100
+                    }
+                  ],
                   "description": "Pagination information"
                 }
               }
             },
-            "example": {
-              "data": [
-                {
-                  "id": "123e4567-e89b-12d3-a456-426614174000",
-                  "meta": {
-                    "createdAt": "2024-01-15T10:30:00Z",
-                    "createdBy": "987fcdeb-51a2-43d1-b567-123456789abc",
-                    "updatedAt": "2024-01-15T14:45:00Z",
-                    "updatedBy": "987fcdeb-51a2-43d1-b567-123456789abc"
+            "examples": {
+              "responseExample": {
+                "summary": "Response body example",
+                "value": {
+                  "data": [
+                    {
+                      "id": "123e4567-e89b-12d3-a456-426614174000",
+                      "meta": {
+                        "createdAt": "2024-01-15T10:30:00Z",
+                        "createdBy": "987fcdeb-51a2-43d1-b567-123456789abc",
+                        "updatedAt": "2024-01-15T14:45:00Z",
+                        "updatedBy": "987fcdeb-51a2-43d1-b567-123456789abc"
+                      }
+                    }
+                  ],
+                  "pagination": {
+                    "offset": 0,
+                    "limit": 1,
+                    "total": 100
                   }
                 }
-              ],
-              "pagination": {
-                "offset": 0,
-                "limit": 1,
-                "total": 100
               }
             }
           }
@@ -2562,7 +2748,13 @@
                 "error": {
                   "allOf": [
                     {
-                      "$ref": "#/components/schemas/ErrorCode"
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ],
+                  "examples": [
+                    {
+                      "code": "UnprocessableEntity",
+                      "message": "Validation failed for Students Search endpoint"
                     }
                   ]
                 },
@@ -2570,6 +2762,11 @@
                   "allOf": [
                     {
                       "$ref": "#/components/schemas/StudentsSearchRequestError"
+                    }
+                  ],
+                  "examples": [
+                    {
+                      "filter": "Invalid Filter"
                     }
                   ]
                 }
@@ -2579,15 +2776,17 @@
                 "errorFields"
               ]
             },
-            "example": {
-              "error": {
-                "code": "UnprocessableEntity",
-                "message": "Validation failed for Students Search endpoint"
-              },
-              "errorFields": {
-                "filter": {
-                  "code": "Required",
-                  "message": "Filter is required"
+            "examples": {
+              "validationError": {
+                "summary": "Validation error example",
+                "value": {
+                  "error": {
+                    "code": "UnprocessableEntity",
+                    "message": "Validation failed for Students Search endpoint"
+                  },
+                  "errorFields": {
+                    "filter": "Invalid Filter"
+                  }
                 }
               }
             }

--- a/testdata/school-management-api-openapi.json
+++ b/testdata/school-management-api-openapi.json
@@ -18,99 +18,6 @@
     }
   ],
   "paths": {
-    "/students/_search": {
-      "post": {
-        "tags": [
-          "Students"
-        ],
-        "summary": "Search Students",
-        "description": "Search for `Students` with filtering capabilities.",
-        "operationId": "StudentsSearch",
-        "parameters": [
-          {
-            "name": "limit",
-            "in": "query",
-            "description": "The maximum number of Students to return (default: 50) when searching Students",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 50
-            }
-          },
-          {
-            "name": "offset",
-            "in": "query",
-            "description": "The number of Students to skip before starting to return results (default: 0) when searching Students",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 0
-            }
-          }
-        ],
-        "requestBody": {
-          "$ref": "#/components/requestBodies/StudentsSearch"
-        },
-        "responses": {
-          "200": {
-            "description": "Response for Students Search operation - returns filtered Students results",
-            "$ref": "#/components/responses/StudentsSearch"
-          },
-          "400": {
-            "description": "Bad Request error for Students Search operation - request contains invalid parameters",
-            "$ref": "#/components/responses/Error400ResponseBody"
-          },
-          "401": {
-            "description": "Unauthorized error for Students Search operation - authentication required",
-            "$ref": "#/components/responses/Error401ResponseBody"
-          },
-          "403": {
-            "description": "Forbidden error for Students Search operation - insufficient permissions",
-            "$ref": "#/components/responses/Error403ResponseBody"
-          },
-          "404": {
-            "description": "Not Found error for Students Search operation - resource does not exist",
-            "$ref": "#/components/responses/Error404ResponseBody"
-          },
-          "409": {
-            "description": "Conflict error for Students Search operation - request conflicts with current state",
-            "$ref": "#/components/responses/Error409ResponseBody"
-          },
-          "422": {
-            "description": "Validation error for Students Search operation - request data failed validation",
-            "$ref": "#/components/responses/StudentsSearch422ResponseBody"
-          },
-          "429": {
-            "description": "Rate Limit error for Students Search operation - too many requests",
-            "$ref": "#/components/responses/Error429ResponseBody"
-          },
-          "500": {
-            "description": "Internal Server error for Students Search operation - unexpected server error",
-            "$ref": "#/components/responses/Error500ResponseBody"
-          }
-        },
-        "x-speakeasy-pagination": {
-          "type": "offsetLimit",
-          "inputs": [
-            {
-              "name": "offset",
-              "in": "parameters",
-              "type": "offset"
-            },
-            {
-              "name": "limit",
-              "in": "parameters",
-              "type": "limit"
-            }
-          ],
-          "outputs": {
-            "results": "$.data.resultArray"
-          }
-        },
-        "x-speakeasy-group": "students",
-        "x-speakeasy-name-override": "search"
-      }
-    },
     "/students/bulk-import": {
       "post": {
         "tags": [
@@ -649,6 +556,99 @@
         "x-speakeasy-group": "students",
         "x-speakeasy-name-override": "update"
       }
+    },
+    "/students/_search": {
+      "post": {
+        "tags": [
+          "Students"
+        ],
+        "summary": "Search Students",
+        "description": "Search for `Students` with filtering capabilities.",
+        "operationId": "StudentsSearch",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "The maximum number of Students to return (default: 50) when searching Students",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 50
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "description": "The number of Students to skip before starting to return results (default: 0) when searching Students",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 0
+            }
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/StudentsSearch"
+        },
+        "responses": {
+          "200": {
+            "description": "Response for Students Search operation - returns filtered Students results",
+            "$ref": "#/components/responses/StudentsSearch"
+          },
+          "400": {
+            "description": "Bad Request error for Students Search operation - request contains invalid parameters",
+            "$ref": "#/components/responses/Error400ResponseBody"
+          },
+          "401": {
+            "description": "Unauthorized error for Students Search operation - authentication required",
+            "$ref": "#/components/responses/Error401ResponseBody"
+          },
+          "403": {
+            "description": "Forbidden error for Students Search operation - insufficient permissions",
+            "$ref": "#/components/responses/Error403ResponseBody"
+          },
+          "404": {
+            "description": "Not Found error for Students Search operation - resource does not exist",
+            "$ref": "#/components/responses/Error404ResponseBody"
+          },
+          "409": {
+            "description": "Conflict error for Students Search operation - request conflicts with current state",
+            "$ref": "#/components/responses/Error409ResponseBody"
+          },
+          "422": {
+            "description": "Validation error for Students Search operation - request data failed validation",
+            "$ref": "#/components/responses/StudentsSearch422ResponseBody"
+          },
+          "429": {
+            "description": "Rate Limit error for Students Search operation - too many requests",
+            "$ref": "#/components/responses/Error429ResponseBody"
+          },
+          "500": {
+            "description": "Internal Server error for Students Search operation - unexpected server error",
+            "$ref": "#/components/responses/Error500ResponseBody"
+          }
+        },
+        "x-speakeasy-pagination": {
+          "type": "offsetLimit",
+          "inputs": [
+            {
+              "name": "offset",
+              "in": "parameters",
+              "type": "offset"
+            },
+            {
+              "name": "limit",
+              "in": "parameters",
+              "type": "limit"
+            }
+          ],
+          "outputs": {
+            "results": "$.data.resultArray"
+          }
+        },
+        "x-speakeasy-group": "students",
+        "x-speakeasy-name-override": "search"
+      }
     }
   },
   "components": {
@@ -987,48 +987,6 @@
         ],
         "description": "Student management resource"
       },
-      "AddressRequestError": {
-        "type": "object",
-        "properties": {
-          "street": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ErrorField"
-              }
-            ],
-            "description": "Street address",
-            "nullable": true
-          },
-          "city": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ErrorField"
-              }
-            ],
-            "description": "City",
-            "nullable": true
-          },
-          "state": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ErrorField"
-              }
-            ],
-            "description": "State or province",
-            "nullable": true
-          },
-          "zipCode": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ErrorField"
-              }
-            ],
-            "description": "ZIP or postal code",
-            "nullable": true
-          }
-        },
-        "description": "Request error object for Address"
-      },
       "StudentRequestError": {
         "type": "object",
         "properties": {
@@ -1103,6 +1061,48 @@
           }
         },
         "description": "Request error object for Contact"
+      },
+      "AddressRequestError": {
+        "type": "object",
+        "properties": {
+          "street": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
+            "description": "Street address",
+            "nullable": true
+          },
+          "city": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
+            "description": "City",
+            "nullable": true
+          },
+          "state": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
+            "description": "State or province",
+            "nullable": true
+          },
+          "zipCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
+            "description": "ZIP or postal code",
+            "nullable": true
+          }
+        },
+        "description": "Request error object for Address"
       },
       "StudentsBulkImportRequestError": {
         "type": "object",
@@ -2766,10 +2766,7 @@
                   ],
                   "examples": [
                     {
-                      "filter": {
-                        "code": "Required",
-                        "message": "Filter is required"
-                      }
+                      "filter": "Invalid Filter"
                     }
                   ]
                 }
@@ -2788,10 +2785,7 @@
                     "message": "Validation failed for Students Search endpoint"
                   },
                   "errorFields": {
-                    "filter": {
-                      "code": "Required",
-                      "message": "Filter is required"
-                    }
+                    "filter": "Invalid Filter"
                   }
                 }
               }

--- a/testdata/school-management-api-openapi.json
+++ b/testdata/school-management-api-openapi.json
@@ -987,29 +987,47 @@
         ],
         "description": "Student management resource"
       },
-      "ContactRequestError": {
+      "AddressRequestError": {
         "type": "object",
         "properties": {
-          "email": {
+          "street": {
             "allOf": [
               {
                 "$ref": "#/components/schemas/ErrorField"
               }
             ],
-            "description": "Email address",
+            "description": "Street address",
             "nullable": true
           },
-          "phone": {
+          "city": {
             "allOf": [
               {
                 "$ref": "#/components/schemas/ErrorField"
               }
             ],
-            "description": "Phone number",
+            "description": "City",
+            "nullable": true
+          },
+          "state": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
+            "description": "State or province",
+            "nullable": true
+          },
+          "zipCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
+            "description": "ZIP or postal code",
             "nullable": true
           }
         },
-        "description": "Request error object for Contact"
+        "description": "Request error object for Address"
       },
       "StudentRequestError": {
         "type": "object",
@@ -1062,47 +1080,29 @@
         },
         "description": "Request error object for Student"
       },
-      "AddressRequestError": {
+      "ContactRequestError": {
         "type": "object",
         "properties": {
-          "street": {
+          "email": {
             "allOf": [
               {
                 "$ref": "#/components/schemas/ErrorField"
               }
             ],
-            "description": "Street address",
+            "description": "Email address",
             "nullable": true
           },
-          "city": {
+          "phone": {
             "allOf": [
               {
                 "$ref": "#/components/schemas/ErrorField"
               }
             ],
-            "description": "City",
-            "nullable": true
-          },
-          "state": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ErrorField"
-              }
-            ],
-            "description": "State or province",
-            "nullable": true
-          },
-          "zipCode": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ErrorField"
-              }
-            ],
-            "description": "ZIP or postal code",
+            "description": "Phone number",
             "nullable": true
           }
         },
-        "description": "Request error object for Address"
+        "description": "Request error object for Contact"
       },
       "StudentsBulkImportRequestError": {
         "type": "object",
@@ -2599,6 +2599,19 @@
               "properties": {
                 "data": {
                   "type": "array",
+                  "examples": [
+                    [
+                      {
+                        "id": "123e4567-e89b-12d3-a456-426614174000",
+                        "meta": {
+                          "createdAt": "2024-01-15T10:30:00Z",
+                          "createdBy": "987fcdeb-51a2-43d1-b567-123456789abc",
+                          "updatedAt": "2024-01-15T14:45:00Z",
+                          "updatedBy": "987fcdeb-51a2-43d1-b567-123456789abc"
+                        }
+                      }
+                    ]
+                  ],
                   "items": {
                     "allOf": [
                       {
@@ -2612,6 +2625,13 @@
                   "allOf": [
                     {
                       "$ref": "#/components/schemas/Pagination"
+                    }
+                  ],
+                  "examples": [
+                    {
+                      "offset": 0,
+                      "limit": 1,
+                      "total": 100
                     }
                   ],
                   "description": "Pagination information"
@@ -2653,6 +2673,19 @@
               "properties": {
                 "data": {
                   "type": "array",
+                  "examples": [
+                    [
+                      {
+                        "id": "123e4567-e89b-12d3-a456-426614174000",
+                        "meta": {
+                          "createdAt": "2024-01-15T10:30:00Z",
+                          "createdBy": "987fcdeb-51a2-43d1-b567-123456789abc",
+                          "updatedAt": "2024-01-15T14:45:00Z",
+                          "updatedBy": "987fcdeb-51a2-43d1-b567-123456789abc"
+                        }
+                      }
+                    ]
+                  ],
                   "items": {
                     "allOf": [
                       {
@@ -2666,6 +2699,13 @@
                   "allOf": [
                     {
                       "$ref": "#/components/schemas/Pagination"
+                    }
+                  ],
+                  "examples": [
+                    {
+                      "offset": 0,
+                      "limit": 1,
+                      "total": 100
                     }
                   ],
                   "description": "Pagination information"

--- a/testdata/school-management-api-openapi.json
+++ b/testdata/school-management-api-openapi.json
@@ -18,71 +18,6 @@
     }
   ],
   "paths": {
-    "/students/bulk-import": {
-      "post": {
-        "tags": [
-          "Students"
-        ],
-        "summary": "Bulk Import Students",
-        "description": "Import multiple students from a CSV file or structured data",
-        "operationId": "StudentsBulkImport",
-        "parameters": [
-          {
-            "name": "validateOnly",
-            "in": "query",
-            "description": "Only validate data without importing",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": false
-            }
-          }
-        ],
-        "requestBody": {
-          "$ref": "#/components/requestBodies/StudentsBulkImport"
-        },
-        "responses": {
-          "200": {
-            "description": "Successfully imported students",
-            "$ref": "#/components/responses/StudentsBulkImport"
-          },
-          "400": {
-            "description": "Bad Request error for Students BulkImport operation - request contains invalid parameters",
-            "$ref": "#/components/responses/Error400ResponseBody"
-          },
-          "401": {
-            "description": "Unauthorized error for Students BulkImport operation - authentication required",
-            "$ref": "#/components/responses/Error401ResponseBody"
-          },
-          "403": {
-            "description": "Forbidden error for Students BulkImport operation - insufficient permissions",
-            "$ref": "#/components/responses/Error403ResponseBody"
-          },
-          "404": {
-            "description": "Not Found error for Students BulkImport operation - resource does not exist",
-            "$ref": "#/components/responses/Error404ResponseBody"
-          },
-          "409": {
-            "description": "Conflict error for Students BulkImport operation - request conflicts with current state",
-            "$ref": "#/components/responses/Error409ResponseBody"
-          },
-          "422": {
-            "description": "Validation error for Students BulkImport operation - request data failed validation",
-            "$ref": "#/components/responses/StudentsBulkImport422ResponseBody"
-          },
-          "429": {
-            "description": "Rate Limit error for Students BulkImport operation - too many requests",
-            "$ref": "#/components/responses/Error429ResponseBody"
-          },
-          "500": {
-            "description": "Internal Server error for Students BulkImport operation - unexpected server error",
-            "$ref": "#/components/responses/Error500ResponseBody"
-          }
-        },
-        "x-speakeasy-group": "students",
-        "x-speakeasy-name-override": "bulkImport"
-      }
-    },
     "/students/reports/generate": {
       "post": {
         "tags": [
@@ -648,6 +583,71 @@
         },
         "x-speakeasy-group": "students",
         "x-speakeasy-name-override": "search"
+      }
+    },
+    "/students/bulk-import": {
+      "post": {
+        "tags": [
+          "Students"
+        ],
+        "summary": "Bulk Import Students",
+        "description": "Import multiple students from a CSV file or structured data",
+        "operationId": "StudentsBulkImport",
+        "parameters": [
+          {
+            "name": "validateOnly",
+            "in": "query",
+            "description": "Only validate data without importing",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/StudentsBulkImport"
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully imported students",
+            "$ref": "#/components/responses/StudentsBulkImport"
+          },
+          "400": {
+            "description": "Bad Request error for Students BulkImport operation - request contains invalid parameters",
+            "$ref": "#/components/responses/Error400ResponseBody"
+          },
+          "401": {
+            "description": "Unauthorized error for Students BulkImport operation - authentication required",
+            "$ref": "#/components/responses/Error401ResponseBody"
+          },
+          "403": {
+            "description": "Forbidden error for Students BulkImport operation - insufficient permissions",
+            "$ref": "#/components/responses/Error403ResponseBody"
+          },
+          "404": {
+            "description": "Not Found error for Students BulkImport operation - resource does not exist",
+            "$ref": "#/components/responses/Error404ResponseBody"
+          },
+          "409": {
+            "description": "Conflict error for Students BulkImport operation - request conflicts with current state",
+            "$ref": "#/components/responses/Error409ResponseBody"
+          },
+          "422": {
+            "description": "Validation error for Students BulkImport operation - request data failed validation",
+            "$ref": "#/components/responses/StudentsBulkImport422ResponseBody"
+          },
+          "429": {
+            "description": "Rate Limit error for Students BulkImport operation - too many requests",
+            "$ref": "#/components/responses/Error429ResponseBody"
+          },
+          "500": {
+            "description": "Internal Server error for Students BulkImport operation - unexpected server error",
+            "$ref": "#/components/responses/Error500ResponseBody"
+          }
+        },
+        "x-speakeasy-group": "students",
+        "x-speakeasy-name-override": "bulkImport"
       }
     }
   },
@@ -2118,25 +2118,30 @@
                 "errorFields"
               ]
             },
-            "example": {
-              "error": {
-                "code": "UnprocessableEntity",
-                "message": "Validation failed for Students BulkImport endpoint"
-              },
-              "errorFields": {
-                "students": {
-                  "firstName": {
-                    "code": "Required",
-                    "message": "firstName is required"
+            "examples": {
+              "validationError": {
+                "summary": "Validation error example",
+                "value": {
+                  "error": {
+                    "code": "UnprocessableEntity",
+                    "message": "Validation failed for Students BulkImport endpoint"
                   },
-                  "lastName": {
-                    "code": "Required",
-                    "message": "lastName is required"
+                  "errorFields": {
+                    "students": {
+                      "firstName": {
+                        "code": "Required",
+                        "message": "firstName is required"
+                      },
+                      "lastName": {
+                        "code": "Required",
+                        "message": "lastName is required"
+                      }
+                    },
+                    "overwriteExisting": {
+                      "code": "Required",
+                      "message": "overwriteExisting is required"
+                    }
                   }
-                },
-                "overwriteExisting": {
-                  "code": "Required",
-                  "message": "overwriteExisting is required"
                 }
               }
             }
@@ -2197,19 +2202,24 @@
                 "errorFields"
               ]
             },
-            "example": {
-              "error": {
-                "code": "UnprocessableEntity",
-                "message": "Validation failed for Students GenerateReport endpoint"
-              },
-              "errorFields": {
-                "gradeLevel": {
-                  "code": "Required",
-                  "message": "gradeLevel is required"
-                },
-                "status": {
-                  "code": "Required",
-                  "message": "status is required"
+            "examples": {
+              "validationError": {
+                "summary": "Validation error example",
+                "value": {
+                  "error": {
+                    "code": "UnprocessableEntity",
+                    "message": "Validation failed for Students GenerateReport endpoint"
+                  },
+                  "errorFields": {
+                    "gradeLevel": {
+                      "code": "Required",
+                      "message": "gradeLevel is required"
+                    },
+                    "status": {
+                      "code": "Required",
+                      "message": "status is required"
+                    }
+                  }
                 }
               }
             }
@@ -2274,19 +2284,24 @@
                 "errorFields"
               ]
             },
-            "example": {
-              "error": {
-                "code": "UnprocessableEntity",
-                "message": "Validation failed for Students AdvancedSearch endpoint"
-              },
-              "errorFields": {
-                "nameQuery": {
-                  "code": "Required",
-                  "message": "nameQuery is required"
-                },
-                "gradeLevel": {
-                  "code": "Required",
-                  "message": "gradeLevel is required"
+            "examples": {
+              "validationError": {
+                "summary": "Validation error example",
+                "value": {
+                  "error": {
+                    "code": "UnprocessableEntity",
+                    "message": "Validation failed for Students AdvancedSearch endpoint"
+                  },
+                  "errorFields": {
+                    "nameQuery": {
+                      "code": "Required",
+                      "message": "nameQuery is required"
+                    },
+                    "gradeLevel": {
+                      "code": "Required",
+                      "message": "gradeLevel is required"
+                    }
+                  }
                 }
               }
             }
@@ -2304,13 +2319,18 @@
                 }
               ]
             },
-            "example": {
-              "id": "123e4567-e89b-12d3-a456-426614174000",
-              "meta": {
-                "createdAt": "2024-01-15T10:30:00Z",
-                "createdBy": "987fcdeb-51a2-43d1-b567-123456789abc",
-                "updatedAt": "2024-01-15T14:45:00Z",
-                "updatedBy": "987fcdeb-51a2-43d1-b567-123456789abc"
+            "examples": {
+              "responseExample": {
+                "summary": "Response body example",
+                "value": {
+                  "id": "123e4567-e89b-12d3-a456-426614174000",
+                  "meta": {
+                    "createdAt": "2024-01-15T10:30:00Z",
+                    "createdBy": "987fcdeb-51a2-43d1-b567-123456789abc",
+                    "updatedAt": "2024-01-15T14:45:00Z",
+                    "updatedBy": "987fcdeb-51a2-43d1-b567-123456789abc"
+                  }
+                }
               }
             }
           }
@@ -2343,19 +2363,24 @@
                 "errorFields"
               ]
             },
-            "example": {
-              "error": {
-                "code": "UnprocessableEntity",
-                "message": "Validation failed for Students Create endpoint"
-              },
-              "errorFields": {
-                "firstName": {
-                  "code": "Required",
-                  "message": "firstName is required"
-                },
-                "lastName": {
-                  "code": "Required",
-                  "message": "lastName is required"
+            "examples": {
+              "validationError": {
+                "summary": "Validation error example",
+                "value": {
+                  "error": {
+                    "code": "UnprocessableEntity",
+                    "message": "Validation failed for Students Create endpoint"
+                  },
+                  "errorFields": {
+                    "firstName": {
+                      "code": "Required",
+                      "message": "firstName is required"
+                    },
+                    "lastName": {
+                      "code": "Required",
+                      "message": "lastName is required"
+                    }
+                  }
                 }
               }
             }
@@ -2373,13 +2398,18 @@
                 }
               ]
             },
-            "example": {
-              "id": "123e4567-e89b-12d3-a456-426614174000",
-              "meta": {
-                "createdAt": "2024-01-15T10:30:00Z",
-                "createdBy": "987fcdeb-51a2-43d1-b567-123456789abc",
-                "updatedAt": "2024-01-15T14:45:00Z",
-                "updatedBy": "987fcdeb-51a2-43d1-b567-123456789abc"
+            "examples": {
+              "responseExample": {
+                "summary": "Response body example",
+                "value": {
+                  "id": "123e4567-e89b-12d3-a456-426614174000",
+                  "meta": {
+                    "createdAt": "2024-01-15T10:30:00Z",
+                    "createdBy": "987fcdeb-51a2-43d1-b567-123456789abc",
+                    "updatedAt": "2024-01-15T14:45:00Z",
+                    "updatedBy": "987fcdeb-51a2-43d1-b567-123456789abc"
+                  }
+                }
               }
             }
           }
@@ -2412,19 +2442,24 @@
                 "errorFields"
               ]
             },
-            "example": {
-              "error": {
-                "code": "UnprocessableEntity",
-                "message": "Validation failed for Students Update endpoint"
-              },
-              "errorFields": {
-                "firstName": {
-                  "code": "Required",
-                  "message": "firstName is required"
-                },
-                "lastName": {
-                  "code": "Required",
-                  "message": "lastName is required"
+            "examples": {
+              "validationError": {
+                "summary": "Validation error example",
+                "value": {
+                  "error": {
+                    "code": "UnprocessableEntity",
+                    "message": "Validation failed for Students Update endpoint"
+                  },
+                  "errorFields": {
+                    "firstName": {
+                      "code": "Required",
+                      "message": "firstName is required"
+                    },
+                    "lastName": {
+                      "code": "Required",
+                      "message": "lastName is required"
+                    }
+                  }
                 }
               }
             }
@@ -2442,13 +2477,18 @@
                 }
               ]
             },
-            "example": {
-              "id": "123e4567-e89b-12d3-a456-426614174000",
-              "meta": {
-                "createdAt": "2024-01-15T10:30:00Z",
-                "createdBy": "987fcdeb-51a2-43d1-b567-123456789abc",
-                "updatedAt": "2024-01-15T14:45:00Z",
-                "updatedBy": "987fcdeb-51a2-43d1-b567-123456789abc"
+            "examples": {
+              "responseExample": {
+                "summary": "Response body example",
+                "value": {
+                  "id": "123e4567-e89b-12d3-a456-426614174000",
+                  "meta": {
+                    "createdAt": "2024-01-15T10:30:00Z",
+                    "createdBy": "987fcdeb-51a2-43d1-b567-123456789abc",
+                    "updatedAt": "2024-01-15T14:45:00Z",
+                    "updatedBy": "987fcdeb-51a2-43d1-b567-123456789abc"
+                  }
+                }
               }
             }
           }
@@ -2482,22 +2522,27 @@
                 }
               }
             },
-            "example": {
-              "data": [
-                {
-                  "id": "123e4567-e89b-12d3-a456-426614174000",
-                  "meta": {
-                    "createdAt": "2024-01-15T10:30:00Z",
-                    "createdBy": "987fcdeb-51a2-43d1-b567-123456789abc",
-                    "updatedAt": "2024-01-15T14:45:00Z",
-                    "updatedBy": "987fcdeb-51a2-43d1-b567-123456789abc"
+            "examples": {
+              "responseExample": {
+                "summary": "Response body example",
+                "value": {
+                  "data": [
+                    {
+                      "id": "123e4567-e89b-12d3-a456-426614174000",
+                      "meta": {
+                        "createdAt": "2024-01-15T10:30:00Z",
+                        "createdBy": "987fcdeb-51a2-43d1-b567-123456789abc",
+                        "updatedAt": "2024-01-15T14:45:00Z",
+                        "updatedBy": "987fcdeb-51a2-43d1-b567-123456789abc"
+                      }
+                    }
+                  ],
+                  "pagination": {
+                    "offset": 0,
+                    "limit": 1,
+                    "total": 100
                   }
                 }
-              ],
-              "pagination": {
-                "offset": 0,
-                "limit": 1,
-                "total": 100
               }
             }
           }
@@ -2531,22 +2576,27 @@
                 }
               }
             },
-            "example": {
-              "data": [
-                {
-                  "id": "123e4567-e89b-12d3-a456-426614174000",
-                  "meta": {
-                    "createdAt": "2024-01-15T10:30:00Z",
-                    "createdBy": "987fcdeb-51a2-43d1-b567-123456789abc",
-                    "updatedAt": "2024-01-15T14:45:00Z",
-                    "updatedBy": "987fcdeb-51a2-43d1-b567-123456789abc"
+            "examples": {
+              "responseExample": {
+                "summary": "Response body example",
+                "value": {
+                  "data": [
+                    {
+                      "id": "123e4567-e89b-12d3-a456-426614174000",
+                      "meta": {
+                        "createdAt": "2024-01-15T10:30:00Z",
+                        "createdBy": "987fcdeb-51a2-43d1-b567-123456789abc",
+                        "updatedAt": "2024-01-15T14:45:00Z",
+                        "updatedBy": "987fcdeb-51a2-43d1-b567-123456789abc"
+                      }
+                    }
+                  ],
+                  "pagination": {
+                    "offset": 0,
+                    "limit": 1,
+                    "total": 100
                   }
                 }
-              ],
-              "pagination": {
-                "offset": 0,
-                "limit": 1,
-                "total": 100
               }
             }
           }
@@ -2579,15 +2629,20 @@
                 "errorFields"
               ]
             },
-            "example": {
-              "error": {
-                "code": "UnprocessableEntity",
-                "message": "Validation failed for Students Search endpoint"
-              },
-              "errorFields": {
-                "filter": {
-                  "code": "Required",
-                  "message": "Filter is required"
+            "examples": {
+              "validationError": {
+                "summary": "Validation error example",
+                "value": {
+                  "error": {
+                    "code": "UnprocessableEntity",
+                    "message": "Validation failed for Students Search endpoint"
+                  },
+                  "errorFields": {
+                    "filter": {
+                      "code": "Required",
+                      "message": "Filter is required"
+                    }
+                  }
                 }
               }
             }

--- a/testdata/school-management-api-openapi.json
+++ b/testdata/school-management-api-openapi.json
@@ -18,6 +18,99 @@
     }
   ],
   "paths": {
+    "/students/_search": {
+      "post": {
+        "tags": [
+          "Students"
+        ],
+        "summary": "Search Students",
+        "description": "Search for `Students` with filtering capabilities.",
+        "operationId": "StudentsSearch",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "The maximum number of Students to return (default: 50) when searching Students",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 50
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "description": "The number of Students to skip before starting to return results (default: 0) when searching Students",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 0
+            }
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/StudentsSearch"
+        },
+        "responses": {
+          "200": {
+            "description": "Response for Students Search operation - returns filtered Students results",
+            "$ref": "#/components/responses/StudentsSearch"
+          },
+          "400": {
+            "description": "Bad Request error for Students Search operation - request contains invalid parameters",
+            "$ref": "#/components/responses/Error400ResponseBody"
+          },
+          "401": {
+            "description": "Unauthorized error for Students Search operation - authentication required",
+            "$ref": "#/components/responses/Error401ResponseBody"
+          },
+          "403": {
+            "description": "Forbidden error for Students Search operation - insufficient permissions",
+            "$ref": "#/components/responses/Error403ResponseBody"
+          },
+          "404": {
+            "description": "Not Found error for Students Search operation - resource does not exist",
+            "$ref": "#/components/responses/Error404ResponseBody"
+          },
+          "409": {
+            "description": "Conflict error for Students Search operation - request conflicts with current state",
+            "$ref": "#/components/responses/Error409ResponseBody"
+          },
+          "422": {
+            "description": "Validation error for Students Search operation - request data failed validation",
+            "$ref": "#/components/responses/StudentsSearch422ResponseBody"
+          },
+          "429": {
+            "description": "Rate Limit error for Students Search operation - too many requests",
+            "$ref": "#/components/responses/Error429ResponseBody"
+          },
+          "500": {
+            "description": "Internal Server error for Students Search operation - unexpected server error",
+            "$ref": "#/components/responses/Error500ResponseBody"
+          }
+        },
+        "x-speakeasy-pagination": {
+          "type": "offsetLimit",
+          "inputs": [
+            {
+              "name": "offset",
+              "in": "parameters",
+              "type": "offset"
+            },
+            {
+              "name": "limit",
+              "in": "parameters",
+              "type": "limit"
+            }
+          ],
+          "outputs": {
+            "results": "$.data.resultArray"
+          }
+        },
+        "x-speakeasy-group": "students",
+        "x-speakeasy-name-override": "search"
+      }
+    },
     "/students/bulk-import": {
       "post": {
         "tags": [
@@ -556,99 +649,6 @@
         "x-speakeasy-group": "students",
         "x-speakeasy-name-override": "update"
       }
-    },
-    "/students/_search": {
-      "post": {
-        "tags": [
-          "Students"
-        ],
-        "summary": "Search Students",
-        "description": "Search for `Students` with filtering capabilities.",
-        "operationId": "StudentsSearch",
-        "parameters": [
-          {
-            "name": "limit",
-            "in": "query",
-            "description": "The maximum number of Students to return (default: 50) when searching Students",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 50
-            }
-          },
-          {
-            "name": "offset",
-            "in": "query",
-            "description": "The number of Students to skip before starting to return results (default: 0) when searching Students",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 0
-            }
-          }
-        ],
-        "requestBody": {
-          "$ref": "#/components/requestBodies/StudentsSearch"
-        },
-        "responses": {
-          "200": {
-            "description": "Response for Students Search operation - returns filtered Students results",
-            "$ref": "#/components/responses/StudentsSearch"
-          },
-          "400": {
-            "description": "Bad Request error for Students Search operation - request contains invalid parameters",
-            "$ref": "#/components/responses/Error400ResponseBody"
-          },
-          "401": {
-            "description": "Unauthorized error for Students Search operation - authentication required",
-            "$ref": "#/components/responses/Error401ResponseBody"
-          },
-          "403": {
-            "description": "Forbidden error for Students Search operation - insufficient permissions",
-            "$ref": "#/components/responses/Error403ResponseBody"
-          },
-          "404": {
-            "description": "Not Found error for Students Search operation - resource does not exist",
-            "$ref": "#/components/responses/Error404ResponseBody"
-          },
-          "409": {
-            "description": "Conflict error for Students Search operation - request conflicts with current state",
-            "$ref": "#/components/responses/Error409ResponseBody"
-          },
-          "422": {
-            "description": "Validation error for Students Search operation - request data failed validation",
-            "$ref": "#/components/responses/StudentsSearch422ResponseBody"
-          },
-          "429": {
-            "description": "Rate Limit error for Students Search operation - too many requests",
-            "$ref": "#/components/responses/Error429ResponseBody"
-          },
-          "500": {
-            "description": "Internal Server error for Students Search operation - unexpected server error",
-            "$ref": "#/components/responses/Error500ResponseBody"
-          }
-        },
-        "x-speakeasy-pagination": {
-          "type": "offsetLimit",
-          "inputs": [
-            {
-              "name": "offset",
-              "in": "parameters",
-              "type": "offset"
-            },
-            {
-              "name": "limit",
-              "in": "parameters",
-              "type": "limit"
-            }
-          ],
-          "outputs": {
-            "results": "$.data.resultArray"
-          }
-        },
-        "x-speakeasy-group": "students",
-        "x-speakeasy-name-override": "search"
-      }
     }
   },
   "components": {
@@ -1011,48 +1011,6 @@
         },
         "description": "Request error object for Contact"
       },
-      "AddressRequestError": {
-        "type": "object",
-        "properties": {
-          "street": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ErrorField"
-              }
-            ],
-            "description": "Street address",
-            "nullable": true
-          },
-          "city": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ErrorField"
-              }
-            ],
-            "description": "City",
-            "nullable": true
-          },
-          "state": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ErrorField"
-              }
-            ],
-            "description": "State or province",
-            "nullable": true
-          },
-          "zipCode": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ErrorField"
-              }
-            ],
-            "description": "ZIP or postal code",
-            "nullable": true
-          }
-        },
-        "description": "Request error object for Address"
-      },
       "StudentRequestError": {
         "type": "object",
         "properties": {
@@ -1103,6 +1061,48 @@
           }
         },
         "description": "Request error object for Student"
+      },
+      "AddressRequestError": {
+        "type": "object",
+        "properties": {
+          "street": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
+            "description": "Street address",
+            "nullable": true
+          },
+          "city": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
+            "description": "City",
+            "nullable": true
+          },
+          "state": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
+            "description": "State or province",
+            "nullable": true
+          },
+          "zipCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
+            "description": "ZIP or postal code",
+            "nullable": true
+          }
+        },
+        "description": "Request error object for Address"
       },
       "StudentsBulkImportRequestError": {
         "type": "object",
@@ -2103,12 +2103,36 @@
                     {
                       "$ref": "#/components/schemas/Error"
                     }
+                  ],
+                  "examples": [
+                    {
+                      "code": "UnprocessableEntity",
+                      "message": "Validation failed for Students BulkImport endpoint"
+                    }
                   ]
                 },
                 "errorFields": {
                   "allOf": [
                     {
                       "$ref": "#/components/schemas/StudentsBulkImportRequestError"
+                    }
+                  ],
+                  "examples": [
+                    {
+                      "students": {
+                        "firstName": {
+                          "code": "Required",
+                          "message": "firstName is required"
+                        },
+                        "lastName": {
+                          "code": "Required",
+                          "message": "lastName is required"
+                        }
+                      },
+                      "overwriteExisting": {
+                        "code": "Required",
+                        "message": "overwriteExisting is required"
+                      }
                     }
                   ]
                 }
@@ -2187,12 +2211,30 @@
                     {
                       "$ref": "#/components/schemas/Error"
                     }
+                  ],
+                  "examples": [
+                    {
+                      "code": "UnprocessableEntity",
+                      "message": "Validation failed for Students GenerateReport endpoint"
+                    }
                   ]
                 },
                 "errorFields": {
                   "allOf": [
                     {
                       "$ref": "#/components/schemas/StudentsGenerateReportRequestError"
+                    }
+                  ],
+                  "examples": [
+                    {
+                      "gradeLevel": {
+                        "code": "Required",
+                        "message": "gradeLevel is required"
+                      },
+                      "status": {
+                        "code": "Required",
+                        "message": "status is required"
+                      }
                     }
                   ]
                 }
@@ -2269,12 +2311,30 @@
                     {
                       "$ref": "#/components/schemas/Error"
                     }
+                  ],
+                  "examples": [
+                    {
+                      "code": "UnprocessableEntity",
+                      "message": "Validation failed for Students AdvancedSearch endpoint"
+                    }
                   ]
                 },
                 "errorFields": {
                   "allOf": [
                     {
                       "$ref": "#/components/schemas/StudentsAdvancedSearchRequestError"
+                    }
+                  ],
+                  "examples": [
+                    {
+                      "nameQuery": {
+                        "code": "Required",
+                        "message": "nameQuery is required"
+                      },
+                      "gradeLevel": {
+                        "code": "Required",
+                        "message": "gradeLevel is required"
+                      }
                     }
                   ]
                 }
@@ -2348,12 +2408,30 @@
                     {
                       "$ref": "#/components/schemas/Error"
                     }
+                  ],
+                  "examples": [
+                    {
+                      "code": "UnprocessableEntity",
+                      "message": "Validation failed for Students Create endpoint"
+                    }
                   ]
                 },
                 "errorFields": {
                   "allOf": [
                     {
                       "$ref": "#/components/schemas/StudentsCreateRequestError"
+                    }
+                  ],
+                  "examples": [
+                    {
+                      "firstName": {
+                        "code": "Required",
+                        "message": "firstName is required"
+                      },
+                      "lastName": {
+                        "code": "Required",
+                        "message": "lastName is required"
+                      }
                     }
                   ]
                 }
@@ -2427,12 +2505,30 @@
                     {
                       "$ref": "#/components/schemas/Error"
                     }
+                  ],
+                  "examples": [
+                    {
+                      "code": "UnprocessableEntity",
+                      "message": "Validation failed for Students Update endpoint"
+                    }
                   ]
                 },
                 "errorFields": {
                   "allOf": [
                     {
                       "$ref": "#/components/schemas/StudentsUpdateRequestError"
+                    }
+                  ],
+                  "examples": [
+                    {
+                      "firstName": {
+                        "code": "Required",
+                        "message": "firstName is required"
+                      },
+                      "lastName": {
+                        "code": "Required",
+                        "message": "lastName is required"
+                      }
                     }
                   ]
                 }
@@ -2614,12 +2710,26 @@
                     {
                       "$ref": "#/components/schemas/Error"
                     }
+                  ],
+                  "examples": [
+                    {
+                      "code": "UnprocessableEntity",
+                      "message": "Validation failed for Students Search endpoint"
+                    }
                   ]
                 },
                 "errorFields": {
                   "allOf": [
                     {
                       "$ref": "#/components/schemas/StudentsSearchRequestError"
+                    }
+                  ],
+                  "examples": [
+                    {
+                      "filter": {
+                        "code": "Required",
+                        "message": "Filter is required"
+                      }
                     }
                   ]
                 }

--- a/testdata/school-management-api-openapi.json
+++ b/testdata/school-management-api-openapi.json
@@ -18,6 +18,71 @@
     }
   ],
   "paths": {
+    "/students/bulk-import": {
+      "post": {
+        "tags": [
+          "Students"
+        ],
+        "summary": "Bulk Import Students",
+        "description": "Import multiple students from a CSV file or structured data",
+        "operationId": "StudentsBulkImport",
+        "parameters": [
+          {
+            "name": "validateOnly",
+            "in": "query",
+            "description": "Only validate data without importing",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/StudentsBulkImport"
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully imported students",
+            "$ref": "#/components/responses/StudentsBulkImport"
+          },
+          "400": {
+            "description": "Bad Request error for Students BulkImport operation - request contains invalid parameters",
+            "$ref": "#/components/responses/Error400ResponseBody"
+          },
+          "401": {
+            "description": "Unauthorized error for Students BulkImport operation - authentication required",
+            "$ref": "#/components/responses/Error401ResponseBody"
+          },
+          "403": {
+            "description": "Forbidden error for Students BulkImport operation - insufficient permissions",
+            "$ref": "#/components/responses/Error403ResponseBody"
+          },
+          "404": {
+            "description": "Not Found error for Students BulkImport operation - resource does not exist",
+            "$ref": "#/components/responses/Error404ResponseBody"
+          },
+          "409": {
+            "description": "Conflict error for Students BulkImport operation - request conflicts with current state",
+            "$ref": "#/components/responses/Error409ResponseBody"
+          },
+          "422": {
+            "description": "Validation error for Students BulkImport operation - request data failed validation",
+            "$ref": "#/components/responses/StudentsBulkImport422ResponseBody"
+          },
+          "429": {
+            "description": "Rate Limit error for Students BulkImport operation - too many requests",
+            "$ref": "#/components/responses/Error429ResponseBody"
+          },
+          "500": {
+            "description": "Internal Server error for Students BulkImport operation - unexpected server error",
+            "$ref": "#/components/responses/Error500ResponseBody"
+          }
+        },
+        "x-speakeasy-group": "students",
+        "x-speakeasy-name-override": "bulkImport"
+      }
+    },
     "/students/reports/generate": {
       "post": {
         "tags": [
@@ -584,71 +649,6 @@
         "x-speakeasy-group": "students",
         "x-speakeasy-name-override": "search"
       }
-    },
-    "/students/bulk-import": {
-      "post": {
-        "tags": [
-          "Students"
-        ],
-        "summary": "Bulk Import Students",
-        "description": "Import multiple students from a CSV file or structured data",
-        "operationId": "StudentsBulkImport",
-        "parameters": [
-          {
-            "name": "validateOnly",
-            "in": "query",
-            "description": "Only validate data without importing",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": false
-            }
-          }
-        ],
-        "requestBody": {
-          "$ref": "#/components/requestBodies/StudentsBulkImport"
-        },
-        "responses": {
-          "200": {
-            "description": "Successfully imported students",
-            "$ref": "#/components/responses/StudentsBulkImport"
-          },
-          "400": {
-            "description": "Bad Request error for Students BulkImport operation - request contains invalid parameters",
-            "$ref": "#/components/responses/Error400ResponseBody"
-          },
-          "401": {
-            "description": "Unauthorized error for Students BulkImport operation - authentication required",
-            "$ref": "#/components/responses/Error401ResponseBody"
-          },
-          "403": {
-            "description": "Forbidden error for Students BulkImport operation - insufficient permissions",
-            "$ref": "#/components/responses/Error403ResponseBody"
-          },
-          "404": {
-            "description": "Not Found error for Students BulkImport operation - resource does not exist",
-            "$ref": "#/components/responses/Error404ResponseBody"
-          },
-          "409": {
-            "description": "Conflict error for Students BulkImport operation - request conflicts with current state",
-            "$ref": "#/components/responses/Error409ResponseBody"
-          },
-          "422": {
-            "description": "Validation error for Students BulkImport operation - request data failed validation",
-            "$ref": "#/components/responses/StudentsBulkImport422ResponseBody"
-          },
-          "429": {
-            "description": "Rate Limit error for Students BulkImport operation - too many requests",
-            "$ref": "#/components/responses/Error429ResponseBody"
-          },
-          "500": {
-            "description": "Internal Server error for Students BulkImport operation - unexpected server error",
-            "$ref": "#/components/responses/Error500ResponseBody"
-          }
-        },
-        "x-speakeasy-group": "students",
-        "x-speakeasy-name-override": "bulkImport"
-      }
     }
   },
   "components": {
@@ -987,57 +987,6 @@
         ],
         "description": "Student management resource"
       },
-      "StudentRequestError": {
-        "type": "object",
-        "properties": {
-          "firstName": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ErrorField"
-              }
-            ],
-            "description": "Student's first name",
-            "nullable": true
-          },
-          "lastName": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ErrorField"
-              }
-            ],
-            "description": "Student's last name",
-            "nullable": true
-          },
-          "studentId": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ErrorField"
-              }
-            ],
-            "description": "School-assigned student ID",
-            "nullable": true
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ErrorField"
-              }
-            ],
-            "description": "Current status of the student",
-            "nullable": true
-          },
-          "gradeLevel": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ErrorField"
-              }
-            ],
-            "description": "Current grade level",
-            "nullable": true
-          }
-        },
-        "description": "Request error object for Student"
-      },
       "ContactRequestError": {
         "type": "object",
         "properties": {
@@ -1103,6 +1052,57 @@
           }
         },
         "description": "Request error object for Address"
+      },
+      "StudentRequestError": {
+        "type": "object",
+        "properties": {
+          "firstName": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
+            "description": "Student's first name",
+            "nullable": true
+          },
+          "lastName": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
+            "description": "Student's last name",
+            "nullable": true
+          },
+          "studentId": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
+            "description": "School-assigned student ID",
+            "nullable": true
+          },
+          "status": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
+            "description": "Current status of the student",
+            "nullable": true
+          },
+          "gradeLevel": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
+            "description": "Current grade level",
+            "nullable": true
+          }
+        },
+        "description": "Request error object for Student"
       },
       "StudentsBulkImportRequestError": {
         "type": "object",
@@ -2101,7 +2101,7 @@
                 "error": {
                   "allOf": [
                     {
-                      "$ref": "#/components/schemas/ErrorCode"
+                      "$ref": "#/components/schemas/Error"
                     }
                   ]
                 },
@@ -2185,7 +2185,7 @@
                 "error": {
                   "allOf": [
                     {
-                      "$ref": "#/components/schemas/ErrorCode"
+                      "$ref": "#/components/schemas/Error"
                     }
                   ]
                 },
@@ -2267,7 +2267,7 @@
                 "error": {
                   "allOf": [
                     {
-                      "$ref": "#/components/schemas/ErrorCode"
+                      "$ref": "#/components/schemas/Error"
                     }
                   ]
                 },
@@ -2346,7 +2346,7 @@
                 "error": {
                   "allOf": [
                     {
-                      "$ref": "#/components/schemas/ErrorCode"
+                      "$ref": "#/components/schemas/Error"
                     }
                   ]
                 },
@@ -2425,7 +2425,7 @@
                 "error": {
                   "allOf": [
                     {
-                      "$ref": "#/components/schemas/ErrorCode"
+                      "$ref": "#/components/schemas/Error"
                     }
                   ]
                 },
@@ -2612,7 +2612,7 @@
                 "error": {
                   "allOf": [
                     {
-                      "$ref": "#/components/schemas/ErrorCode"
+                      "$ref": "#/components/schemas/Error"
                     }
                   ]
                 },


### PR DESCRIPTION
Update OpenAPI examples to use `examples` (plural) for complex objects to resolve validation warnings.

The OpenAPI 3.0+ specification requires complex object examples to be defined under the `examples` (plural) keyword, rather than `example` (singular), to allow for multiple named examples. This change addresses the `got object, want stringoas3-valid-schema-example` validation warning by correctly structuring the examples for request bodies, response bodies, and 422 error responses. Related tests have also been updated to reflect this new format.

---
Linear Issue: [INF-307](https://linear.app/meitner-se/issue/INF-307/openapi-example-warnings)

<a href="https://cursor.com/background-agent?bcId=bc-0e2a21e3-bf3d-4556-a915-c6ac6d61bd33">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0e2a21e3-bf3d-4556-a915-c6ac6d61bd33">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

