### PR TITLE
Pass requestID to error object

### DIFF
--- a/specification/servergen/servergen.go
+++ b/specification/servergen/servergen.go
@@ -391,9 +391,10 @@ func generateUtils(buf *bytes.Buffer) error {
 			return
 		}
 
-		err := server.ConvertErrorFunc(function(c.Request.Context(), request), requestID)
+		err := function(c.Request.Context(), request)
 		if err != nil {
-			c.JSON(err.HTTPStatusCode(), err)
+			apiError := server.ConvertErrorFunc(err, requestID)
+			c.JSON(apiError.HTTPStatusCode(), apiError)
 			return
 		}
 		
@@ -416,8 +417,9 @@ func generateUtils(buf *bytes.Buffer) error {
 	session, err := getSession(c.Request.Context(), c.Request.Header, requestID)
 	if err != nil {
 		return nilRequest, &Error{
-			Code:    ErrorCodeUnauthorized,
-			Message: types.NewString(err.Error()),
+			Code:      ErrorCodeUnauthorized,
+			Message:   types.NewString(err.Error()),
+			RequestID: types.NewString(requestID),
 		}
 	}
 
@@ -430,8 +432,9 @@ func generateUtils(buf *bytes.Buffer) error {
 		bodyParams, err := decodeBodyParams[bodyParamsType](c.Request)
 		if err != nil {
 			return nilRequest, &Error{
-				Code:    ErrorCodeBadRequest,
-				Message: types.NewString("cannot decode json body params: " + err.Error()),
+				Code:      ErrorCodeBadRequest,
+				Message:   types.NewString("cannot decode json body params: " + err.Error()),
+				RequestID: types.NewString(requestID),
 			}
 		}
 
@@ -442,8 +445,9 @@ func generateUtils(buf *bytes.Buffer) error {
 		pathParams, err := decodePathParams[pathParamsType](c)
 		if err != nil {
 			return nilRequest, &Error{
-				Code:    ErrorCodeBadRequest,
-				Message: types.NewString("cannot decode path params: " + err.Error()),
+				Code:      ErrorCodeBadRequest,
+				Message:   types.NewString("cannot decode path params: " + err.Error()),
+				RequestID: types.NewString(requestID),
 			}
 		}
 
@@ -454,8 +458,9 @@ func generateUtils(buf *bytes.Buffer) error {
 		queryParams, err := decodeQueryParams[queryParamsType](c)
 		if err != nil {
 			return nilRequest, &Error{
-				Code:    ErrorCodeBadRequest,
-				Message: types.NewString("cannot decode query params: " + err.Error()),
+				Code:      ErrorCodeBadRequest,
+				Message:   types.NewString("cannot decode query params: " + err.Error()),
+				RequestID: types.NewString(requestID),
 			}
 		}
 


### PR DESCRIPTION
Pass `RequestID` to `Error` objects in `parseRequest` and refactor `serveWithoutResponse` error handling.

This ensures all generated API error responses include the `RequestID` for improved traceability and corrects the logic for applying `server.ConvertErrorFunc` only when an actual error occurs.

---
Linear Issue: [INF-377](https://linear.app/meitner-se/issue/INF-377/pass-requestid-to-error-object)

<a href="https://cursor.com/background-agent?bcId=bc-82df700a-911c-45a5-bff7-655109f947f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-82df700a-911c-45a5-bff7-655109f947f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

