### PR TITLE
Implement publicapis-gen diff command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ publicapis-gen
 coverage.html
 coverage.out
 
+# Generated output files for testing
+output/
+
 # IDE and editor files
 .vscode/
 .idea/


### PR DESCRIPTION
Add `publicapis-gen diff` command to verify consistency between generated API files and their on-disk versions.

---
Linear Issue: [INF-314](https://linear.app/meitner-se/issue/INF-314/add-diff-check)

<a href="https://cursor.com/background-agent?bcId=bc-396b34f4-44ec-4ec7-87e7-35f73790b22d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-396b34f4-44ec-4ec7-87e7-35f73790b22d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

