### PR TITLE
Add openapi examples to error responses

### DIFF
--- a/specification/openapi/openapi.go
+++ b/specification/openapi/openapi.go
@@ -1794,36 +1794,140 @@ func (g *Generator) createWrappedErrorSchema(service *specification.Service) *ba
 	return wrapperSchema
 }
 
+// generateStandardErrorExample generates a wrapped error example YAML node for standard error responses.
+func (g *Generator) generateStandardErrorExample(errorCode, message string) *yaml.Node {
+	// Create the wrapper object node (contains the "error" field)
+	wrapperNode := &yaml.Node{
+		Kind: yaml.MappingNode,
+	}
+
+	// Add error field key
+	errorKeyNode := &yaml.Node{
+		Kind:  yaml.ScalarNode,
+		Tag:   "!!str",
+		Value: errorFieldName,
+	}
+
+	// Create the error object node
+	errorObjectNode := &yaml.Node{
+		Kind: yaml.MappingNode,
+	}
+
+	// Add code field
+	codeKeyNode := &yaml.Node{
+		Kind:  yaml.ScalarNode,
+		Tag:   "!!str",
+		Value: codeFieldName,
+	}
+	codeValueNode := &yaml.Node{
+		Kind:  yaml.ScalarNode,
+		Tag:   "!!str",
+		Value: errorCode,
+	}
+	errorObjectNode.Content = append(errorObjectNode.Content, codeKeyNode, codeValueNode)
+
+	// Add message field
+	messageKeyNode := &yaml.Node{
+		Kind:  yaml.ScalarNode,
+		Tag:   "!!str",
+		Value: messageFieldName,
+	}
+	messageValueNode := &yaml.Node{
+		Kind:  yaml.ScalarNode,
+		Tag:   "!!str",
+		Value: message,
+	}
+	errorObjectNode.Content = append(errorObjectNode.Content, messageKeyNode, messageValueNode)
+
+	// Add the error object to the wrapper
+	wrapperNode.Content = append(wrapperNode.Content, errorKeyNode, errorObjectNode)
+
+	return wrapperNode
+}
+
 // addErrorResponseBodiesToComponents adds common error response bodies to the components section.
 func (g *Generator) addErrorResponseBodiesToComponents(components *v3.Components, service *specification.Service) {
 	// Create standard wrapped error schema
 	standardErrorSchema := g.createWrappedErrorSchema(service)
-	standardErrorContent := orderedmap.New[string, *v3.MediaType]()
-	standardMediaType := &v3.MediaType{
-		Schema: base.CreateSchemaProxy(standardErrorSchema),
-	}
-	standardErrorContent.Set(contentTypeJSON, standardMediaType)
 
-	// Define common error responses in deterministic order
+	// Define common error responses with examples in deterministic order
 	errorResponses := []struct {
 		description string
 		statusCode  string
+		errorCode   string
+		message     string
 	}{
-		{badRequestDescription, httpStatus400},
-		{unauthorizedDescription, httpStatus401},
-		{"Forbidden - Request is authenticated, but the user is not allowed to perform the operation", httpStatus403},
-		{notFoundDescription, httpStatus404},
-		{"Conflict - The request could not be completed due to a conflict", httpStatus409},
-		{"Too Many Requests - When the rate limit has been exceeded", httpStatus429},
-		{internalErrorDescription, httpStatus500},
+		{
+			badRequestDescription,
+			httpStatus400,
+			errorCodeBadRequest,
+			"The request contains invalid parameters or malformed data",
+		},
+		{
+			unauthorizedDescription,
+			httpStatus401,
+			errorCodeUnauthorized,
+			"Authentication credentials are missing or invalid",
+		},
+		{
+			"Forbidden - Request is authenticated, but the user is not allowed to perform the operation",
+			httpStatus403,
+			errorCodeForbidden,
+			"You do not have permission to perform this operation",
+		},
+		{
+			notFoundDescription,
+			httpStatus404,
+			errorCodeNotFound,
+			"The requested resource could not be found",
+		},
+		{
+			"Conflict - The request could not be completed due to a conflict",
+			httpStatus409,
+			errorCodeConflict,
+			"The request conflicts with the current state of the resource",
+		},
+		{
+			"Too Many Requests - When the rate limit has been exceeded",
+			httpStatus429,
+			errorCodeRateLimited,
+			"Too many requests - rate limit exceeded",
+		},
+		{
+			internalErrorDescription,
+			httpStatus500,
+			errorCodeInternal,
+			"An unexpected server error occurred",
+		},
 	}
 
 	for _, errorResponse := range errorResponses {
+		// Generate error example using YAML nodes
+		errorExample := g.generateStandardErrorExample(errorResponse.errorCode, errorResponse.message)
+
+		// Create MediaType with schema and examples
+		mediaType := &v3.MediaType{
+			Schema: base.CreateSchemaProxy(standardErrorSchema),
+		}
+
+		if errorExample != nil {
+			// Use Examples (plural) for complex objects per OpenAPI 3.0+ specification
+			examples := orderedmap.New[string, *base.Example]()
+			examples.Set("errorExample", &base.Example{
+				Summary: "Error response example",
+				Value:   errorExample,
+			})
+			mediaType.Examples = examples
+		}
+
+		content := orderedmap.New[string, *v3.MediaType]()
+		content.Set(contentTypeJSON, mediaType)
+
 		// Add standard error response
 		standardResponseBodyName := errorResponseBodyPrefix + errorResponse.statusCode + responseBodySuffix
 		standardResponse := &v3.Response{
 			Description: errorResponse.description,
-			Content:     standardErrorContent,
+			Content:     content,
 		}
 		components.Responses.Set(standardResponseBodyName, standardResponse)
 	}

--- a/testdata/school-management-api-expected.json
+++ b/testdata/school-management-api-expected.json
@@ -2811,6 +2811,17 @@
         "description": "Bad Request - The request was malformed or contained invalid parameters",
         "content": {
           "application/json": {
+            "examples": {
+              "errorExample": {
+                "summary": "Error response example",
+                "value": {
+                  "error": {
+                    "code": "BadRequest",
+                    "message": "The request contains invalid parameters or malformed data"
+                  }
+                }
+              }
+            },
             "schema": {
               "type": "object",
               "properties": {
@@ -2833,6 +2844,17 @@
         "description": "Unauthorized - The request is missing valid authentication credentials",
         "content": {
           "application/json": {
+            "examples": {
+              "errorExample": {
+                "summary": "Error response example",
+                "value": {
+                  "error": {
+                    "code": "Unauthorized",
+                    "message": "Authentication credentials are missing or invalid"
+                  }
+                }
+              }
+            },
             "schema": {
               "type": "object",
               "properties": {
@@ -2855,6 +2877,17 @@
         "description": "Forbidden - Request is authenticated, but the user is not allowed to perform the operation",
         "content": {
           "application/json": {
+            "examples": {
+              "errorExample": {
+                "summary": "Error response example",
+                "value": {
+                  "error": {
+                    "code": "Forbidden",
+                    "message": "You do not have permission to perform this operation"
+                  }
+                }
+              }
+            },
             "schema": {
               "type": "object",
               "properties": {
@@ -2877,6 +2910,17 @@
         "description": "Not Found - The requested resource does not exist",
         "content": {
           "application/json": {
+            "examples": {
+              "errorExample": {
+                "summary": "Error response example",
+                "value": {
+                  "error": {
+                    "code": "NotFound",
+                    "message": "The requested resource could not be found"
+                  }
+                }
+              }
+            },
             "schema": {
               "type": "object",
               "properties": {
@@ -2899,6 +2943,17 @@
         "description": "Conflict - The request could not be completed due to a conflict",
         "content": {
           "application/json": {
+            "examples": {
+              "errorExample": {
+                "summary": "Error response example",
+                "value": {
+                  "error": {
+                    "code": "Conflict",
+                    "message": "The request conflicts with the current state of the resource"
+                  }
+                }
+              }
+            },
             "schema": {
               "type": "object",
               "properties": {
@@ -2921,6 +2976,17 @@
         "description": "Too Many Requests - When the rate limit has been exceeded",
         "content": {
           "application/json": {
+            "examples": {
+              "errorExample": {
+                "summary": "Error response example",
+                "value": {
+                  "error": {
+                    "code": "RateLimited",
+                    "message": "Too many requests - rate limit exceeded"
+                  }
+                }
+              }
+            },
             "schema": {
               "type": "object",
               "properties": {
@@ -2943,6 +3009,17 @@
         "description": "Internal Server Error - An unexpected server error occurred",
         "content": {
           "application/json": {
+            "examples": {
+              "errorExample": {
+                "summary": "Error response example",
+                "value": {
+                  "error": {
+                    "code": "Internal",
+                    "message": "An unexpected server error occurred"
+                  }
+                }
+              }
+            },
             "schema": {
               "type": "object",
               "properties": {


### PR DESCRIPTION
Add OpenAPI examples to default error responses to resolve `oas3-missing-example` validation issues.

---
Linear Issue: [INF-313](https://linear.app/meitner-se/issue/INF-313/default-error-responses-are-missing-openapi-example)

<a href="https://cursor.com/background-agent?bcId=bc-420950df-6971-46b0-a4a2-27027dd3e8de">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-420950df-6971-46b0-a4a2-27027dd3e8de">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

