### PR TITLE
Add json tags to queryparams struct

### DIFF
--- a/specification/servergen/servergen.go
+++ b/specification/servergen/servergen.go
@@ -304,7 +304,7 @@ func generateRequestTypes(buf *bytes.Buffer, service *specification.Service) err
 			if len(endpoint.Request.QueryParams) > 0 {
 				buf.WriteString(fmt.Sprintf("type %s struct {\n", endpoint.GetQueryParamsType(resource.Name)))
 				for _, field := range endpoint.Request.QueryParams {
-					buf.WriteString(fmt.Sprintf("\t%s %s `form:\"%s\"`\n", field.Name, getTypeForGo(field, service), field.TagJSON()))
+					buf.WriteString(fmt.Sprintf("\t%s %s `form:\"%s\" json:\"%s\"`\n", field.Name, getTypeForGo(field, service), field.TagJSON(), field.TagJSON()))
 				}
 				buf.WriteString("}\n\n")
 			}

--- a/specification/servergen/servergen_test.go
+++ b/specification/servergen/servergen_test.go
@@ -707,7 +707,7 @@ func TestGenerateRequestTypes(t *testing.T) {
 
 	// Check query params type generation
 	assert.Contains(t, generatedCode, "type UserListUsersQueryParams struct {", "Should generate query params type")
-	assert.Contains(t, generatedCode, `Limit types.Int `+"`form:\"limit\"`", "Should use form tag for query params")
+	assert.Contains(t, generatedCode, `Limit types.Int `+"`form:\"limit\" json:\"limit\"`", "Should use both form and json tags for query params")
 
 	// Check body params type generation
 	assert.Contains(t, generatedCode, "type UserCreateUserBodyParams struct {", "Should generate body params type")


### PR DESCRIPTION
Add JSON tags to QueryParams struct fields to enable JSON parsing for testing.

---
Linear Issue: [INF-378](https://linear.app/meitner-se/issue/INF-378/add-json-tags-to-queryparams-struct-fields)

<a href="https://cursor.com/background-agent?bcId=bc-cd4e5abe-d0e8-4abd-b551-c0485e82a4ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cd4e5abe-d0e8-4abd-b551-c0485e82a4ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

