### PR TITLE
Generate specific request structs for servergen

### DIFF
--- a/specification/servergen/servergen.go
+++ b/specification/servergen/servergen.go
@@ -235,19 +235,15 @@ func generateServer(buf *bytes.Buffer, service *specification.Service) error {
 		buf.WriteString(fmt.Sprintf("type %sAPI[Session any] interface {\n", resource.Name))
 		for _, endpoint := range resource.Endpoints {
 			if endpoint.HasResponseType() {
-				buf.WriteString(fmt.Sprintf("\t%s(ctx context.Context, request Request[Session, %s, %s, %s]) (*%s, error)\n",
+				buf.WriteString(fmt.Sprintf("\t%s(ctx context.Context, request %s[Session]) (*%s, error)\n",
 					endpoint.Name,
-					endpoint.GetPathParamsType(resource.Name),
-					endpoint.GetQueryParamsType(resource.Name),
-					endpoint.GetBodyParamsType(resource.Name),
+					endpoint.GetRequestType(resource.Name),
 					endpoint.GetResponseType(resource.Name),
 				))
 			} else {
-				buf.WriteString(fmt.Sprintf("\t%s(ctx context.Context, request Request[Session, %s, %s, %s]) error\n",
+				buf.WriteString(fmt.Sprintf("\t%s(ctx context.Context, request %s[Session]) error\n",
 					endpoint.Name,
-					endpoint.GetPathParamsType(resource.Name),
-					endpoint.GetQueryParamsType(resource.Name),
-					endpoint.GetBodyParamsType(resource.Name),
+					endpoint.GetRequestType(resource.Name),
 				))
 			}
 		}
@@ -295,6 +291,18 @@ func generateRequestTypes(buf *bytes.Buffer, service *specification.Service) err
 				}
 				buf.WriteString("}\n\n")
 			}
+		}
+	}
+
+	// Generate endpoint-specific request types
+	for _, resource := range service.Resources {
+		for _, endpoint := range resource.Endpoints {
+			buf.WriteString(fmt.Sprintf("type %s[Session any] Request[Session, %s, %s, %s]\n\n",
+				endpoint.GetRequestType(resource.Name),
+				endpoint.GetPathParamsType(resource.Name),
+				endpoint.GetQueryParamsType(resource.Name),
+				endpoint.GetBodyParamsType(resource.Name),
+			))
 		}
 	}
 


### PR DESCRIPTION
Generate endpoint-specific request structs and use them in API interface methods to improve type safety and readability.

The server generation previously used a generic `Request` struct in API interface method signatures, which was verbose. This change introduces dedicated request types for each endpoint, making the generated API interfaces clearer and more idiomatic Go.

---
Linear Issue: [INF-371](https://linear.app/meitner-se/issue/INF-371/generate-request-structs-for-each-endpoint-in-servergen)

<a href="https://cursor.com/background-agent?bcId=bc-5242bccd-3f87-4bac-8f86-0133839056cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5242bccd-3f87-4bac-8f86-0133839056cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

