### PR TITLE
Refactor openapigen to match servergen api

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"flag"
@@ -444,13 +445,14 @@ func generateOverlay(ctx context.Context, service *specification.Service, inputF
 func generateOpenAPIBytes(ctx context.Context, service *specification.Service) ([]byte, error) {
 	slog.InfoContext(ctx, "Generating OpenAPI document bytes", logKeyMode, modeOpenAPI)
 
-	// Generate OpenAPI document as JSON in a single call
-	outputData, err := openapigen.GenerateFromSpecificationToJSON(service)
+	// Generate OpenAPI document as JSON using the new API pattern
+	var buf bytes.Buffer
+	err := openapigen.GenerateOpenAPI(&buf, service)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate OpenAPI document: %w", err)
 	}
 
-	return outputData, nil
+	return buf.Bytes(), nil
 }
 
 // generateOpenAPI generates an OpenAPI document from the specification.


### PR DESCRIPTION
Refactor `openapigen` to expose a single `GenerateOpenAPI` function that writes to a buffer, aligning with `servergen`'s minimalistic API pattern.

---
Linear Issue: [INF-352](https://linear.app/meitner-se/issue/INF-352/refactor-openapigen-to-follow-servergen-api)

<a href="https://cursor.com/background-agent?bcId=bc-bb8cd263-e0f8-40f7-95cc-cfdadf834f6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bb8cd263-e0f8-40f7-95cc-cfdadf834f6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

