### PR TITLE
Add example to external field schema

### DIFF
--- a/specification/openapi/openapi.go
+++ b/specification/openapi/openapi.go
@@ -727,6 +727,41 @@ func (g *Generator) createFieldSchema(field specification.Field, service *specif
 		}
 
 		schema.Examples = examples
+	} else if field.IsArray() && service.HasObject(field.Type) {
+		// Generate example array from object definition when no explicit example is provided
+		if obj := service.GetObject(field.Type); obj != nil {
+			if objectExample := g.generateObjectExample(*obj, service); objectExample != nil {
+				arrayNode := &yaml.Node{
+					Kind: yaml.SequenceNode,
+				}
+				arrayNode.Content = append(arrayNode.Content, objectExample)
+
+				examples := []*yaml.Node{arrayNode}
+
+				// If the field is nullable, add null as an additional example
+				if field.IsNullable() {
+					nullNode := g.createNullExampleNode()
+					examples = append(examples, nullNode)
+				}
+
+				schema.Examples = examples
+			}
+		}
+	} else if service.HasObject(field.Type) {
+		// Generate example from object definition when no explicit example is provided
+		if obj := service.GetObject(field.Type); obj != nil {
+			if objectExample := g.generateObjectExample(*obj, service); objectExample != nil {
+				examples := []*yaml.Node{objectExample}
+
+				// If the field is nullable, add null as an additional example
+				if field.IsNullable() {
+					nullNode := g.createNullExampleNode()
+					examples = append(examples, nullNode)
+				}
+
+				schema.Examples = examples
+			}
+		}
 	}
 
 	return schema

--- a/specification/openapi/openapi.go
+++ b/specification/openapi/openapi.go
@@ -735,17 +735,18 @@ func (g *Generator) createFieldSchema(field specification.Field, service *specif
 			if objectExample := g.generateObjectExampleWithVisited(*obj, service, visited); objectExample != nil {
 				arrayNode := &yaml.Node{
 					Kind: yaml.SequenceNode,
+					Tag:  "!!seq",
 				}
 				arrayNode.Content = append(arrayNode.Content, objectExample)
-
+				
 				examples := []*yaml.Node{arrayNode}
-
+				
 				// If the field is nullable, add null as an additional example
 				if field.IsNullable() {
 					nullNode := g.createNullExampleNode()
 					examples = append(examples, nullNode)
 				}
-
+				
 				schema.Examples = examples
 			}
 		}
@@ -755,13 +756,13 @@ func (g *Generator) createFieldSchema(field specification.Field, service *specif
 			visited := make(map[string]bool)
 			if objectExample := g.generateObjectExampleWithVisited(*obj, service, visited); objectExample != nil {
 				examples := []*yaml.Node{objectExample}
-
+				
 				// If the field is nullable, add null as an additional example
 				if field.IsNullable() {
 					nullNode := g.createNullExampleNode()
 					examples = append(examples, nullNode)
 				}
-
+				
 				schema.Examples = examples
 			}
 		}
@@ -1087,7 +1088,8 @@ func (g *Generator) generateRequestBodyExample(bodyParams []specification.Field,
 		if service.HasObject(field.Type) {
 			obj := service.GetObject(field.Type)
 			if obj != nil {
-				return g.generateObjectExample(*obj, service)
+				visited := make(map[string]bool)
+				return g.generateObjectExampleWithVisited(*obj, service, visited)
 			}
 		}
 		return nil
@@ -1196,7 +1198,8 @@ func (g *Generator) generateResponseBodyExample(response specification.EndpointR
 		if service.HasObject(*response.BodyObject) {
 			obj := service.GetObject(*response.BodyObject)
 			if obj != nil {
-				return g.generateObjectExample(*obj, service)
+				visited := make(map[string]bool)
+				return g.generateObjectExampleWithVisited(*obj, service, visited)
 			}
 		}
 		return nil
@@ -1423,7 +1426,8 @@ func (g *Generator) createComponentResponse(response specification.EndpointRespo
 				} else if field.IsArray() && service.HasObject(field.Type) {
 					// Generate example array from object definition
 					if obj := service.GetObject(field.Type); obj != nil {
-						if objectExample := g.generateObjectExample(*obj, service); objectExample != nil {
+						visited := make(map[string]bool)
+						if objectExample := g.generateObjectExampleWithVisited(*obj, service, visited); objectExample != nil {
 							arrayNode := &yaml.Node{
 								Kind: yaml.SequenceNode,
 							}
@@ -1434,7 +1438,8 @@ func (g *Generator) createComponentResponse(response specification.EndpointRespo
 				} else if service.HasObject(field.Type) {
 					// Generate example from object definition
 					if obj := service.GetObject(field.Type); obj != nil {
-						if objectExample := g.generateObjectExample(*obj, service); objectExample != nil {
+						visited := make(map[string]bool)
+						if objectExample := g.generateObjectExampleWithVisited(*obj, service, visited); objectExample != nil {
 							fieldSchema.Examples = []*yaml.Node{objectExample}
 						}
 					}
@@ -1587,7 +1592,8 @@ func (g *Generator) generateErrorFieldsExample(fields []specification.Field, ser
 			// For other types, try to generate from object definition or fallback to string
 			if service.HasObject(field.Type) {
 				if obj := service.GetObject(field.Type); obj != nil {
-					fieldValueNode = g.generateObjectExample(*obj, service)
+					visited := make(map[string]bool)
+					fieldValueNode = g.generateObjectExampleWithVisited(*obj, service, visited)
 				}
 			} else {
 				fieldValueNode = g.createTypedExampleNode(specification.FieldTypeString, fmt.Sprintf("Invalid %s", field.Name))
@@ -2102,7 +2108,8 @@ func (g *Generator) createResponse(response specification.EndpointResponse, reso
 				} else if field.IsArray() && service.HasObject(field.Type) {
 					// Generate example array from object definition
 					if obj := service.GetObject(field.Type); obj != nil {
-						if objectExample := g.generateObjectExample(*obj, service); objectExample != nil {
+						visited := make(map[string]bool)
+						if objectExample := g.generateObjectExampleWithVisited(*obj, service, visited); objectExample != nil {
 							arrayNode := &yaml.Node{
 								Kind: yaml.SequenceNode,
 							}
@@ -2113,7 +2120,8 @@ func (g *Generator) createResponse(response specification.EndpointResponse, reso
 				} else if service.HasObject(field.Type) {
 					// Generate example from object definition
 					if obj := service.GetObject(field.Type); obj != nil {
-						if objectExample := g.generateObjectExample(*obj, service); objectExample != nil {
+						visited := make(map[string]bool)
+						if objectExample := g.generateObjectExampleWithVisited(*obj, service, visited); objectExample != nil {
 							fieldSchema.Examples = []*yaml.Node{objectExample}
 						}
 					}

--- a/specification/openapi/openapi.go
+++ b/specification/openapi/openapi.go
@@ -1115,12 +1115,6 @@ func (g *Generator) generateRequestBodyExample(bodyParams []specification.Field,
 	return g.generateObjectExampleFromFields(bodyParams, service)
 }
 
-// generateObjectExample generates an example from an object definition.
-func (g *Generator) generateObjectExample(obj specification.Object, service *specification.Service) *yaml.Node {
-	visited := make(map[string]bool)
-	return g.generateObjectExampleWithVisited(obj, service, visited)
-}
-
 // generateObjectExampleWithVisited generates an example from an object definition with circular reference protection.
 func (g *Generator) generateObjectExampleWithVisited(obj specification.Object, service *specification.Service, visited map[string]bool) *yaml.Node {
 	// Check for circular reference

--- a/specification/openapi/openapi_test.go
+++ b/specification/openapi/openapi_test.go
@@ -3628,7 +3628,7 @@ func TestErrorFieldExamples(t *testing.T) {
 
 	// Verify the structure includes both fields in the same example object
 	assert.Contains(t, jsonString, "\"allOf\"", "Should contain allOf for ErrorField references")
-	
+
 	// Look for the pattern where we have both code and message in the same example
 	codeMessagePattern := `"code":\s*"InvalidValue"[^}]*"message"`
 	assert.Regexp(t, codeMessagePattern, jsonString, "ErrorField example should contain both code and message fields")

--- a/specification/openapi/openapi_test.go
+++ b/specification/openapi/openapi_test.go
@@ -3528,3 +3528,110 @@ func TestCircularReferenceHandling(t *testing.T) {
 
 	t.Logf("Generated JSON for circular reference test (should not hang):\n%s", jsonString)
 }
+
+func TestErrorFieldExamples(t *testing.T) {
+	generator := newGenerator()
+	service := &specification.Service{
+		Name: "ErrorFieldTestAPI",
+		Objects: []specification.Object{
+			{
+				Name:        "ErrorField",
+				Description: "Error field object with code and message",
+				Fields: []specification.Field{
+					{
+						Name:        "code",
+						Description: "Error code",
+						Type:        specification.FieldTypeString,
+					},
+					{
+						Name:        "message",
+						Description: "Error message",
+						Type:        specification.FieldTypeString,
+					},
+				},
+			},
+			{
+				Name:        "AddressRequestError",
+				Description: "Validation errors for address fields",
+				Fields: []specification.Field{
+					{
+						Name:        "postalCode",
+						Description: "The postal code of the address",
+						Type:        "ErrorField",
+						Modifiers:   []string{"Nullable"},
+					},
+					{
+						Name:        "street",
+						Description: "The street address",
+						Type:        "ErrorField",
+					},
+				},
+			},
+		},
+		Resources: []specification.Resource{
+			{
+				Name:        "Address",
+				Description: "Address resource",
+				Operations:  []string{specification.OperationCreate},
+				Fields: []specification.ResourceField{
+					{
+						Field: specification.Field{
+							Name:        "postalCode",
+							Description: "Postal code field",
+							Type:        specification.FieldTypeString,
+						},
+						Operations: []string{specification.OperationCreate},
+					},
+				},
+				Endpoints: []specification.Endpoint{
+					{
+						Name:        "Create",
+						Title:       "Create Address",
+						Description: "Create a new address",
+						Method:      "POST",
+						Path:        "",
+						Request: specification.EndpointRequest{
+							ContentType: "application/json",
+							BodyParams: []specification.Field{
+								{
+									Name:        "postalCode",
+									Description: "Postal code validation",
+									Type:        "ErrorField",
+									Modifiers:   []string{"Nullable"},
+								},
+							},
+						},
+						Response: specification.EndpointResponse{
+							ContentType: "application/json",
+							StatusCode:  201,
+							Description: "Address created successfully",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	document, err := generator.GenerateFromService(service)
+	assert.NoError(t, err, "Should generate document successfully")
+	assert.NotNil(t, document, "Document should not be nil")
+
+	// Convert to JSON to check ErrorField examples
+	jsonBytes, err := generator.ToJSON(document)
+	assert.NoError(t, err, "Should convert to JSON successfully")
+	jsonString := string(jsonBytes)
+
+	// Verify that ErrorField examples contain both code and message
+	assert.Contains(t, jsonString, "\"code\"", "ErrorField examples should contain code field")
+	assert.Contains(t, jsonString, "\"message\"", "ErrorField examples should contain message field")
+	assert.Contains(t, jsonString, "\"InvalidValue\"", "ErrorField examples should use InvalidValue as code")
+
+	// Verify the structure includes both fields in the same example object
+	assert.Contains(t, jsonString, "\"allOf\"", "Should contain allOf for ErrorField references")
+	
+	// Look for the pattern where we have both code and message in the same example
+	codeMessagePattern := `"code":\s*"InvalidValue"[^}]*"message"`
+	assert.Regexp(t, codeMessagePattern, jsonString, "ErrorField example should contain both code and message fields")
+
+	t.Logf("Generated JSON for ErrorField examples test:\n%s", jsonString)
+}

--- a/specification/openapi/openapi_test.go
+++ b/specification/openapi/openapi_test.go
@@ -3521,7 +3521,7 @@ func TestCircularReferenceHandling(t *testing.T) {
 	// Verify that circular references don't cause infinite loops
 	// PersonA should have name example but friend field should be omitted due to circular reference protection
 	assert.Contains(t, jsonString, "John Doe", "PersonA name example should be present")
-	assert.Contains(t, jsonString, "Jane Smith", "PersonB name example should be present") 
+	assert.Contains(t, jsonString, "Jane Smith", "PersonB name example should be present")
 
 	// Verify the request body example is generated successfully
 	assert.Contains(t, jsonString, "\"requestExample\"", "Request body should contain examples")

--- a/testdata/school-management-api-expected.json
+++ b/testdata/school-management-api-expected.json
@@ -18,191 +18,6 @@
     }
   ],
   "paths": {
-    "/students/{id}": {
-      "get": {
-        "tags": [
-          "Students"
-        ],
-        "summary": "Retrieve an existing Students",
-        "description": "Retrieves the `Students` with the given ID.",
-        "operationId": "StudentsGet",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "description": "The unique identifier of the Students to retrieve",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "examples": [
-                "123e4567-e89b-12d3-a456-426614174000"
-              ],
-              "format": "uuid"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Response for Students Get operation - returns the requested Students",
-            "$ref": "#/components/responses/StudentsGet"
-          },
-          "400": {
-            "description": "Bad Request error for Students Get operation - request contains invalid parameters",
-            "$ref": "#/components/responses/Error400ResponseBody"
-          },
-          "401": {
-            "description": "Unauthorized error for Students Get operation - authentication required",
-            "$ref": "#/components/responses/Error401ResponseBody"
-          },
-          "403": {
-            "description": "Forbidden error for Students Get operation - insufficient permissions",
-            "$ref": "#/components/responses/Error403ResponseBody"
-          },
-          "404": {
-            "description": "Not Found error for Students Get operation - resource does not exist",
-            "$ref": "#/components/responses/Error404ResponseBody"
-          },
-          "409": {
-            "description": "Conflict error for Students Get operation - request conflicts with current state",
-            "$ref": "#/components/responses/Error409ResponseBody"
-          },
-          "429": {
-            "description": "Rate Limit error for Students Get operation - too many requests",
-            "$ref": "#/components/responses/Error429ResponseBody"
-          },
-          "500": {
-            "description": "Internal Server error for Students Get operation - unexpected server error",
-            "$ref": "#/components/responses/Error500ResponseBody"
-          }
-        },
-        "x-speakeasy-group": "students",
-        "x-speakeasy-name-override": "get"
-      },
-      "delete": {
-        "tags": [
-          "Students"
-        ],
-        "summary": "Delete Students",
-        "description": "Delete a Students",
-        "operationId": "StudentsDelete",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "description": "The unique identifier of the Students to delete",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "examples": [
-                "123e4567-e89b-12d3-a456-426614174000"
-              ],
-              "format": "uuid"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Response for Students Delete operation - confirms successful deletion"
-          },
-          "400": {
-            "description": "Bad Request error for Students Delete operation - request contains invalid parameters",
-            "$ref": "#/components/responses/Error400ResponseBody"
-          },
-          "401": {
-            "description": "Unauthorized error for Students Delete operation - authentication required",
-            "$ref": "#/components/responses/Error401ResponseBody"
-          },
-          "403": {
-            "description": "Forbidden error for Students Delete operation - insufficient permissions",
-            "$ref": "#/components/responses/Error403ResponseBody"
-          },
-          "404": {
-            "description": "Not Found error for Students Delete operation - resource does not exist",
-            "$ref": "#/components/responses/Error404ResponseBody"
-          },
-          "409": {
-            "description": "Conflict error for Students Delete operation - request conflicts with current state",
-            "$ref": "#/components/responses/Error409ResponseBody"
-          },
-          "429": {
-            "description": "Rate Limit error for Students Delete operation - too many requests",
-            "$ref": "#/components/responses/Error429ResponseBody"
-          },
-          "500": {
-            "description": "Internal Server error for Students Delete operation - unexpected server error",
-            "$ref": "#/components/responses/Error500ResponseBody"
-          }
-        },
-        "x-speakeasy-group": "students",
-        "x-speakeasy-name-override": "delete"
-      },
-      "patch": {
-        "tags": [
-          "Students"
-        ],
-        "summary": "Update Students",
-        "description": "Update a Students",
-        "operationId": "StudentsUpdate",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "description": "The unique identifier of the Students to update",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "examples": [
-                "123e4567-e89b-12d3-a456-426614174000"
-              ],
-              "format": "uuid"
-            }
-          }
-        ],
-        "requestBody": {
-          "$ref": "#/components/requestBodies/StudentsUpdate"
-        },
-        "responses": {
-          "200": {
-            "description": "Response for Students Update operation - returns the updated Students",
-            "$ref": "#/components/responses/StudentsUpdate"
-          },
-          "400": {
-            "description": "Bad Request error for Students Update operation - request contains invalid parameters",
-            "$ref": "#/components/responses/Error400ResponseBody"
-          },
-          "401": {
-            "description": "Unauthorized error for Students Update operation - authentication required",
-            "$ref": "#/components/responses/Error401ResponseBody"
-          },
-          "403": {
-            "description": "Forbidden error for Students Update operation - insufficient permissions",
-            "$ref": "#/components/responses/Error403ResponseBody"
-          },
-          "404": {
-            "description": "Not Found error for Students Update operation - resource does not exist",
-            "$ref": "#/components/responses/Error404ResponseBody"
-          },
-          "409": {
-            "description": "Conflict error for Students Update operation - request conflicts with current state",
-            "$ref": "#/components/responses/Error409ResponseBody"
-          },
-          "422": {
-            "description": "Validation error for Students Update operation - request data failed validation",
-            "$ref": "#/components/responses/StudentsUpdate422ResponseBody"
-          },
-          "429": {
-            "description": "Rate Limit error for Students Update operation - too many requests",
-            "$ref": "#/components/responses/Error429ResponseBody"
-          },
-          "500": {
-            "description": "Internal Server error for Students Update operation - unexpected server error",
-            "$ref": "#/components/responses/Error500ResponseBody"
-          }
-        },
-        "x-speakeasy-group": "students",
-        "x-speakeasy-name-override": "update"
-      }
-    },
     "/students/_search": {
       "post": {
         "tags": [
@@ -688,6 +503,191 @@
         "x-speakeasy-group": "students",
         "x-speakeasy-name-override": "create"
       }
+    },
+    "/students/{id}": {
+      "get": {
+        "tags": [
+          "Students"
+        ],
+        "summary": "Retrieve an existing Students",
+        "description": "Retrieves the `Students` with the given ID.",
+        "operationId": "StudentsGet",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The unique identifier of the Students to retrieve",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "examples": [
+                "123e4567-e89b-12d3-a456-426614174000"
+              ],
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response for Students Get operation - returns the requested Students",
+            "$ref": "#/components/responses/StudentsGet"
+          },
+          "400": {
+            "description": "Bad Request error for Students Get operation - request contains invalid parameters",
+            "$ref": "#/components/responses/Error400ResponseBody"
+          },
+          "401": {
+            "description": "Unauthorized error for Students Get operation - authentication required",
+            "$ref": "#/components/responses/Error401ResponseBody"
+          },
+          "403": {
+            "description": "Forbidden error for Students Get operation - insufficient permissions",
+            "$ref": "#/components/responses/Error403ResponseBody"
+          },
+          "404": {
+            "description": "Not Found error for Students Get operation - resource does not exist",
+            "$ref": "#/components/responses/Error404ResponseBody"
+          },
+          "409": {
+            "description": "Conflict error for Students Get operation - request conflicts with current state",
+            "$ref": "#/components/responses/Error409ResponseBody"
+          },
+          "429": {
+            "description": "Rate Limit error for Students Get operation - too many requests",
+            "$ref": "#/components/responses/Error429ResponseBody"
+          },
+          "500": {
+            "description": "Internal Server error for Students Get operation - unexpected server error",
+            "$ref": "#/components/responses/Error500ResponseBody"
+          }
+        },
+        "x-speakeasy-group": "students",
+        "x-speakeasy-name-override": "get"
+      },
+      "delete": {
+        "tags": [
+          "Students"
+        ],
+        "summary": "Delete Students",
+        "description": "Delete a Students",
+        "operationId": "StudentsDelete",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The unique identifier of the Students to delete",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "examples": [
+                "123e4567-e89b-12d3-a456-426614174000"
+              ],
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Response for Students Delete operation - confirms successful deletion"
+          },
+          "400": {
+            "description": "Bad Request error for Students Delete operation - request contains invalid parameters",
+            "$ref": "#/components/responses/Error400ResponseBody"
+          },
+          "401": {
+            "description": "Unauthorized error for Students Delete operation - authentication required",
+            "$ref": "#/components/responses/Error401ResponseBody"
+          },
+          "403": {
+            "description": "Forbidden error for Students Delete operation - insufficient permissions",
+            "$ref": "#/components/responses/Error403ResponseBody"
+          },
+          "404": {
+            "description": "Not Found error for Students Delete operation - resource does not exist",
+            "$ref": "#/components/responses/Error404ResponseBody"
+          },
+          "409": {
+            "description": "Conflict error for Students Delete operation - request conflicts with current state",
+            "$ref": "#/components/responses/Error409ResponseBody"
+          },
+          "429": {
+            "description": "Rate Limit error for Students Delete operation - too many requests",
+            "$ref": "#/components/responses/Error429ResponseBody"
+          },
+          "500": {
+            "description": "Internal Server error for Students Delete operation - unexpected server error",
+            "$ref": "#/components/responses/Error500ResponseBody"
+          }
+        },
+        "x-speakeasy-group": "students",
+        "x-speakeasy-name-override": "delete"
+      },
+      "patch": {
+        "tags": [
+          "Students"
+        ],
+        "summary": "Update Students",
+        "description": "Update a Students",
+        "operationId": "StudentsUpdate",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The unique identifier of the Students to update",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "examples": [
+                "123e4567-e89b-12d3-a456-426614174000"
+              ],
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/StudentsUpdate"
+        },
+        "responses": {
+          "200": {
+            "description": "Response for Students Update operation - returns the updated Students",
+            "$ref": "#/components/responses/StudentsUpdate"
+          },
+          "400": {
+            "description": "Bad Request error for Students Update operation - request contains invalid parameters",
+            "$ref": "#/components/responses/Error400ResponseBody"
+          },
+          "401": {
+            "description": "Unauthorized error for Students Update operation - authentication required",
+            "$ref": "#/components/responses/Error401ResponseBody"
+          },
+          "403": {
+            "description": "Forbidden error for Students Update operation - insufficient permissions",
+            "$ref": "#/components/responses/Error403ResponseBody"
+          },
+          "404": {
+            "description": "Not Found error for Students Update operation - resource does not exist",
+            "$ref": "#/components/responses/Error404ResponseBody"
+          },
+          "409": {
+            "description": "Conflict error for Students Update operation - request conflicts with current state",
+            "$ref": "#/components/responses/Error409ResponseBody"
+          },
+          "422": {
+            "description": "Validation error for Students Update operation - request data failed validation",
+            "$ref": "#/components/responses/StudentsUpdate422ResponseBody"
+          },
+          "429": {
+            "description": "Rate Limit error for Students Update operation - too many requests",
+            "$ref": "#/components/responses/Error429ResponseBody"
+          },
+          "500": {
+            "description": "Internal Server error for Students Update operation - unexpected server error",
+            "$ref": "#/components/responses/Error500ResponseBody"
+          }
+        },
+        "x-speakeasy-group": "students",
+        "x-speakeasy-name-override": "update"
+      }
     }
   },
   "components": {
@@ -994,6 +994,14 @@
                 "$ref": "#/components/schemas/Meta"
               }
             ],
+            "examples": [
+              {
+                "createdAt": "2024-01-15T10:30:00Z",
+                "createdBy": "987fcdeb-51a2-43d1-b567-123456789abc",
+                "updatedAt": "2024-01-15T14:45:00Z",
+                "updatedBy": "987fcdeb-51a2-43d1-b567-123456789abc"
+              }
+            ],
             "description": "Metadata information for the Students"
           },
           "firstName": {
@@ -1040,6 +1048,12 @@
                 "$ref": "#/components/schemas/Contact"
               }
             ],
+            "examples": [
+              {
+                "email": "example",
+                "phone": "example"
+              }
+            ],
             "description": "Student contact information"
           },
           "address": {
@@ -1047,6 +1061,15 @@
               {
                 "$ref": "#/components/schemas/Address"
               }
+            ],
+            "examples": [
+              {
+                "street": "example",
+                "city": "example",
+                "state": "example",
+                "zipCode": "example"
+              },
+              null
             ],
             "description": "Student home address",
             "nullable": true
@@ -1081,72 +1104,6 @@
         ],
         "description": "Student management resource"
       },
-      "ContactRequestError": {
-        "type": "object",
-        "properties": {
-          "email": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ErrorField"
-              }
-            ],
-            "description": "Email address",
-            "nullable": true
-          },
-          "phone": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ErrorField"
-              }
-            ],
-            "description": "Phone number",
-            "nullable": true
-          }
-        },
-        "description": "Request error object for Contact"
-      },
-      "AddressRequestError": {
-        "type": "object",
-        "properties": {
-          "street": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ErrorField"
-              }
-            ],
-            "description": "Street address",
-            "nullable": true
-          },
-          "city": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ErrorField"
-              }
-            ],
-            "description": "City",
-            "nullable": true
-          },
-          "state": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ErrorField"
-              }
-            ],
-            "description": "State or province",
-            "nullable": true
-          },
-          "zipCode": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ErrorField"
-              }
-            ],
-            "description": "ZIP or postal code",
-            "nullable": true
-          }
-        },
-        "description": "Request error object for Address"
-      },
       "StudentRequestError": {
         "type": "object",
         "properties": {
@@ -1155,6 +1112,12 @@
               {
                 "$ref": "#/components/schemas/ErrorField"
               }
+            ],
+            "examples": [
+              {
+                "message": "example"
+              },
+              null
             ],
             "description": "Student's first name",
             "nullable": true
@@ -1165,6 +1128,12 @@
                 "$ref": "#/components/schemas/ErrorField"
               }
             ],
+            "examples": [
+              {
+                "message": "example"
+              },
+              null
+            ],
             "description": "Student's last name",
             "nullable": true
           },
@@ -1173,6 +1142,12 @@
               {
                 "$ref": "#/components/schemas/ErrorField"
               }
+            ],
+            "examples": [
+              {
+                "message": "example"
+              },
+              null
             ],
             "description": "School-assigned student ID",
             "nullable": true
@@ -1183,6 +1158,12 @@
                 "$ref": "#/components/schemas/ErrorField"
               }
             ],
+            "examples": [
+              {
+                "message": "example"
+              },
+              null
+            ],
             "description": "Current status of the student",
             "nullable": true
           },
@@ -1192,11 +1173,119 @@
                 "$ref": "#/components/schemas/ErrorField"
               }
             ],
+            "examples": [
+              {
+                "message": "example"
+              },
+              null
+            ],
             "description": "Current grade level",
             "nullable": true
           }
         },
         "description": "Request error object for Student"
+      },
+      "AddressRequestError": {
+        "type": "object",
+        "properties": {
+          "street": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
+            "examples": [
+              {
+                "message": "example"
+              },
+              null
+            ],
+            "description": "Street address",
+            "nullable": true
+          },
+          "city": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
+            "examples": [
+              {
+                "message": "example"
+              },
+              null
+            ],
+            "description": "City",
+            "nullable": true
+          },
+          "state": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
+            "examples": [
+              {
+                "message": "example"
+              },
+              null
+            ],
+            "description": "State or province",
+            "nullable": true
+          },
+          "zipCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
+            "examples": [
+              {
+                "message": "example"
+              },
+              null
+            ],
+            "description": "ZIP or postal code",
+            "nullable": true
+          }
+        },
+        "description": "Request error object for Address"
+      },
+      "ContactRequestError": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
+            "examples": [
+              {
+                "message": "example"
+              },
+              null
+            ],
+            "description": "Email address",
+            "nullable": true
+          },
+          "phone": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
+            "examples": [
+              {
+                "message": "example"
+              },
+              null
+            ],
+            "description": "Phone number",
+            "nullable": true
+          }
+        },
+        "description": "Request error object for Contact"
       },
       "StudentsBulkImportRequestError": {
         "type": "object",
@@ -1207,6 +1296,26 @@
                 "$ref": "#/components/schemas/StudentRequestError"
               }
             ],
+            "examples": [
+              {
+                "firstName": {
+                  "message": "example"
+                },
+                "lastName": {
+                  "message": "example"
+                },
+                "studentId": {
+                  "message": "example"
+                },
+                "status": {
+                  "message": "example"
+                },
+                "gradeLevel": {
+                  "message": "example"
+                }
+              },
+              null
+            ],
             "description": "Array of student data to import",
             "nullable": true
           },
@@ -1215,6 +1324,12 @@
               {
                 "$ref": "#/components/schemas/ErrorField"
               }
+            ],
+            "examples": [
+              {
+                "message": "example"
+              },
+              null
             ],
             "description": "Whether to overwrite existing student records",
             "nullable": true
@@ -1231,6 +1346,12 @@
                 "$ref": "#/components/schemas/ErrorField"
               }
             ],
+            "examples": [
+              {
+                "message": "example"
+              },
+              null
+            ],
             "description": "Filter by specific grade level",
             "nullable": true
           },
@@ -1239,6 +1360,12 @@
               {
                 "$ref": "#/components/schemas/ErrorField"
               }
+            ],
+            "examples": [
+              {
+                "message": "example"
+              },
+              null
             ],
             "description": "Filter by student status",
             "nullable": true
@@ -1249,6 +1376,12 @@
                 "$ref": "#/components/schemas/ErrorField"
               }
             ],
+            "examples": [
+              {
+                "message": "example"
+              },
+              null
+            ],
             "description": "Filter students enrolled after this date",
             "nullable": true
           },
@@ -1258,6 +1391,12 @@
                 "$ref": "#/components/schemas/ErrorField"
               }
             ],
+            "examples": [
+              {
+                "message": "example"
+              },
+              null
+            ],
             "description": "Filter students enrolled before this date",
             "nullable": true
           },
@@ -1266,6 +1405,12 @@
               {
                 "$ref": "#/components/schemas/ErrorField"
               }
+            ],
+            "examples": [
+              {
+                "message": "example"
+              },
+              null
             ],
             "description": "Include inactive students in report",
             "nullable": true
@@ -1282,6 +1427,12 @@
                 "$ref": "#/components/schemas/ErrorField"
               }
             ],
+            "examples": [
+              {
+                "message": "example"
+              },
+              null
+            ],
             "description": "Search in first name and last name",
             "nullable": true
           },
@@ -1290,6 +1441,12 @@
               {
                 "$ref": "#/components/schemas/ErrorField"
               }
+            ],
+            "examples": [
+              {
+                "message": "example"
+              },
+              null
             ],
             "description": "Filter by one or more grade levels",
             "nullable": true
@@ -1300,6 +1457,12 @@
                 "$ref": "#/components/schemas/ErrorField"
               }
             ],
+            "examples": [
+              {
+                "message": "example"
+              },
+              null
+            ],
             "description": "Filter by one or more statuses",
             "nullable": true
           },
@@ -1309,6 +1472,12 @@
                 "$ref": "#/components/schemas/ErrorField"
               }
             ],
+            "examples": [
+              {
+                "message": "example"
+              },
+              null
+            ],
             "description": "Date range filter [from, to]",
             "nullable": true
           },
@@ -1317,6 +1486,12 @@
               {
                 "$ref": "#/components/schemas/ErrorField"
               }
+            ],
+            "examples": [
+              {
+                "message": "example"
+              },
+              null
             ],
             "description": "Filter students with or without graduation date",
             "nullable": true
@@ -1333,6 +1508,12 @@
                 "$ref": "#/components/schemas/ErrorField"
               }
             ],
+            "examples": [
+              {
+                "message": "example"
+              },
+              null
+            ],
             "description": "Student's first name",
             "nullable": true
           },
@@ -1341,6 +1522,12 @@
               {
                 "$ref": "#/components/schemas/ErrorField"
               }
+            ],
+            "examples": [
+              {
+                "message": "example"
+              },
+              null
             ],
             "description": "Student's last name",
             "nullable": true
@@ -1351,6 +1538,12 @@
                 "$ref": "#/components/schemas/ErrorField"
               }
             ],
+            "examples": [
+              {
+                "message": "example"
+              },
+              null
+            ],
             "description": "School-assigned student ID",
             "nullable": true
           },
@@ -1359,6 +1552,12 @@
               {
                 "$ref": "#/components/schemas/ErrorField"
               }
+            ],
+            "examples": [
+              {
+                "message": "example"
+              },
+              null
             ],
             "description": "Current status of the student",
             "nullable": true
@@ -1369,6 +1568,12 @@
                 "$ref": "#/components/schemas/ErrorField"
               }
             ],
+            "examples": [
+              {
+                "message": "example"
+              },
+              null
+            ],
             "description": "Current grade level",
             "nullable": true
           },
@@ -1377,6 +1582,17 @@
               {
                 "$ref": "#/components/schemas/ContactRequestError"
               }
+            ],
+            "examples": [
+              {
+                "email": {
+                  "message": "example"
+                },
+                "phone": {
+                  "message": "example"
+                }
+              },
+              null
             ],
             "description": "Student contact information",
             "nullable": true
@@ -1387,6 +1603,23 @@
                 "$ref": "#/components/schemas/AddressRequestError"
               }
             ],
+            "examples": [
+              {
+                "street": {
+                  "message": "example"
+                },
+                "city": {
+                  "message": "example"
+                },
+                "state": {
+                  "message": "example"
+                },
+                "zipCode": {
+                  "message": "example"
+                }
+              },
+              null
+            ],
             "description": "Student home address",
             "nullable": true
           },
@@ -1395,6 +1628,12 @@
               {
                 "$ref": "#/components/schemas/ErrorField"
               }
+            ],
+            "examples": [
+              {
+                "message": "example"
+              },
+              null
             ],
             "description": "Date when student was enrolled",
             "nullable": true
@@ -1411,6 +1650,12 @@
                 "$ref": "#/components/schemas/ErrorField"
               }
             ],
+            "examples": [
+              {
+                "message": "example"
+              },
+              null
+            ],
             "description": "Student's first name",
             "nullable": true
           },
@@ -1419,6 +1664,12 @@
               {
                 "$ref": "#/components/schemas/ErrorField"
               }
+            ],
+            "examples": [
+              {
+                "message": "example"
+              },
+              null
             ],
             "description": "Student's last name",
             "nullable": true
@@ -1429,6 +1680,12 @@
                 "$ref": "#/components/schemas/ErrorField"
               }
             ],
+            "examples": [
+              {
+                "message": "example"
+              },
+              null
+            ],
             "description": "Current status of the student",
             "nullable": true
           },
@@ -1437,6 +1694,12 @@
               {
                 "$ref": "#/components/schemas/ErrorField"
               }
+            ],
+            "examples": [
+              {
+                "message": "example"
+              },
+              null
             ],
             "description": "Current grade level",
             "nullable": true
@@ -1447,6 +1710,17 @@
                 "$ref": "#/components/schemas/ContactRequestError"
               }
             ],
+            "examples": [
+              {
+                "email": {
+                  "message": "example"
+                },
+                "phone": {
+                  "message": "example"
+                }
+              },
+              null
+            ],
             "description": "Student contact information",
             "nullable": true
           },
@@ -1456,6 +1730,23 @@
                 "$ref": "#/components/schemas/AddressRequestError"
               }
             ],
+            "examples": [
+              {
+                "street": {
+                  "message": "example"
+                },
+                "city": {
+                  "message": "example"
+                },
+                "state": {
+                  "message": "example"
+                },
+                "zipCode": {
+                  "message": "example"
+                }
+              },
+              null
+            ],
             "description": "Student home address",
             "nullable": true
           },
@@ -1464,6 +1755,12 @@
               {
                 "$ref": "#/components/schemas/ErrorField"
               }
+            ],
+            "examples": [
+              {
+                "message": "example"
+              },
+              null
             ],
             "description": "Expected or actual graduation date",
             "nullable": true
@@ -1491,6 +1788,13 @@
                 "$ref": "#/components/schemas/ContactFilterEquals"
               }
             ],
+            "examples": [
+              {
+                "email": "example",
+                "phone": "example"
+              },
+              null
+            ],
             "description": "Equality filters for Contact",
             "nullable": true
           },
@@ -1499,6 +1803,13 @@
               {
                 "$ref": "#/components/schemas/ContactFilterEquals"
               }
+            ],
+            "examples": [
+              {
+                "email": "example",
+                "phone": "example"
+              },
+              null
             ],
             "description": "Inequality filters for Contact",
             "nullable": true
@@ -1545,6 +1856,17 @@
                 "$ref": "#/components/schemas/ContactFilterContains"
               }
             ],
+            "examples": [
+              {
+                "email": [
+                  "example"
+                ],
+                "phone": [
+                  "example"
+                ]
+              },
+              null
+            ],
             "description": "Contains filters for Contact",
             "nullable": true
           },
@@ -1553,6 +1875,17 @@
               {
                 "$ref": "#/components/schemas/ContactFilterContains"
               }
+            ],
+            "examples": [
+              {
+                "email": [
+                  "example"
+                ],
+                "phone": [
+                  "example"
+                ]
+              },
+              null
             ],
             "description": "Not contains filters for Contact",
             "nullable": true
@@ -1563,6 +1896,13 @@
                 "$ref": "#/components/schemas/ContactFilterLike"
               }
             ],
+            "examples": [
+              {
+                "email": "example",
+                "phone": "example"
+              },
+              null
+            ],
             "description": "LIKE filters for Contact",
             "nullable": true
           },
@@ -1571,6 +1911,13 @@
               {
                 "$ref": "#/components/schemas/ContactFilterLike"
               }
+            ],
+            "examples": [
+              {
+                "email": "example",
+                "phone": "example"
+              },
+              null
             ],
             "description": "NOT LIKE filters for Contact",
             "nullable": true
@@ -1581,6 +1928,12 @@
                 "$ref": "#/components/schemas/ContactFilterNull"
               }
             ],
+            "examples": [
+              {
+                "phone": true
+              },
+              null
+            ],
             "description": "Null filters for Contact",
             "nullable": true
           },
@@ -1589,6 +1942,12 @@
               {
                 "$ref": "#/components/schemas/ContactFilterNull"
               }
+            ],
+            "examples": [
+              {
+                "phone": true
+              },
+              null
             ],
             "description": "Not null filters for Contact",
             "nullable": true
@@ -1602,6 +1961,51 @@
           },
           "nestedFilters": {
             "type": "array",
+            "examples": [
+              [
+                {
+                  "equals": {
+                    "email": "example",
+                    "phone": "example"
+                  },
+                  "notEquals": {
+                    "email": "example",
+                    "phone": "example"
+                  },
+                  "contains": {
+                    "email": [
+                      "example"
+                    ],
+                    "phone": [
+                      "example"
+                    ]
+                  },
+                  "notContains": {
+                    "email": [
+                      "example"
+                    ],
+                    "phone": [
+                      "example"
+                    ]
+                  },
+                  "like": {
+                    "email": "example",
+                    "phone": "example"
+                  },
+                  "notLike": {
+                    "email": "example",
+                    "phone": "example"
+                  },
+                  "null": {
+                    "phone": true
+                  },
+                  "notNull": {
+                    "phone": true
+                  },
+                  "orCondition": true
+                }
+              ]
+            ],
             "items": {
               "allOf": [
                 {
@@ -1723,6 +2127,15 @@
                 "$ref": "#/components/schemas/AddressFilterEquals"
               }
             ],
+            "examples": [
+              {
+                "street": "example",
+                "city": "example",
+                "state": "example",
+                "zipCode": "example"
+              },
+              null
+            ],
             "description": "Equality filters for Address",
             "nullable": true
           },
@@ -1731,6 +2144,15 @@
               {
                 "$ref": "#/components/schemas/AddressFilterEquals"
               }
+            ],
+            "examples": [
+              {
+                "street": "example",
+                "city": "example",
+                "state": "example",
+                "zipCode": "example"
+              },
+              null
             ],
             "description": "Inequality filters for Address",
             "nullable": true
@@ -1777,6 +2199,23 @@
                 "$ref": "#/components/schemas/AddressFilterContains"
               }
             ],
+            "examples": [
+              {
+                "street": [
+                  "example"
+                ],
+                "city": [
+                  "example"
+                ],
+                "state": [
+                  "example"
+                ],
+                "zipCode": [
+                  "example"
+                ]
+              },
+              null
+            ],
             "description": "Contains filters for Address",
             "nullable": true
           },
@@ -1785,6 +2224,23 @@
               {
                 "$ref": "#/components/schemas/AddressFilterContains"
               }
+            ],
+            "examples": [
+              {
+                "street": [
+                  "example"
+                ],
+                "city": [
+                  "example"
+                ],
+                "state": [
+                  "example"
+                ],
+                "zipCode": [
+                  "example"
+                ]
+              },
+              null
             ],
             "description": "Not contains filters for Address",
             "nullable": true
@@ -1795,6 +2251,15 @@
                 "$ref": "#/components/schemas/AddressFilterLike"
               }
             ],
+            "examples": [
+              {
+                "street": "example",
+                "city": "example",
+                "state": "example",
+                "zipCode": "example"
+              },
+              null
+            ],
             "description": "LIKE filters for Address",
             "nullable": true
           },
@@ -1803,6 +2268,15 @@
               {
                 "$ref": "#/components/schemas/AddressFilterLike"
               }
+            ],
+            "examples": [
+              {
+                "street": "example",
+                "city": "example",
+                "state": "example",
+                "zipCode": "example"
+              },
+              null
             ],
             "description": "NOT LIKE filters for Address",
             "nullable": true
@@ -1834,6 +2308,65 @@
           },
           "nestedFilters": {
             "type": "array",
+            "examples": [
+              [
+                {
+                  "equals": {
+                    "street": "example",
+                    "city": "example",
+                    "state": "example",
+                    "zipCode": "example"
+                  },
+                  "notEquals": {
+                    "street": "example",
+                    "city": "example",
+                    "state": "example",
+                    "zipCode": "example"
+                  },
+                  "contains": {
+                    "street": [
+                      "example"
+                    ],
+                    "city": [
+                      "example"
+                    ],
+                    "state": [
+                      "example"
+                    ],
+                    "zipCode": [
+                      "example"
+                    ]
+                  },
+                  "notContains": {
+                    "street": [
+                      "example"
+                    ],
+                    "city": [
+                      "example"
+                    ],
+                    "state": [
+                      "example"
+                    ],
+                    "zipCode": [
+                      "example"
+                    ]
+                  },
+                  "like": {
+                    "street": "example",
+                    "city": "example",
+                    "state": "example",
+                    "zipCode": "example"
+                  },
+                  "notLike": {
+                    "street": "example",
+                    "city": "example",
+                    "state": "example",
+                    "zipCode": "example"
+                  },
+                  "orCondition": true
+                }
+              ]
+            ],
             "items": {
               "allOf": [
                 {
@@ -2004,6 +2537,14 @@
                 "$ref": "#/components/schemas/StudentFilterEquals"
               }
             ],
+            "examples": [
+              {
+                "firstName": "example",
+                "lastName": "example",
+                "studentId": "example"
+              },
+              null
+            ],
             "description": "Equality filters for Student",
             "nullable": true
           },
@@ -2012,6 +2553,14 @@
               {
                 "$ref": "#/components/schemas/StudentFilterEquals"
               }
+            ],
+            "examples": [
+              {
+                "firstName": "example",
+                "lastName": "example",
+                "studentId": "example"
+              },
+              null
             ],
             "description": "Inequality filters for Student",
             "nullable": true
@@ -2058,6 +2607,20 @@
                 "$ref": "#/components/schemas/StudentFilterContains"
               }
             ],
+            "examples": [
+              {
+                "firstName": [
+                  "example"
+                ],
+                "lastName": [
+                  "example"
+                ],
+                "studentId": [
+                  "example"
+                ]
+              },
+              null
+            ],
             "description": "Contains filters for Student",
             "nullable": true
           },
@@ -2066,6 +2629,20 @@
               {
                 "$ref": "#/components/schemas/StudentFilterContains"
               }
+            ],
+            "examples": [
+              {
+                "firstName": [
+                  "example"
+                ],
+                "lastName": [
+                  "example"
+                ],
+                "studentId": [
+                  "example"
+                ]
+              },
+              null
             ],
             "description": "Not contains filters for Student",
             "nullable": true
@@ -2076,6 +2653,14 @@
                 "$ref": "#/components/schemas/StudentFilterLike"
               }
             ],
+            "examples": [
+              {
+                "firstName": "example",
+                "lastName": "example",
+                "studentId": "example"
+              },
+              null
+            ],
             "description": "LIKE filters for Student",
             "nullable": true
           },
@@ -2084,6 +2669,14 @@
               {
                 "$ref": "#/components/schemas/StudentFilterLike"
               }
+            ],
+            "examples": [
+              {
+                "firstName": "example",
+                "lastName": "example",
+                "studentId": "example"
+              },
+              null
             ],
             "description": "NOT LIKE filters for Student",
             "nullable": true
@@ -2115,6 +2708,55 @@
           },
           "nestedFilters": {
             "type": "array",
+            "examples": [
+              [
+                {
+                  "equals": {
+                    "firstName": "example",
+                    "lastName": "example",
+                    "studentId": "example"
+                  },
+                  "notEquals": {
+                    "firstName": "example",
+                    "lastName": "example",
+                    "studentId": "example"
+                  },
+                  "contains": {
+                    "firstName": [
+                      "example"
+                    ],
+                    "lastName": [
+                      "example"
+                    ],
+                    "studentId": [
+                      "example"
+                    ]
+                  },
+                  "notContains": {
+                    "firstName": [
+                      "example"
+                    ],
+                    "lastName": [
+                      "example"
+                    ],
+                    "studentId": [
+                      "example"
+                    ]
+                  },
+                  "like": {
+                    "firstName": "example",
+                    "lastName": "example",
+                    "studentId": "example"
+                  },
+                  "notLike": {
+                    "firstName": "example",
+                    "lastName": "example",
+                    "studentId": "example"
+                  },
+                  "orCondition": true
+                }
+              ]
+            ],
             "items": {
               "allOf": [
                 {
@@ -3479,6 +4121,15 @@
               "properties": {
                 "students": {
                   "type": "array",
+                  "examples": [
+                    [
+                      {
+                        "firstName": "example",
+                        "lastName": "example",
+                        "studentId": "example"
+                      }
+                    ]
+                  ],
                   "items": {
                     "allOf": [
                       {
@@ -3719,6 +4370,12 @@
                       "$ref": "#/components/schemas/Contact"
                     }
                   ],
+                  "examples": [
+                    {
+                      "email": "example",
+                      "phone": "example"
+                    }
+                  ],
                   "description": "Student contact information"
                 },
                 "address": {
@@ -3726,6 +4383,15 @@
                     {
                       "$ref": "#/components/schemas/Address"
                     }
+                  ],
+                  "examples": [
+                    {
+                      "street": "example",
+                      "city": "example",
+                      "state": "example",
+                      "zipCode": "example"
+                    },
+                    null
                   ],
                   "description": "Student home address",
                   "nullable": true
@@ -3816,6 +4482,12 @@
                       "$ref": "#/components/schemas/Contact"
                     }
                   ],
+                  "examples": [
+                    {
+                      "email": "example",
+                      "phone": "example"
+                    }
+                  ],
                   "description": "Student contact information"
                 },
                 "address": {
@@ -3823,6 +4495,15 @@
                     {
                       "$ref": "#/components/schemas/Address"
                     }
+                  ],
+                  "examples": [
+                    {
+                      "street": "example",
+                      "city": "example",
+                      "state": "example",
+                      "zipCode": "example"
+                    },
+                    null
                   ],
                   "description": "Student home address",
                   "nullable": true

--- a/testdata/school-management-api-expected.json
+++ b/testdata/school-management-api-expected.json
@@ -18,6 +18,335 @@
     }
   ],
   "paths": {
+    "/students": {
+      "get": {
+        "tags": [
+          "Students"
+        ],
+        "summary": "List all Students",
+        "description": "Returns a paginated list of all `Students` in your organization.",
+        "operationId": "StudentsList",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "The maximum number of Students to return (default: 50) when listing Students",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "examples": [
+                1
+              ],
+              "default": 50
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "description": "The number of Students to skip before starting to return results (default: 0) when listing Students",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "examples": [
+                0
+              ],
+              "default": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response for Students List operation - returns a paginated list of Students",
+            "$ref": "#/components/responses/StudentsList"
+          },
+          "400": {
+            "description": "Bad Request error for Students List operation - request contains invalid parameters",
+            "$ref": "#/components/responses/Error400ResponseBody"
+          },
+          "401": {
+            "description": "Unauthorized error for Students List operation - authentication required",
+            "$ref": "#/components/responses/Error401ResponseBody"
+          },
+          "403": {
+            "description": "Forbidden error for Students List operation - insufficient permissions",
+            "$ref": "#/components/responses/Error403ResponseBody"
+          },
+          "404": {
+            "description": "Not Found error for Students List operation - resource does not exist",
+            "$ref": "#/components/responses/Error404ResponseBody"
+          },
+          "409": {
+            "description": "Conflict error for Students List operation - request conflicts with current state",
+            "$ref": "#/components/responses/Error409ResponseBody"
+          },
+          "429": {
+            "description": "Rate Limit error for Students List operation - too many requests",
+            "$ref": "#/components/responses/Error429ResponseBody"
+          },
+          "500": {
+            "description": "Internal Server error for Students List operation - unexpected server error",
+            "$ref": "#/components/responses/Error500ResponseBody"
+          }
+        },
+        "x-speakeasy-pagination": {
+          "type": "offsetLimit",
+          "inputs": [
+            {
+              "name": "offset",
+              "in": "parameters",
+              "type": "offset"
+            },
+            {
+              "name": "limit",
+              "in": "parameters",
+              "type": "limit"
+            }
+          ],
+          "outputs": {
+            "results": "$.data.resultArray"
+          }
+        },
+        "x-speakeasy-group": "students",
+        "x-speakeasy-name-override": "list"
+      },
+      "post": {
+        "tags": [
+          "Students"
+        ],
+        "summary": "Create Students",
+        "description": "Create a new Students",
+        "operationId": "StudentsCreate",
+        "parameters": [],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/StudentsCreate"
+        },
+        "responses": {
+          "201": {
+            "description": "Response for Students Create operation - returns the created Students",
+            "$ref": "#/components/responses/StudentsCreate"
+          },
+          "400": {
+            "description": "Bad Request error for Students Create operation - request contains invalid parameters",
+            "$ref": "#/components/responses/Error400ResponseBody"
+          },
+          "401": {
+            "description": "Unauthorized error for Students Create operation - authentication required",
+            "$ref": "#/components/responses/Error401ResponseBody"
+          },
+          "403": {
+            "description": "Forbidden error for Students Create operation - insufficient permissions",
+            "$ref": "#/components/responses/Error403ResponseBody"
+          },
+          "404": {
+            "description": "Not Found error for Students Create operation - resource does not exist",
+            "$ref": "#/components/responses/Error404ResponseBody"
+          },
+          "409": {
+            "description": "Conflict error for Students Create operation - request conflicts with current state",
+            "$ref": "#/components/responses/Error409ResponseBody"
+          },
+          "422": {
+            "description": "Validation error for Students Create operation - request data failed validation",
+            "$ref": "#/components/responses/StudentsCreate422ResponseBody"
+          },
+          "429": {
+            "description": "Rate Limit error for Students Create operation - too many requests",
+            "$ref": "#/components/responses/Error429ResponseBody"
+          },
+          "500": {
+            "description": "Internal Server error for Students Create operation - unexpected server error",
+            "$ref": "#/components/responses/Error500ResponseBody"
+          }
+        },
+        "x-speakeasy-group": "students",
+        "x-speakeasy-name-override": "create"
+      }
+    },
+    "/students/{id}": {
+      "get": {
+        "tags": [
+          "Students"
+        ],
+        "summary": "Retrieve an existing Students",
+        "description": "Retrieves the `Students` with the given ID.",
+        "operationId": "StudentsGet",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The unique identifier of the Students to retrieve",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "examples": [
+                "123e4567-e89b-12d3-a456-426614174000"
+              ],
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response for Students Get operation - returns the requested Students",
+            "$ref": "#/components/responses/StudentsGet"
+          },
+          "400": {
+            "description": "Bad Request error for Students Get operation - request contains invalid parameters",
+            "$ref": "#/components/responses/Error400ResponseBody"
+          },
+          "401": {
+            "description": "Unauthorized error for Students Get operation - authentication required",
+            "$ref": "#/components/responses/Error401ResponseBody"
+          },
+          "403": {
+            "description": "Forbidden error for Students Get operation - insufficient permissions",
+            "$ref": "#/components/responses/Error403ResponseBody"
+          },
+          "404": {
+            "description": "Not Found error for Students Get operation - resource does not exist",
+            "$ref": "#/components/responses/Error404ResponseBody"
+          },
+          "409": {
+            "description": "Conflict error for Students Get operation - request conflicts with current state",
+            "$ref": "#/components/responses/Error409ResponseBody"
+          },
+          "429": {
+            "description": "Rate Limit error for Students Get operation - too many requests",
+            "$ref": "#/components/responses/Error429ResponseBody"
+          },
+          "500": {
+            "description": "Internal Server error for Students Get operation - unexpected server error",
+            "$ref": "#/components/responses/Error500ResponseBody"
+          }
+        },
+        "x-speakeasy-group": "students",
+        "x-speakeasy-name-override": "get"
+      },
+      "delete": {
+        "tags": [
+          "Students"
+        ],
+        "summary": "Delete Students",
+        "description": "Delete a Students",
+        "operationId": "StudentsDelete",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The unique identifier of the Students to delete",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "examples": [
+                "123e4567-e89b-12d3-a456-426614174000"
+              ],
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Response for Students Delete operation - confirms successful deletion"
+          },
+          "400": {
+            "description": "Bad Request error for Students Delete operation - request contains invalid parameters",
+            "$ref": "#/components/responses/Error400ResponseBody"
+          },
+          "401": {
+            "description": "Unauthorized error for Students Delete operation - authentication required",
+            "$ref": "#/components/responses/Error401ResponseBody"
+          },
+          "403": {
+            "description": "Forbidden error for Students Delete operation - insufficient permissions",
+            "$ref": "#/components/responses/Error403ResponseBody"
+          },
+          "404": {
+            "description": "Not Found error for Students Delete operation - resource does not exist",
+            "$ref": "#/components/responses/Error404ResponseBody"
+          },
+          "409": {
+            "description": "Conflict error for Students Delete operation - request conflicts with current state",
+            "$ref": "#/components/responses/Error409ResponseBody"
+          },
+          "429": {
+            "description": "Rate Limit error for Students Delete operation - too many requests",
+            "$ref": "#/components/responses/Error429ResponseBody"
+          },
+          "500": {
+            "description": "Internal Server error for Students Delete operation - unexpected server error",
+            "$ref": "#/components/responses/Error500ResponseBody"
+          }
+        },
+        "x-speakeasy-group": "students",
+        "x-speakeasy-name-override": "delete"
+      },
+      "patch": {
+        "tags": [
+          "Students"
+        ],
+        "summary": "Update Students",
+        "description": "Update a Students",
+        "operationId": "StudentsUpdate",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The unique identifier of the Students to update",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "examples": [
+                "123e4567-e89b-12d3-a456-426614174000"
+              ],
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/StudentsUpdate"
+        },
+        "responses": {
+          "200": {
+            "description": "Response for Students Update operation - returns the updated Students",
+            "$ref": "#/components/responses/StudentsUpdate"
+          },
+          "400": {
+            "description": "Bad Request error for Students Update operation - request contains invalid parameters",
+            "$ref": "#/components/responses/Error400ResponseBody"
+          },
+          "401": {
+            "description": "Unauthorized error for Students Update operation - authentication required",
+            "$ref": "#/components/responses/Error401ResponseBody"
+          },
+          "403": {
+            "description": "Forbidden error for Students Update operation - insufficient permissions",
+            "$ref": "#/components/responses/Error403ResponseBody"
+          },
+          "404": {
+            "description": "Not Found error for Students Update operation - resource does not exist",
+            "$ref": "#/components/responses/Error404ResponseBody"
+          },
+          "409": {
+            "description": "Conflict error for Students Update operation - request conflicts with current state",
+            "$ref": "#/components/responses/Error409ResponseBody"
+          },
+          "422": {
+            "description": "Validation error for Students Update operation - request data failed validation",
+            "$ref": "#/components/responses/StudentsUpdate422ResponseBody"
+          },
+          "429": {
+            "description": "Rate Limit error for Students Update operation - too many requests",
+            "$ref": "#/components/responses/Error429ResponseBody"
+          },
+          "500": {
+            "description": "Internal Server error for Students Update operation - unexpected server error",
+            "$ref": "#/components/responses/Error500ResponseBody"
+          }
+        },
+        "x-speakeasy-group": "students",
+        "x-speakeasy-name-override": "update"
+      }
+    },
     "/students/_search": {
       "post": {
         "tags": [
@@ -358,335 +687,6 @@
         },
         "x-speakeasy-group": "students",
         "x-speakeasy-name-override": "advancedSearch"
-      }
-    },
-    "/students": {
-      "get": {
-        "tags": [
-          "Students"
-        ],
-        "summary": "List all Students",
-        "description": "Returns a paginated list of all `Students` in your organization.",
-        "operationId": "StudentsList",
-        "parameters": [
-          {
-            "name": "limit",
-            "in": "query",
-            "description": "The maximum number of Students to return (default: 50) when listing Students",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "examples": [
-                1
-              ],
-              "default": 50
-            }
-          },
-          {
-            "name": "offset",
-            "in": "query",
-            "description": "The number of Students to skip before starting to return results (default: 0) when listing Students",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "examples": [
-                0
-              ],
-              "default": 0
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Response for Students List operation - returns a paginated list of Students",
-            "$ref": "#/components/responses/StudentsList"
-          },
-          "400": {
-            "description": "Bad Request error for Students List operation - request contains invalid parameters",
-            "$ref": "#/components/responses/Error400ResponseBody"
-          },
-          "401": {
-            "description": "Unauthorized error for Students List operation - authentication required",
-            "$ref": "#/components/responses/Error401ResponseBody"
-          },
-          "403": {
-            "description": "Forbidden error for Students List operation - insufficient permissions",
-            "$ref": "#/components/responses/Error403ResponseBody"
-          },
-          "404": {
-            "description": "Not Found error for Students List operation - resource does not exist",
-            "$ref": "#/components/responses/Error404ResponseBody"
-          },
-          "409": {
-            "description": "Conflict error for Students List operation - request conflicts with current state",
-            "$ref": "#/components/responses/Error409ResponseBody"
-          },
-          "429": {
-            "description": "Rate Limit error for Students List operation - too many requests",
-            "$ref": "#/components/responses/Error429ResponseBody"
-          },
-          "500": {
-            "description": "Internal Server error for Students List operation - unexpected server error",
-            "$ref": "#/components/responses/Error500ResponseBody"
-          }
-        },
-        "x-speakeasy-pagination": {
-          "type": "offsetLimit",
-          "inputs": [
-            {
-              "name": "offset",
-              "in": "parameters",
-              "type": "offset"
-            },
-            {
-              "name": "limit",
-              "in": "parameters",
-              "type": "limit"
-            }
-          ],
-          "outputs": {
-            "results": "$.data.resultArray"
-          }
-        },
-        "x-speakeasy-group": "students",
-        "x-speakeasy-name-override": "list"
-      },
-      "post": {
-        "tags": [
-          "Students"
-        ],
-        "summary": "Create Students",
-        "description": "Create a new Students",
-        "operationId": "StudentsCreate",
-        "parameters": [],
-        "requestBody": {
-          "$ref": "#/components/requestBodies/StudentsCreate"
-        },
-        "responses": {
-          "201": {
-            "description": "Response for Students Create operation - returns the created Students",
-            "$ref": "#/components/responses/StudentsCreate"
-          },
-          "400": {
-            "description": "Bad Request error for Students Create operation - request contains invalid parameters",
-            "$ref": "#/components/responses/Error400ResponseBody"
-          },
-          "401": {
-            "description": "Unauthorized error for Students Create operation - authentication required",
-            "$ref": "#/components/responses/Error401ResponseBody"
-          },
-          "403": {
-            "description": "Forbidden error for Students Create operation - insufficient permissions",
-            "$ref": "#/components/responses/Error403ResponseBody"
-          },
-          "404": {
-            "description": "Not Found error for Students Create operation - resource does not exist",
-            "$ref": "#/components/responses/Error404ResponseBody"
-          },
-          "409": {
-            "description": "Conflict error for Students Create operation - request conflicts with current state",
-            "$ref": "#/components/responses/Error409ResponseBody"
-          },
-          "422": {
-            "description": "Validation error for Students Create operation - request data failed validation",
-            "$ref": "#/components/responses/StudentsCreate422ResponseBody"
-          },
-          "429": {
-            "description": "Rate Limit error for Students Create operation - too many requests",
-            "$ref": "#/components/responses/Error429ResponseBody"
-          },
-          "500": {
-            "description": "Internal Server error for Students Create operation - unexpected server error",
-            "$ref": "#/components/responses/Error500ResponseBody"
-          }
-        },
-        "x-speakeasy-group": "students",
-        "x-speakeasy-name-override": "create"
-      }
-    },
-    "/students/{id}": {
-      "get": {
-        "tags": [
-          "Students"
-        ],
-        "summary": "Retrieve an existing Students",
-        "description": "Retrieves the `Students` with the given ID.",
-        "operationId": "StudentsGet",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "description": "The unique identifier of the Students to retrieve",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "examples": [
-                "123e4567-e89b-12d3-a456-426614174000"
-              ],
-              "format": "uuid"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Response for Students Get operation - returns the requested Students",
-            "$ref": "#/components/responses/StudentsGet"
-          },
-          "400": {
-            "description": "Bad Request error for Students Get operation - request contains invalid parameters",
-            "$ref": "#/components/responses/Error400ResponseBody"
-          },
-          "401": {
-            "description": "Unauthorized error for Students Get operation - authentication required",
-            "$ref": "#/components/responses/Error401ResponseBody"
-          },
-          "403": {
-            "description": "Forbidden error for Students Get operation - insufficient permissions",
-            "$ref": "#/components/responses/Error403ResponseBody"
-          },
-          "404": {
-            "description": "Not Found error for Students Get operation - resource does not exist",
-            "$ref": "#/components/responses/Error404ResponseBody"
-          },
-          "409": {
-            "description": "Conflict error for Students Get operation - request conflicts with current state",
-            "$ref": "#/components/responses/Error409ResponseBody"
-          },
-          "429": {
-            "description": "Rate Limit error for Students Get operation - too many requests",
-            "$ref": "#/components/responses/Error429ResponseBody"
-          },
-          "500": {
-            "description": "Internal Server error for Students Get operation - unexpected server error",
-            "$ref": "#/components/responses/Error500ResponseBody"
-          }
-        },
-        "x-speakeasy-group": "students",
-        "x-speakeasy-name-override": "get"
-      },
-      "delete": {
-        "tags": [
-          "Students"
-        ],
-        "summary": "Delete Students",
-        "description": "Delete a Students",
-        "operationId": "StudentsDelete",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "description": "The unique identifier of the Students to delete",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "examples": [
-                "123e4567-e89b-12d3-a456-426614174000"
-              ],
-              "format": "uuid"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Response for Students Delete operation - confirms successful deletion"
-          },
-          "400": {
-            "description": "Bad Request error for Students Delete operation - request contains invalid parameters",
-            "$ref": "#/components/responses/Error400ResponseBody"
-          },
-          "401": {
-            "description": "Unauthorized error for Students Delete operation - authentication required",
-            "$ref": "#/components/responses/Error401ResponseBody"
-          },
-          "403": {
-            "description": "Forbidden error for Students Delete operation - insufficient permissions",
-            "$ref": "#/components/responses/Error403ResponseBody"
-          },
-          "404": {
-            "description": "Not Found error for Students Delete operation - resource does not exist",
-            "$ref": "#/components/responses/Error404ResponseBody"
-          },
-          "409": {
-            "description": "Conflict error for Students Delete operation - request conflicts with current state",
-            "$ref": "#/components/responses/Error409ResponseBody"
-          },
-          "429": {
-            "description": "Rate Limit error for Students Delete operation - too many requests",
-            "$ref": "#/components/responses/Error429ResponseBody"
-          },
-          "500": {
-            "description": "Internal Server error for Students Delete operation - unexpected server error",
-            "$ref": "#/components/responses/Error500ResponseBody"
-          }
-        },
-        "x-speakeasy-group": "students",
-        "x-speakeasy-name-override": "delete"
-      },
-      "patch": {
-        "tags": [
-          "Students"
-        ],
-        "summary": "Update Students",
-        "description": "Update a Students",
-        "operationId": "StudentsUpdate",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "description": "The unique identifier of the Students to update",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "examples": [
-                "123e4567-e89b-12d3-a456-426614174000"
-              ],
-              "format": "uuid"
-            }
-          }
-        ],
-        "requestBody": {
-          "$ref": "#/components/requestBodies/StudentsUpdate"
-        },
-        "responses": {
-          "200": {
-            "description": "Response for Students Update operation - returns the updated Students",
-            "$ref": "#/components/responses/StudentsUpdate"
-          },
-          "400": {
-            "description": "Bad Request error for Students Update operation - request contains invalid parameters",
-            "$ref": "#/components/responses/Error400ResponseBody"
-          },
-          "401": {
-            "description": "Unauthorized error for Students Update operation - authentication required",
-            "$ref": "#/components/responses/Error401ResponseBody"
-          },
-          "403": {
-            "description": "Forbidden error for Students Update operation - insufficient permissions",
-            "$ref": "#/components/responses/Error403ResponseBody"
-          },
-          "404": {
-            "description": "Not Found error for Students Update operation - resource does not exist",
-            "$ref": "#/components/responses/Error404ResponseBody"
-          },
-          "409": {
-            "description": "Conflict error for Students Update operation - request conflicts with current state",
-            "$ref": "#/components/responses/Error409ResponseBody"
-          },
-          "422": {
-            "description": "Validation error for Students Update operation - request data failed validation",
-            "$ref": "#/components/responses/StudentsUpdate422ResponseBody"
-          },
-          "429": {
-            "description": "Rate Limit error for Students Update operation - too many requests",
-            "$ref": "#/components/responses/Error429ResponseBody"
-          },
-          "500": {
-            "description": "Internal Server error for Students Update operation - unexpected server error",
-            "$ref": "#/components/responses/Error500ResponseBody"
-          }
-        },
-        "x-speakeasy-group": "students",
-        "x-speakeasy-name-override": "update"
       }
     }
   },
@@ -1104,6 +1104,44 @@
         ],
         "description": "Student management resource"
       },
+      "ContactRequestError": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
+            "examples": [
+              {
+                "code": "InvalidValue",
+                "message": "email is required"
+              },
+              null
+            ],
+            "description": "Email address",
+            "nullable": true
+          },
+          "phone": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorField"
+              }
+            ],
+            "examples": [
+              {
+                "code": "InvalidValue",
+                "message": "phone is required"
+              },
+              null
+            ],
+            "description": "Phone number",
+            "nullable": true
+          }
+        },
+        "description": "Request error object for Contact"
+      },
       "StudentRequestError": {
         "type": "object",
         "properties": {
@@ -1115,7 +1153,8 @@
             ],
             "examples": [
               {
-                "message": "example"
+                "code": "InvalidValue",
+                "message": "firstName is required"
               },
               null
             ],
@@ -1130,7 +1169,8 @@
             ],
             "examples": [
               {
-                "message": "example"
+                "code": "InvalidValue",
+                "message": "lastName is required"
               },
               null
             ],
@@ -1145,7 +1185,8 @@
             ],
             "examples": [
               {
-                "message": "example"
+                "code": "InvalidValue",
+                "message": "studentId is required"
               },
               null
             ],
@@ -1160,7 +1201,8 @@
             ],
             "examples": [
               {
-                "message": "example"
+                "code": "InvalidValue",
+                "message": "status is required"
               },
               null
             ],
@@ -1175,7 +1217,8 @@
             ],
             "examples": [
               {
-                "message": "example"
+                "code": "InvalidValue",
+                "message": "gradeLevel is required"
               },
               null
             ],
@@ -1196,7 +1239,8 @@
             ],
             "examples": [
               {
-                "message": "example"
+                "code": "InvalidValue",
+                "message": "street is required"
               },
               null
             ],
@@ -1211,7 +1255,8 @@
             ],
             "examples": [
               {
-                "message": "example"
+                "code": "InvalidValue",
+                "message": "city is required"
               },
               null
             ],
@@ -1226,7 +1271,8 @@
             ],
             "examples": [
               {
-                "message": "example"
+                "code": "InvalidValue",
+                "message": "state is required"
               },
               null
             ],
@@ -1241,7 +1287,8 @@
             ],
             "examples": [
               {
-                "message": "example"
+                "code": "InvalidValue",
+                "message": "zipCode is required"
               },
               null
             ],
@@ -1250,42 +1297,6 @@
           }
         },
         "description": "Request error object for Address"
-      },
-      "ContactRequestError": {
-        "type": "object",
-        "properties": {
-          "email": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ErrorField"
-              }
-            ],
-            "examples": [
-              {
-                "message": "example"
-              },
-              null
-            ],
-            "description": "Email address",
-            "nullable": true
-          },
-          "phone": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ErrorField"
-              }
-            ],
-            "examples": [
-              {
-                "message": "example"
-              },
-              null
-            ],
-            "description": "Phone number",
-            "nullable": true
-          }
-        },
-        "description": "Request error object for Contact"
       },
       "StudentsBulkImportRequestError": {
         "type": "object",
@@ -1299,19 +1310,24 @@
             "examples": [
               {
                 "firstName": {
-                  "message": "example"
+                  "code": "InvalidValue",
+                  "message": "firstName is required"
                 },
                 "lastName": {
-                  "message": "example"
+                  "code": "InvalidValue",
+                  "message": "lastName is required"
                 },
                 "studentId": {
-                  "message": "example"
+                  "code": "InvalidValue",
+                  "message": "studentId is required"
                 },
                 "status": {
-                  "message": "example"
+                  "code": "InvalidValue",
+                  "message": "status is required"
                 },
                 "gradeLevel": {
-                  "message": "example"
+                  "code": "InvalidValue",
+                  "message": "gradeLevel is required"
                 }
               },
               null
@@ -1327,7 +1343,8 @@
             ],
             "examples": [
               {
-                "message": "example"
+                "code": "InvalidValue",
+                "message": "overwriteExisting is required"
               },
               null
             ],
@@ -1348,7 +1365,8 @@
             ],
             "examples": [
               {
-                "message": "example"
+                "code": "InvalidValue",
+                "message": "gradeLevel is required"
               },
               null
             ],
@@ -1363,7 +1381,8 @@
             ],
             "examples": [
               {
-                "message": "example"
+                "code": "InvalidValue",
+                "message": "status is required"
               },
               null
             ],
@@ -1378,7 +1397,8 @@
             ],
             "examples": [
               {
-                "message": "example"
+                "code": "InvalidValue",
+                "message": "enrollmentDateFrom is required"
               },
               null
             ],
@@ -1393,7 +1413,8 @@
             ],
             "examples": [
               {
-                "message": "example"
+                "code": "InvalidValue",
+                "message": "enrollmentDateTo is required"
               },
               null
             ],
@@ -1408,7 +1429,8 @@
             ],
             "examples": [
               {
-                "message": "example"
+                "code": "InvalidValue",
+                "message": "includeInactive is required"
               },
               null
             ],
@@ -1429,7 +1451,8 @@
             ],
             "examples": [
               {
-                "message": "example"
+                "code": "InvalidValue",
+                "message": "nameQuery is required"
               },
               null
             ],
@@ -1444,7 +1467,8 @@
             ],
             "examples": [
               {
-                "message": "example"
+                "code": "InvalidValue",
+                "message": "gradeLevel is required"
               },
               null
             ],
@@ -1459,7 +1483,8 @@
             ],
             "examples": [
               {
-                "message": "example"
+                "code": "InvalidValue",
+                "message": "status is required"
               },
               null
             ],
@@ -1474,7 +1499,8 @@
             ],
             "examples": [
               {
-                "message": "example"
+                "code": "InvalidValue",
+                "message": "enrollmentDateRange is required"
               },
               null
             ],
@@ -1489,7 +1515,8 @@
             ],
             "examples": [
               {
-                "message": "example"
+                "code": "InvalidValue",
+                "message": "hasGraduationDate is required"
               },
               null
             ],
@@ -1510,7 +1537,8 @@
             ],
             "examples": [
               {
-                "message": "example"
+                "code": "InvalidValue",
+                "message": "firstName is required"
               },
               null
             ],
@@ -1525,7 +1553,8 @@
             ],
             "examples": [
               {
-                "message": "example"
+                "code": "InvalidValue",
+                "message": "lastName is required"
               },
               null
             ],
@@ -1540,7 +1569,8 @@
             ],
             "examples": [
               {
-                "message": "example"
+                "code": "InvalidValue",
+                "message": "studentId is required"
               },
               null
             ],
@@ -1555,7 +1585,8 @@
             ],
             "examples": [
               {
-                "message": "example"
+                "code": "InvalidValue",
+                "message": "status is required"
               },
               null
             ],
@@ -1570,7 +1601,8 @@
             ],
             "examples": [
               {
-                "message": "example"
+                "code": "InvalidValue",
+                "message": "gradeLevel is required"
               },
               null
             ],
@@ -1586,10 +1618,12 @@
             "examples": [
               {
                 "email": {
-                  "message": "example"
+                  "code": "InvalidValue",
+                  "message": "email is required"
                 },
                 "phone": {
-                  "message": "example"
+                  "code": "InvalidValue",
+                  "message": "phone is required"
                 }
               },
               null
@@ -1606,16 +1640,20 @@
             "examples": [
               {
                 "street": {
-                  "message": "example"
+                  "code": "InvalidValue",
+                  "message": "street is required"
                 },
                 "city": {
-                  "message": "example"
+                  "code": "InvalidValue",
+                  "message": "city is required"
                 },
                 "state": {
-                  "message": "example"
+                  "code": "InvalidValue",
+                  "message": "state is required"
                 },
                 "zipCode": {
-                  "message": "example"
+                  "code": "InvalidValue",
+                  "message": "zipCode is required"
                 }
               },
               null
@@ -1631,7 +1669,8 @@
             ],
             "examples": [
               {
-                "message": "example"
+                "code": "InvalidValue",
+                "message": "enrollmentDate is required"
               },
               null
             ],
@@ -1652,7 +1691,8 @@
             ],
             "examples": [
               {
-                "message": "example"
+                "code": "InvalidValue",
+                "message": "firstName is required"
               },
               null
             ],
@@ -1667,7 +1707,8 @@
             ],
             "examples": [
               {
-                "message": "example"
+                "code": "InvalidValue",
+                "message": "lastName is required"
               },
               null
             ],
@@ -1682,7 +1723,8 @@
             ],
             "examples": [
               {
-                "message": "example"
+                "code": "InvalidValue",
+                "message": "status is required"
               },
               null
             ],
@@ -1697,7 +1739,8 @@
             ],
             "examples": [
               {
-                "message": "example"
+                "code": "InvalidValue",
+                "message": "gradeLevel is required"
               },
               null
             ],
@@ -1713,10 +1756,12 @@
             "examples": [
               {
                 "email": {
-                  "message": "example"
+                  "code": "InvalidValue",
+                  "message": "email is required"
                 },
                 "phone": {
-                  "message": "example"
+                  "code": "InvalidValue",
+                  "message": "phone is required"
                 }
               },
               null
@@ -1733,16 +1778,20 @@
             "examples": [
               {
                 "street": {
-                  "message": "example"
+                  "code": "InvalidValue",
+                  "message": "street is required"
                 },
                 "city": {
-                  "message": "example"
+                  "code": "InvalidValue",
+                  "message": "city is required"
                 },
                 "state": {
-                  "message": "example"
+                  "code": "InvalidValue",
+                  "message": "state is required"
                 },
                 "zipCode": {
-                  "message": "example"
+                  "code": "InvalidValue",
+                  "message": "zipCode is required"
                 }
               },
               null
@@ -1758,7 +1807,8 @@
             ],
             "examples": [
               {
-                "message": "example"
+                "code": "InvalidValue",
+                "message": "graduationDate is required"
               },
               null
             ],
@@ -3010,16 +3060,16 @@
                     {
                       "students": {
                         "firstName": {
-                          "code": "Required",
+                          "code": "InvalidValue",
                           "message": "firstName is required"
                         },
                         "lastName": {
-                          "code": "Required",
+                          "code": "InvalidValue",
                           "message": "lastName is required"
                         }
                       },
                       "overwriteExisting": {
-                        "code": "Required",
+                        "code": "InvalidValue",
                         "message": "overwriteExisting is required"
                       }
                     }
@@ -3042,16 +3092,16 @@
                   "errorFields": {
                     "students": {
                       "firstName": {
-                        "code": "Required",
+                        "code": "InvalidValue",
                         "message": "firstName is required"
                       },
                       "lastName": {
-                        "code": "Required",
+                        "code": "InvalidValue",
                         "message": "lastName is required"
                       }
                     },
                     "overwriteExisting": {
-                      "code": "Required",
+                      "code": "InvalidValue",
                       "message": "overwriteExisting is required"
                     }
                   }
@@ -3136,11 +3186,11 @@
                   "examples": [
                     {
                       "gradeLevel": {
-                        "code": "Required",
+                        "code": "InvalidValue",
                         "message": "gradeLevel is required"
                       },
                       "status": {
-                        "code": "Required",
+                        "code": "InvalidValue",
                         "message": "status is required"
                       }
                     }
@@ -3162,11 +3212,11 @@
                   },
                   "errorFields": {
                     "gradeLevel": {
-                      "code": "Required",
+                      "code": "InvalidValue",
                       "message": "gradeLevel is required"
                     },
                     "status": {
-                      "code": "Required",
+                      "code": "InvalidValue",
                       "message": "status is required"
                     }
                   }
@@ -3267,11 +3317,11 @@
                   "examples": [
                     {
                       "nameQuery": {
-                        "code": "Required",
+                        "code": "InvalidValue",
                         "message": "nameQuery is required"
                       },
                       "gradeLevel": {
-                        "code": "Required",
+                        "code": "InvalidValue",
                         "message": "gradeLevel is required"
                       }
                     }
@@ -3293,11 +3343,11 @@
                   },
                   "errorFields": {
                     "nameQuery": {
-                      "code": "Required",
+                      "code": "InvalidValue",
                       "message": "nameQuery is required"
                     },
                     "gradeLevel": {
-                      "code": "Required",
+                      "code": "InvalidValue",
                       "message": "gradeLevel is required"
                     }
                   }
@@ -3379,11 +3429,11 @@
                   "examples": [
                     {
                       "firstName": {
-                        "code": "Required",
+                        "code": "InvalidValue",
                         "message": "firstName is required"
                       },
                       "lastName": {
-                        "code": "Required",
+                        "code": "InvalidValue",
                         "message": "lastName is required"
                       }
                     }
@@ -3405,11 +3455,11 @@
                   },
                   "errorFields": {
                     "firstName": {
-                      "code": "Required",
+                      "code": "InvalidValue",
                       "message": "firstName is required"
                     },
                     "lastName": {
-                      "code": "Required",
+                      "code": "InvalidValue",
                       "message": "lastName is required"
                     }
                   }
@@ -3491,11 +3541,11 @@
                   "examples": [
                     {
                       "firstName": {
-                        "code": "Required",
+                        "code": "InvalidValue",
                         "message": "firstName is required"
                       },
                       "lastName": {
-                        "code": "Required",
+                        "code": "InvalidValue",
                         "message": "lastName is required"
                       }
                     }
@@ -3517,11 +3567,11 @@
                   },
                   "errorFields": {
                     "firstName": {
-                      "code": "Required",
+                      "code": "InvalidValue",
                       "message": "firstName is required"
                     },
                     "lastName": {
-                      "code": "Required",
+                      "code": "InvalidValue",
                       "message": "lastName is required"
                     }
                   }


### PR DESCRIPTION
Add example generation for `allOf` schemas referencing objects in OpenAPI documentation.

This resolves a linting issue (`oas3-missing-example`) where schema properties using `allOf` with `$ref` to other schemas were missing examples. The `createFieldSchema` function now automatically generates examples from the referenced object definitions when no explicit example is provided, ensuring comprehensive and valid OpenAPI documentation.

---
Linear Issue: [INF-320](https://linear.app/meitner-se/issue/INF-320/object-is-missing-example-in-openapi-docs)

<a href="https://cursor.com/background-agent?bcId=bc-354d112e-8464-416f-ae8e-86f2f62c0431"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-354d112e-8464-416f-ae8e-86f2f62c0431"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

