### PR TITLE
Fix go comment formatting

### DIFF
--- a/specification/servergen/servergen.go
+++ b/specification/servergen/servergen.go
@@ -141,7 +141,7 @@ func getTypePrefix(field specification.Field, service *specification.Service) st
 
 func generateObjects(buf *bytes.Buffer, service *specification.Service) error {
 	for _, object := range service.Objects {
-		buf.WriteString(fmt.Sprintf("// %s\n", object.GetComment()))
+		buf.WriteString(fmt.Sprintf("%s\n", object.GetComment()))
 		buf.WriteString(fmt.Sprintf("type %s struct {\n", object.Name))
 
 		for _, field := range object.Fields {

--- a/specification/specification.go
+++ b/specification/specification.go
@@ -1654,7 +1654,7 @@ func (o Object) IsFilter() bool {
 }
 
 func (o Object) GetComment() string {
-	return getComment(commentPrefix, o.Description, o.Name)
+	return getComment("", o.Description, o.Name)
 }
 
 // Utility factory methods

--- a/specification/specification_test.go
+++ b/specification/specification_test.go
@@ -995,6 +995,14 @@ func TestObject_GetComment(t *testing.T) {
 			},
 			expected: "// Address object",
 		},
+		{
+			name: "object with multiline description",
+			object: Object{
+				Name:        "User",
+				Description: "User entity representing a person\nContains profile and contact information",
+			},
+			expected: "// User entity representing a person\n// Contains profile and contact information",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/specification/specification_test.go
+++ b/specification/specification_test.go
@@ -972,6 +972,39 @@ func TestField_GetComment(t *testing.T) {
 	}
 }
 
+func TestObject_GetComment(t *testing.T) {
+	// Test Object.GetComment method which uses the getComment helper
+	testCases := []struct {
+		name     string
+		object   Object
+		expected string
+	}{
+		{
+			name: "basic object comment",
+			object: Object{
+				Name:        "User",
+				Description: "A user entity",
+			},
+			expected: "// User: A user entity",
+		},
+		{
+			name: "object with description starting with object name",
+			object: Object{
+				Name:        "Address",
+				Description: "Address object",
+			},
+			expected: "// Address object",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := tc.object.GetComment()
+			assert.Equal(t, tc.expected, result, "Object comment should match expected for case '%s'", tc.name)
+		})
+	}
+}
+
 // ============================================================================
 // Factory Function Tests
 // ============================================================================


### PR DESCRIPTION
Fixes excessive `//` prefixes in generated Go comments by correcting the `Object.GetComment` method and its usage.

Previously, `Object.GetComment` was incorrectly passing an existing `//` prefix to a helper function that added another `//`, resulting in `// //` comments. The `generateObjects` function then added a third `//` prefix, leading to `// // //` in the output. This PR adjusts `Object.GetComment` to return a correctly formatted single-slash comment and modifies `generateObjects` to use this output directly.

---
Linear Issue: [INF-398](https://linear.app/meitner-se/issue/INF-398/fix-go-comments)

<a href="https://cursor.com/background-agent?bcId=bc-562d0411-d4bb-4a42-855e-380b55fe2324"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-562d0411-d4bb-4a42-855e-380b55fe2324"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

