### PR TITLE
Fix speakeasy pagination extension case sensitivity

### DIFF
--- a/specification/openapigen/openapigen.go
+++ b/specification/openapigen/openapigen.go
@@ -179,6 +179,12 @@ const (
 	speakeasyDataFieldName        = "Data" // Still used in isPaginatedOperation
 )
 
+// List endpoint parameter names (should match specification package constants)
+const (
+	listLimitParamName  = "Limit"
+	listOffsetParamName = "Offset"
+)
+
 // Object and field names
 const (
 	errorObjectName         = "Error"
@@ -341,10 +347,14 @@ func (g *generator) addSpeakeasyPaginationExtension(operation *v3.Operation) {
 	inputsKeyNode := &yaml.Node{Kind: yaml.ScalarNode, Value: "inputs"}
 	inputsArrayNode := &yaml.Node{Kind: yaml.SequenceNode, Tag: "!!seq"}
 
+	// Create Field objects to get proper JSON tag names
+	offsetField := specification.Field{Name: listOffsetParamName}
+	limitField := specification.Field{Name: listLimitParamName}
+
 	// Create offset input object
 	offsetInputNode := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
 	offsetNameKeyNode := &yaml.Node{Kind: yaml.ScalarNode, Value: "name"}
-	offsetNameValueNode := &yaml.Node{Kind: yaml.ScalarNode, Value: speakeasyOffsetParamName}
+	offsetNameValueNode := &yaml.Node{Kind: yaml.ScalarNode, Value: offsetField.TagJSON()}
 	offsetInKeyNode := &yaml.Node{Kind: yaml.ScalarNode, Value: "in"}
 	offsetInValueNode := &yaml.Node{Kind: yaml.ScalarNode, Value: speakeasyPaginationInputsIn}
 	offsetTypeKeyNode := &yaml.Node{Kind: yaml.ScalarNode, Value: "type"}
@@ -358,7 +368,7 @@ func (g *generator) addSpeakeasyPaginationExtension(operation *v3.Operation) {
 	// Create limit input object
 	limitInputNode := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
 	limitNameKeyNode := &yaml.Node{Kind: yaml.ScalarNode, Value: "name"}
-	limitNameValueNode := &yaml.Node{Kind: yaml.ScalarNode, Value: speakeasyLimitParamName}
+	limitNameValueNode := &yaml.Node{Kind: yaml.ScalarNode, Value: limitField.TagJSON()}
 	limitInKeyNode := &yaml.Node{Kind: yaml.ScalarNode, Value: "in"}
 	limitInValueNode := &yaml.Node{Kind: yaml.ScalarNode, Value: speakeasyPaginationInputsIn}
 	limitTypeKeyNode := &yaml.Node{Kind: yaml.ScalarNode, Value: "type"}
@@ -423,11 +433,13 @@ func (g *generator) isPaginatedOperation(endpoint specification.Endpoint) bool {
 	hasOffsetParam := false
 
 	// Check query parameters for limit and offset
+	// Check based on the JSON tag name (camelCase) which is what appears in the actual API
 	for _, param := range endpoint.Request.QueryParams {
-		if param.Name == speakeasyLimitParamName {
+		paramTagJSON := param.TagJSON()
+		if paramTagJSON == speakeasyLimitParamName {
 			hasLimitParam = true
 		}
-		if param.Name == speakeasyOffsetParamName {
+		if paramTagJSON == speakeasyOffsetParamName {
 			hasOffsetParam = true
 		}
 	}


### PR DESCRIPTION
Fix Speakeasy pagination extension by using JSON tag names for parameter detection and extension generation.

The autogenerated OpenAPI specification defined pagination parameters as "Limit" and "Offset". However, the Speakeasy extension's detection logic and parameter references were hardcoded to "limit" and "offset". This PR updates the logic to use `TagJSON()` for parameter names, ensuring consistency with the actual camelCase names ("limit", "offset") that appear in the OpenAPI JSON, thus correctly applying the extension.

---
Linear Issue: [INF-381](https://linear.app/meitner-se/issue/INF-381/fix-speakeasy-pagination-extension-in-openapi)

<a href="https://cursor.com/background-agent?bcId=bc-9fc11be7-d27f-40ac-85dc-37793a15cabb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9fc11be7-d27f-40ac-85dc-37793a15cabb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

