### PR TITLE
Add generate argument to command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,9 +106,66 @@ Common errors and solutions:
 
 ## Installation
 
+### Using the Go library
 ```bash
 go get github.com/meitner-se/publicapis-gen
 ```
+
+### Using the CLI tool
+```bash
+go install github.com/meitner-se/publicapis-gen@latest
+```
+
+## CLI Usage
+
+The CLI tool provides a `generate` command to process specification files and create OpenAPI documents, JSON schemas, and overlays.
+
+### Basic Usage
+```bash
+# Show available commands
+publicapis-gen help
+
+# Show help for generate command
+publicapis-gen help generate
+publicapis-gen generate -help
+
+# Generate from specification file (legacy mode)
+publicapis-gen generate -file=api-spec.yaml -mode=openapi -output=openapi.json
+publicapis-gen generate -file=api-spec.yaml -mode=schema -output=schemas.json
+publicapis-gen generate -file=api-spec.yaml -mode=overlay -output=complete-spec.yaml
+
+# Using config file (recommended)
+publicapis-gen generate -config=build-config.yaml
+
+# Auto-detect default config file
+publicapis-gen generate  # Looks for publicapis.yaml or publicapis.yml
+```
+
+### Configuration File Example
+Create a `publicapis.yaml` config file to process multiple specifications:
+
+```yaml
+- specification: "users-api.yaml"
+  openapi_json: "dist/users-openapi.json"
+  schema_json: "dist/users-schema.json"
+  overlay_yaml: "dist/users-complete.yaml"
+
+- specification: "products-api.yaml"  
+  openapi_yaml: "dist/products-openapi.yaml"
+  schema_json: "dist/products-schema.json"
+```
+
+### Available Modes
+- **`openapi`** - Generate OpenAPI 3.1 specification (JSON)
+- **`schema`** - Generate JSON schemas for validation  
+- **`overlay`** - Generate complete specification with overlays applied
+
+### Options
+- **`-file`** - Path to input specification file (YAML or JSON)
+- **`-mode`** - Operation mode (openapi, schema, overlay)
+- **`-output`** - Output file path (optional, auto-generated if not specified)
+- **`-config`** - Path to YAML config file for batch processing
+- **`-log-level`** - Logging verbosity (debug, info, warn, error, off)
 
 ## Running Tests
 

--- a/main_test.go
+++ b/main_test.go
@@ -66,7 +66,7 @@ func Test_run(t *testing.T) {
 		flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
 
 		// Arrange
-		os.Args = []string{"publicapis-gen"}
+		os.Args = []string{"publicapis-gen", "generate"}
 		ctx := context.Background()
 
 		// Act
@@ -82,7 +82,7 @@ func Test_run(t *testing.T) {
 		flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
 
 		// Arrange
-		os.Args = []string{"publicapis-gen", "-file=test.yaml"}
+		os.Args = []string{"publicapis-gen", "generate", "-file=test.yaml"}
 		ctx := context.Background()
 
 		// Act
@@ -98,7 +98,7 @@ func Test_run(t *testing.T) {
 		flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
 
 		// Arrange
-		os.Args = []string{"publicapis-gen", "-file=test.yaml", "-mode=invalid"}
+		os.Args = []string{"publicapis-gen", "generate", "-file=test.yaml", "-mode=invalid"}
 		ctx := context.Background()
 
 		// Act
@@ -114,7 +114,7 @@ func Test_run(t *testing.T) {
 		flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
 
 		// Arrange
-		os.Args = []string{"publicapis-gen", "-file=test.yaml", "-mode=overlay", "-log-level=invalid"}
+		os.Args = []string{"publicapis-gen", "generate", "-file=test.yaml", "-mode=overlay", "-log-level=invalid"}
 		ctx := context.Background()
 
 		// Act
@@ -130,7 +130,7 @@ func Test_run(t *testing.T) {
 		flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
 
 		// Arrange
-		os.Args = []string{"publicapis-gen", "-file=nonexistent.yaml", "-mode=overlay"}
+		os.Args = []string{"publicapis-gen", "generate", "-file=nonexistent.yaml", "-mode=overlay"}
 		ctx := context.Background()
 
 		// Act
@@ -156,7 +156,7 @@ func Test_run(t *testing.T) {
 		tmpOutputFile.Close()
 
 		// Arrange command line arguments for OpenAPI generation
-		os.Args = []string{"publicapis-gen", "-file=" + inputSpecFile, "-mode=openapi", "-output=" + tmpOutputFile.Name()}
+		os.Args = []string{"publicapis-gen", "generate", "-file=" + inputSpecFile, "-mode=openapi", "-output=" + tmpOutputFile.Name()}
 		ctx := context.Background()
 
 		// Act - run the command
@@ -215,7 +215,7 @@ func Test_run(t *testing.T) {
 		tmpConfigFile.Close()
 
 		// Arrange command line arguments for config mode
-		os.Args = []string{"publicapis-gen", "-config=" + tmpConfigFile.Name()}
+		os.Args = []string{"publicapis-gen", "generate", "-config=" + tmpConfigFile.Name()}
 		ctx := context.Background()
 
 		// Act - run the command
@@ -237,7 +237,7 @@ func Test_run(t *testing.T) {
 		flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
 
 		// Arrange command line arguments with both config and legacy flags
-		os.Args = []string{"publicapis-gen", "-config=test.yaml", "-file=spec.yaml"}
+		os.Args = []string{"publicapis-gen", "generate", "-config=test.yaml", "-file=spec.yaml"}
 		ctx := context.Background()
 
 		// Act
@@ -253,7 +253,7 @@ func Test_run(t *testing.T) {
 		flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
 
 		// Arrange command line arguments for nonexistent config
-		os.Args = []string{"publicapis-gen", "-config=nonexistent-config.yaml"}
+		os.Args = []string{"publicapis-gen", "generate", "-config=nonexistent-config.yaml"}
 		ctx := context.Background()
 
 		// Act
@@ -304,7 +304,7 @@ func Test_run(t *testing.T) {
 		flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
 
 		// Arrange command line arguments with no flags (should use default config)
-		os.Args = []string{"publicapis-gen"}
+		os.Args = []string{"publicapis-gen", "generate"}
 		ctx := context.Background()
 
 		// Act
@@ -358,7 +358,7 @@ func Test_run(t *testing.T) {
 		flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
 
 		// Arrange command line arguments with no flags (should use default config)
-		os.Args = []string{"publicapis-gen"}
+		os.Args = []string{"publicapis-gen", "generate"}
 		ctx := context.Background()
 
 		// Act
@@ -424,7 +424,7 @@ func Test_run(t *testing.T) {
 		flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
 
 		// Arrange command line arguments with no flags (should use default config)
-		os.Args = []string{"publicapis-gen"}
+		os.Args = []string{"publicapis-gen", "generate"}
 		ctx := context.Background()
 
 		// Act
@@ -467,7 +467,7 @@ func Test_run(t *testing.T) {
 		flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
 
 		// Arrange command line arguments with no flags and no default config
-		os.Args = []string{"publicapis-gen"}
+		os.Args = []string{"publicapis-gen", "generate"}
 		ctx := context.Background()
 
 		// Act


### PR DESCRIPTION
Refactor the CLI to use a `generate` subcommand, enabling future command extensibility.

---
Linear Issue: [INF-331](https://linear.app/meitner-se/issue/INF-331/add-generate-argument-to-command-line)

<a href="https://cursor.com/background-agent?bcId=bc-74334c0d-2263-4ef6-aac1-52b43a3b8cf8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-74334c0d-2263-4ef6-aac1-52b43a3b8cf8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

