### PR TITLE
Refactor security configuration for consolidation

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -417,6 +417,72 @@ type DocumentStats struct {
 
 ---
 
+## Security Configuration
+
+The specification supports two ways to define security:
+
+### 1. Traditional Format (Separate SecuritySchemes and Security)
+```yaml
+# Define available security schemes
+securitySchemes:
+  apiKey:
+    type: apiKey
+    in: header
+    name: X-API-Key
+  bearerAuth:
+    type: http
+    scheme: bearer
+    bearerFormat: JWT
+
+# Define security requirements (schemes that must be satisfied together)
+security:
+  - [apiKey]           # Only API key required
+  - [bearerAuth]       # Only bearer token required
+  - [apiKey, bearerAuth]  # Both required together
+```
+
+### 2. New Grouped Format (Recommended)
+Groups related security schemes that work together:
+
+```yaml
+# Define security groups with their schemes
+security:
+  Basic:
+    - name: ClientID
+      type: apiKey
+      in: header
+      description: Client identifier
+    - name: ClientSecret
+      type: apiKey
+      in: header
+      description: Client secret
+  Secure:
+    - name: mTLS
+      type: mutualTLS
+      description: Mutual TLS authentication
+    - name: Bearer
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: JWT token authentication
+```
+
+This generates:
+- Security schemes: `Basic_ClientID`, `Basic_ClientSecret`, `Secure_mTLS`, `Secure_Bearer`
+- Security requirements: All schemes in a group are required together
+
+### Supported Security Types
+
+| Type | Fields | Description |
+|------|--------|-------------|
+| `apiKey` | `name`, `in` | API key in header, query, or cookie |
+| `http` | `scheme`, `bearerFormat` | HTTP authentication (basic, bearer, etc.) |
+| `mutualTLS` | - | Mutual TLS certificate authentication |
+| `oauth2` | `flows` | OAuth 2.0 (not shown in examples) |
+| `openIdConnect` | `openIdConnectUrl` | OpenID Connect Discovery (not shown) |
+
+---
+
 ## Usage Patterns
 
 ### Basic Usage Pattern

--- a/docs/openapi.md
+++ b/docs/openapi.md
@@ -23,6 +23,25 @@ retry:
   status_codes: ["5XX", "429"]
   retry_connection_errors: false
 
+# Security configuration (new grouped format)
+# Groups multiple schemes that work together
+security:
+  BasicAuth:
+    - name: ApiKey
+      type: apiKey
+      in: header
+      description: API key for authentication
+    - name: ApiSecret
+      type: apiKey
+      in: header
+      description: API secret for authentication
+  TokenAuth:
+    - name: Bearer
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: JWT token authentication
+
 enums:
   - name: "PetStatus"
     description: "Pet availability status"

--- a/examples/security-grouped.yaml
+++ b/examples/security-grouped.yaml
@@ -1,0 +1,52 @@
+name: Security Example API
+version: 1.0.0
+contact:
+  name: API Team
+  email: api@example.com
+servers:
+  - url: https://api.example.com/v1
+    description: Production server
+
+# New grouped security format
+# Groups multiple schemes that work together
+security:
+  Basic:
+    - name: ClientID
+      type: apiKey
+      in: header
+      description: Client identifier for API access
+    - name: ClientSecret
+      type: apiKey
+      in: header
+      description: Client secret for API access
+  Secure:
+    - name: mTLS
+      type: mutualTLS
+      description: Mutual TLS certificate authentication
+    - name: Bearer
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: JWT Bearer token authentication
+
+resources:
+  - name: User
+    description: User management endpoints
+    operations: [Create, Read, Update, Delete]
+    fields:
+      - name: id
+        type: UUID
+        description: Unique identifier for the user
+        modifiers: []
+      - name: email
+        type: String
+        description: User's email address
+        modifiers: []
+      - name: name
+        type: String
+        description: User's full name
+        modifiers: []
+      - name: role
+        type: String
+        description: User's role
+        modifiers: [Nullable]

--- a/specification/openapigen/openapigen.go
+++ b/specification/openapigen/openapigen.go
@@ -2248,13 +2248,19 @@ func (g *generator) createSecurityScheme(scheme specification.SecurityScheme) *v
 
 // addSecurityToDocument adds security requirements from the service to the OpenAPI document.
 func (g *generator) addSecurityToDocument(document *v3.Document, service *specification.Service) {
-	if len(service.Security) == 0 {
+	if service.Security == nil {
+		return
+	}
+
+	// Handle Security as interface{} - it should be []SecurityRequirement after processing
+	requirements, ok := service.Security.([]specification.SecurityRequirement)
+	if !ok || len(requirements) == 0 {
 		return
 	}
 
 	// Convert simplified SecurityRequirement to base.SecurityRequirement
-	securityRequirements := make([]*base.SecurityRequirement, len(service.Security))
-	for i, requirement := range service.Security {
+	securityRequirements := make([]*base.SecurityRequirement, len(requirements))
+	for i, requirement := range requirements {
 		securityRequirement := &base.SecurityRequirement{
 			Requirements: orderedmap.New[string, []string](),
 		}

--- a/specification/specification_security_test.go
+++ b/specification/specification_security_test.go
@@ -1,0 +1,224 @@
+package specification
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
+)
+
+// Test constants for security tests
+const (
+	testSecurityGroupName  = "Basic"
+	testSecurityGroupName2 = "Secure"
+	testClientIDName       = "ClientID"
+	testClientSecretName   = "ClientSecret"
+	testMTLSName           = "mTLS"
+	testBearerName         = "Bearer"
+	testAPIKeyType         = "apiKey"
+	testMutualTLSType      = "mutualTLS"
+	testHTTPType           = "http"
+	testHeaderLocation     = "header"
+	testBearerScheme       = "bearer"
+	testJWTFormat          = "JWT"
+)
+
+// contains is a helper function to check if a slice contains a string
+func contains(slice []string, str string) bool {
+	for _, s := range slice {
+		if s == str {
+			return true
+		}
+	}
+	return false
+}
+
+// TestProcessSecurity_GroupedFormat tests processing of the new grouped security format
+func TestProcessSecurity_GroupedFormat(t *testing.T) {
+	yamlData := `
+name: Test Service
+version: 1.0.0
+security:
+  Basic:
+    - name: ClientID
+      type: apiKey
+      in: header
+    - name: ClientSecret
+      type: apiKey
+      in: header
+  Secure:
+    - name: mTLS
+      type: mutualTLS
+    - name: Bearer
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+resources: []
+`
+
+	var service Service
+	err := yaml.Unmarshal([]byte(yamlData), &service)
+	assert.NoError(t, err, "Should parse YAML without error")
+
+	// Process security
+	requirements, err := service.ProcessSecurity()
+	assert.NoError(t, err, "Should process security without error")
+	assert.NotNil(t, requirements, "Should return security requirements")
+	assert.Len(t, requirements, 2, "Should have 2 security requirement groups")
+
+	// Check that security schemes were created
+	assert.NotNil(t, service.SecuritySchemes, "Should create security schemes map")
+	assert.Len(t, service.SecuritySchemes, 4, "Should have 4 security schemes")
+
+	// Verify Basic group schemes
+	basicClientID, exists := service.SecuritySchemes["Basic_ClientID"]
+	assert.True(t, exists, "Should have Basic_ClientID scheme")
+	assert.Equal(t, testAPIKeyType, basicClientID.Type)
+	assert.Equal(t, testClientIDName, basicClientID.Name)
+	assert.Equal(t, testHeaderLocation, basicClientID.In)
+
+	basicClientSecret, exists := service.SecuritySchemes["Basic_ClientSecret"]
+	assert.True(t, exists, "Should have Basic_ClientSecret scheme")
+	assert.Equal(t, testAPIKeyType, basicClientSecret.Type)
+	assert.Equal(t, testClientSecretName, basicClientSecret.Name)
+	assert.Equal(t, testHeaderLocation, basicClientSecret.In)
+
+	// Verify Secure group schemes
+	secureMTLS, exists := service.SecuritySchemes["Secure_mTLS"]
+	assert.True(t, exists, "Should have Secure_mTLS scheme")
+	assert.Equal(t, testMutualTLSType, secureMTLS.Type)
+
+	secureBearer, exists := service.SecuritySchemes["Secure_Bearer"]
+	assert.True(t, exists, "Should have Secure_Bearer scheme")
+	assert.Equal(t, testHTTPType, secureBearer.Type)
+	assert.Equal(t, testBearerScheme, secureBearer.Scheme)
+	assert.Equal(t, testJWTFormat, secureBearer.BearerFormat)
+
+	// Verify security requirements - order is not guaranteed
+	var foundBasic, foundSecure bool
+	for _, req := range requirements {
+		if len(req) == 2 && contains(req, "Basic_ClientID") && contains(req, "Basic_ClientSecret") {
+			foundBasic = true
+		}
+		if len(req) == 2 && contains(req, "Secure_mTLS") && contains(req, "Secure_Bearer") {
+			foundSecure = true
+		}
+	}
+	assert.True(t, foundBasic, "Should have Basic security requirement")
+	assert.True(t, foundSecure, "Should have Secure security requirement")
+}
+
+// TestProcessSecurity_OldFormat tests backward compatibility with the old format
+func TestProcessSecurity_OldFormat(t *testing.T) {
+	// Create service with old format already populated
+	service := Service{
+		Name:    "Test Service",
+		Version: "1.0.0",
+		SecuritySchemes: map[string]SecurityScheme{
+			"clientId": {
+				Type: "apiKey",
+				In:   "header",
+				Name: "X-Client-Id",
+			},
+			"clientSecret": {
+				Type: "apiKey",
+				In:   "header",
+				Name: "X-Client-Secret",
+			},
+		},
+		Security: []SecurityRequirement{
+			{"clientId", "clientSecret"},
+		},
+		Resources: []Resource{},
+	}
+
+	// Process security
+	requirements, err := service.ProcessSecurity()
+	assert.NoError(t, err, "Should process security without error")
+	assert.NotNil(t, requirements, "Should return security requirements")
+	assert.Len(t, requirements, 1, "Should have 1 security requirement")
+
+	// Verify old format is preserved
+	assert.Contains(t, requirements[0], "clientId")
+	assert.Contains(t, requirements[0], "clientSecret")
+	assert.Len(t, requirements[0], 2)
+
+	// SecuritySchemes should remain unchanged
+	assert.Len(t, service.SecuritySchemes, 2, "Should keep original security schemes")
+}
+
+// TestProcessSecurity_EmptySecurity tests processing with no security defined
+func TestProcessSecurity_EmptySecurity(t *testing.T) {
+	service := Service{
+		Name:      "Test Service",
+		Version:   "1.0.0",
+		Resources: []Resource{},
+	}
+
+	requirements, err := service.ProcessSecurity()
+	assert.NoError(t, err, "Should process without error")
+	assert.Nil(t, requirements, "Should return nil for empty security")
+}
+
+// TestProcessSecurity_InvalidGroupedFormat tests error handling for invalid format
+func TestProcessSecurity_InvalidGroupedFormat(t *testing.T) {
+	yamlData := `
+name: Test Service
+version: 1.0.0
+security:
+  Basic:
+    - type: apiKey
+      in: header
+resources: []
+`
+
+	var service Service
+	err := yaml.Unmarshal([]byte(yamlData), &service)
+	assert.NoError(t, err, "Should parse YAML without error")
+
+	// Process security - should fail due to missing name
+	_, err = service.ProcessSecurity()
+	assert.Error(t, err, "Should error when name is missing")
+	assert.Contains(t, err.Error(), "must have a 'name' field")
+}
+
+// TestParseServiceFromYAML_WithGroupedSecurity tests full parsing with grouped security
+func TestParseServiceFromYAML_WithGroupedSecurity(t *testing.T) {
+	yamlData := `
+name: Test Service
+version: 1.0.0
+security:
+  Basic:
+    - name: ClientID
+      type: apiKey
+      in: header
+      description: Client ID for authentication
+    - name: ClientSecret
+      type: apiKey
+      in: header
+      description: Client secret for authentication
+resources: []
+`
+
+	service, err := ParseServiceFromYAML([]byte(yamlData))
+	assert.NoError(t, err, "Should parse service without error")
+	assert.NotNil(t, service, "Should return service")
+
+	// After parsing with overlays, security should be processed
+	requirements, ok := service.Security.([]SecurityRequirement)
+	assert.True(t, ok, "Security should be converted to []SecurityRequirement")
+	assert.Len(t, requirements, 1, "Should have 1 security requirement")
+
+	// Check security schemes were created
+	assert.NotNil(t, service.SecuritySchemes)
+	assert.Len(t, service.SecuritySchemes, 2, "Should have 2 security schemes")
+
+	// Verify scheme details
+	scheme1, exists := service.SecuritySchemes["Basic_ClientID"]
+	assert.True(t, exists)
+	assert.Equal(t, "Client ID for authentication", scheme1.Description)
+
+	scheme2, exists := service.SecuritySchemes["Basic_ClientSecret"]
+	assert.True(t, exists)
+	assert.Equal(t, "Client secret for authentication", scheme2.Description)
+}


### PR DESCRIPTION
Introduce a new grouped security configuration format to simplify defining related security schemes.

This refactoring allows users to define security schemes that logically belong together under a single group, such as `Basic` or `Secure`. The system automatically expands these groups into individual security schemes (e.g., `Basic_ClientID`) and creates corresponding security requirements, improving clarity and reducing redundancy compared to defining schemes and requirements separately.

---
Linear Issue: [INF-454](https://linear.app/meitner-se/issue/INF-454/bug-when-defining-security-schemes)

<a href="https://cursor.com/background-agent?bcId=bc-55e19e02-03b0-45e2-9ceb-4c03308362d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-55e19e02-03b0-45e2-9ceb-4c03308362d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

