### PR TITLE
Remove custom enum type generation in servergen

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -1274,9 +1274,8 @@ func Test_generateServerFromSpecification_e2e(t *testing.T) {
 	assert.Contains(t, generatedCode, expectedOpenAPIRoute, "Generated code should contain OpenAPI route")
 
 	// Verify enum generation
-	assert.Contains(t, generatedCode, "type Status types.String", "Generated code should contain Status enum")
 	assert.Contains(t, generatedCode, "StatusActive", "Generated code should contain StatusActive")
-	assert.Contains(t, generatedCode, "Status(types.NewString(\"Active\"))", "Generated code should contain enum values")
+	assert.Contains(t, generatedCode, "types.NewString(\"Active\")", "Generated code should contain enum values")
 
 	// Verify object generation
 	assert.Contains(t, generatedCode, "type User struct {", "Generated code should contain User object")

--- a/specification/servergen/doc.go
+++ b/specification/servergen/doc.go
@@ -48,12 +48,11 @@
 //
 // The generated server includes:
 //
-// 1. **Enum Types**: All enums are generated as typed strings using go-types:
+// 1. **Enum Variables**: All enums are generated as variables using go-types:
 //
-//	type ErrorCode types.String
 //	var (
-//	    ErrorCodeBadRequest = ErrorCode(types.NewString("BadRequest"))
-//	    ErrorCodeNotFound   = ErrorCode(types.NewString("NotFound"))
+//	    ErrorCodeBadRequest = types.NewString("BadRequest")
+//	    ErrorCodeNotFound   = types.NewString("NotFound")
 //	)
 //
 // 2. **Object Types**: Objects are generated as Go structs with JSON tags:

--- a/specification/servergen/servergen.go
+++ b/specification/servergen/servergen.go
@@ -97,11 +97,9 @@ func GenerateServer(buf *bytes.Buffer, service *specification.Service) error {
 
 func generateEnums(buf *bytes.Buffer, enums []specification.Enum) error {
 	for _, enumStruct := range enums {
-		buf.WriteString(fmt.Sprintf("type %s types.String\n\n", enumStruct.Name))
-
 		buf.WriteString("var (\n")
 		for _, value := range enumStruct.Values {
-			buf.WriteString(fmt.Sprintf("\t%s%s = %s(types.NewString(\"%s\")) // %s\n", enumStruct.Name, value.Name, enumStruct.Name, value.Name, value.Description))
+			buf.WriteString(fmt.Sprintf("\t%s%s = types.NewString(\"%s\") // %s\n", enumStruct.Name, value.Name, value.Name, value.Description))
 		}
 		buf.WriteString(")\n\n")
 	}
@@ -112,16 +110,15 @@ func generateEnums(buf *bytes.Buffer, enums []specification.Enum) error {
 func getTypeForGo(field specification.Field, service *specification.Service) string {
 	fieldType := field.Type
 
-	//	if service.HasEnum(fieldType) {
-	//		fieldType = "String"
-	//	}
+	if service.HasEnum(fieldType) {
+		fieldType = "String"
+	}
 
 	return getTypePrefix(field, service) + fieldType
 }
 
 func getTypePrefix(field specification.Field, service *specification.Service) string {
 	isObject := service.IsObject(field.Type)
-	isEnum := service.HasEnum(field.Type)
 
 	prefixes := []string{}
 
@@ -133,7 +130,7 @@ func getTypePrefix(field specification.Field, service *specification.Service) st
 		prefixes = append(prefixes, "*")
 	}
 
-	if !isObject && !isEnum {
+	if !isObject {
 		prefixes = append(prefixes, "types.")
 	}
 

--- a/specification/servergen/servergen_test.go
+++ b/specification/servergen/servergen_test.go
@@ -81,9 +81,8 @@ const (
 	expectedOpenAPIRoute      = `routerGroup.StaticFileFS("/openapi.json", "openapi.json", http.FS(api.OpenAPI_JSON))`
 
 	// Type generation constants
-	expectedEnumType   = "type UserRole types.String"
 	expectedEnumVar    = "var ("
-	expectedEnumValue  = "UserRoleAdmin = UserRole(types.NewString(\"Admin\")) // Administrator role"
+	expectedEnumValue  = "UserRoleAdmin = types.NewString(\"Admin\") // Administrator role"
 	expectedObjectType = "type Address struct {"
 	expectedFieldDecl  = "Name types.String `json:\"name\"`"
 
@@ -142,7 +141,7 @@ func TestGenerateServer(t *testing.T) {
 	assert.Contains(t, generatedCode, expectedRegisterFunc, "Generated code should contain RegisterAPI function")
 
 	// Verify enum generation
-	assert.Contains(t, generatedCode, expectedEnumType, "Generated code should contain enum type declaration")
+	assert.Contains(t, generatedCode, expectedEnumVar, "Generated code should contain enum var declaration")
 
 	// Verify object generation
 	assert.Contains(t, generatedCode, expectedObjectType, "Generated code should contain object type declaration")
@@ -216,10 +215,9 @@ func TestGenerateEnums(t *testing.T) {
 	assert.Nil(t, err, "Expected no error when generating enums")
 
 	generatedCode := buf.String()
-	assert.Contains(t, generatedCode, expectedEnumType, "Should generate enum type declaration")
 	assert.Contains(t, generatedCode, expectedEnumVar, "Should generate var block")
 	assert.Contains(t, generatedCode, expectedEnumValue, "Should generate enum value with description")
-	assert.Contains(t, generatedCode, "UserRoleUser = UserRole(types.NewString(\"User\")) // Regular user role",
+	assert.Contains(t, generatedCode, "UserRoleUser = types.NewString(\"User\") // Regular user role",
 		"Should generate all enum values")
 
 	t.Run("edge cases", func(t *testing.T) {
@@ -252,7 +250,6 @@ func TestGenerateEnums(t *testing.T) {
 			// Assert
 			assert.Nil(t, err, "Expected no error")
 			generatedCode := buf.String()
-			assert.Contains(t, generatedCode, expectedEnumType, "Should still generate enum type")
 			assert.Contains(t, generatedCode, expectedEnumVar, "Should generate empty var block")
 		})
 
@@ -275,7 +272,7 @@ func TestGenerateEnums(t *testing.T) {
 			// Assert
 			assert.Nil(t, err, "Expected no error")
 			generatedCode := buf.String()
-			assert.Contains(t, generatedCode, `StatusIn-Progress = Status(types.NewString("In-Progress"))`,
+			assert.Contains(t, generatedCode, `StatusIn-Progress = types.NewString("In-Progress")`,
 				"Should handle special characters in enum names")
 		})
 	})
@@ -360,7 +357,7 @@ func TestGetTypeForGo(t *testing.T) {
 				Name: "Role",
 				Type: testEnumName,
 			},
-			expectedType: testEnumName,
+			expectedType: "types.String",
 		},
 	}
 
@@ -465,7 +462,7 @@ func TestGetTypePrefix(t *testing.T) {
 			field: specification.Field{
 				Type: testEnumName,
 			},
-			expectedPrefix: "",
+			expectedPrefix: "types.",
 		},
 	}
 


### PR DESCRIPTION
Remove custom enum type generation in `servergen` to resolve JSON marshaling/unmarshaling issues.

---
Linear Issue: [INF-376](https://linear.app/meitner-se/issue/INF-376/remove-enum-types-generation-in-servergen)

<a href="https://cursor.com/background-agent?bcId=bc-80b46981-7c96-4dac-bc5b-81beeeba6a5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-80b46981-7c96-4dac-bc5b-81beeeba6a5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

