### PR TITLE
Make updatedat nullable in meta

### DIFF
--- a/specification/specification.go
+++ b/specification/specification.go
@@ -1847,6 +1847,7 @@ func createDefaultMeta() Object {
 				Name:        autoColumnUpdatedAtName,
 				Description: "Timestamp when the resource was last updated",
 				Type:        FieldTypeTimestamp,
+				Modifiers:   []string{ModifierNullable},
 				Example:     "2024-01-15T14:45:00Z",
 			},
 			{

--- a/specification/specification_test.go
+++ b/specification/specification_test.go
@@ -1318,7 +1318,7 @@ func TestCreateDefaultMeta(t *testing.T) {
 	// Verify modifiers are correct
 	assert.Empty(t, metaObject.Fields[0].Modifiers, "CreatedAt should have no modifiers")
 	assert.Equal(t, []string{ModifierNullable}, metaObject.Fields[1].Modifiers, "CreatedBy should be nullable")
-	assert.Empty(t, metaObject.Fields[2].Modifiers, "UpdatedAt should have no modifiers")
+	assert.Equal(t, []string{ModifierNullable}, metaObject.Fields[2].Modifiers, "UpdatedAt should be nullable")
 	assert.Equal(t, []string{ModifierNullable}, metaObject.Fields[3].Modifiers, "UpdatedBy should be nullable")
 
 	// Verify descriptions are generic (not resource-specific)
@@ -3141,7 +3141,7 @@ func TestApplyFilterOverlay_MetaObjectFilters(t *testing.T) {
 			"MetaFilterRange":    2,  // Only Timestamp fields: CreatedAt, UpdatedAt
 			"MetaFilterContains": 2,  // Only UUID fields: CreatedBy, UpdatedBy (Timestamp excluded)
 			"MetaFilterLike":     0,  // No String fields in Meta object
-			"MetaFilterNull":     2,  // Only nullable fields: CreatedBy, UpdatedBy
+			"MetaFilterNull":     3,  // Only nullable fields: CreatedBy, UpdatedAt, UpdatedBy
 		}
 
 		for expectedFilter, expectedFieldCount := range expectedMetaFilters {


### PR DESCRIPTION
Make `UpdatedAt` in the `Meta` object nullable to correctly reflect that it may not be set initially for newly created resources.

This change aligns with common API patterns where audit fields like `UpdatedAt` are initially null and only populated after the first modification. It also updates the relevant tests to expect `UpdatedAt` to be nullable and correctly counts nullable fields in `MetaFilterNull`.

---
Linear Issue: [INF-397](https://linear.app/meitner-se/issue/INF-397/updatedat-in-meta-should-be-nullable)

<a href="https://cursor.com/background-agent?bcId=bc-220e77ad-ecaa-4673-99c2-5d4e403d96e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-220e77ad-ecaa-4673-99c2-5d4e403d96e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

