### PR TITLE
Refactor security definitions in specification

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -17,10 +17,9 @@ type Service struct {
     Version         string                     `json:"version,omitempty"`         // Service version  
     Contact         *ServiceContact            `json:"contact,omitempty"`         // Contact information
     License         *ServiceLicense            `json:"license,omitempty"`         // License information
-    Servers         []ServiceServer            `json:"servers,omitempty"`         // Server definitions
-    SecuritySchemes map[string]SecurityScheme  `json:"securitySchemes,omitempty"` // Security schemes
-    Security        []SecurityRequirement      `json:"security,omitempty"`        // Security requirements
-    Retry           *RetryConfiguration        `json:"retry,omitempty"`           // Retry configuration
+    Servers  []ServiceServer       `json:"servers,omitempty"`  // Server definitions
+    Security SecurityDefinition    `json:"security,omitempty"` // Security configurations
+    Retry    *RetryConfiguration   `json:"retry,omitempty"`    // Retry configuration
     Timeout         *TimeoutConfiguration      `json:"timeout,omitempty"`         // Timeout configuration
     Enums           []Enum                     `json:"enums"`                     // Enum definitions
     Objects         []Object                   `json:"objects"`                   // Shared objects
@@ -392,14 +391,24 @@ func (g *Generator) GetDocumentStats(document *v3.Document) DocumentStats
 
 ### Types
 
+#### SecurityDefinition
+Security configuration combining schemes and requirements.
+
+```go
+type SecurityDefinition map[string][]SecurityScheme
+```
+
 #### SecurityScheme
 Security scheme definition for OpenAPI.
 
 ```go
 type SecurityScheme struct {
-    Type string `json:"type"`
-    Name string `json:"name,omitempty"`
-    In   string `json:"in,omitempty"`
+    Type         string `json:"type"`
+    Description  string `json:"description,omitempty"`
+    Scheme       string `json:"scheme,omitempty"`
+    BearerFormat string `json:"bearerFormat,omitempty"`
+    Name         string `json:"name,omitempty"`
+    In           string `json:"in,omitempty"`
 }
 ```
 

--- a/docs/openapi.md
+++ b/docs/openapi.md
@@ -402,11 +402,6 @@ func customizeOpenAPI() {
     generator.SetContactInfo("API Team", "api@company.com", "https://company.com")
     generator.SetLicenseInfo("MIT", "https://opensource.org/licenses/MIT")  
     generator.AddTag("pets", "Everything about your Pets")
-    generator.AddSecurityScheme("apiKey", openapi.SecurityScheme{
-        Type: "apiKey",
-        Name: "X-API-Key",  
-        In:   "header",
-    })
     
     // Generate with customization
     document, _ := generator.GenerateFromService(service)

--- a/examples/security-example.yaml
+++ b/examples/security-example.yaml
@@ -1,0 +1,40 @@
+name: "Example API"
+version: "1.0.0"
+contact:
+  name: "API Support"
+  email: "support@example.com"
+  
+# New unified security configuration
+security:
+  Basic:
+    - name: ClientID
+      type: apiKey
+      in: header
+      description: Your client identifier
+    - name: ClientSecret
+      type: apiKey
+      in: header
+      description: Your client secret
+  Secure:
+    - name: mTLS
+      type: mutualTLS
+      description: Client TLS certificate required
+    - name: Bearer
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: Bearer access token in Authorization header
+
+resources:
+  - name: User
+    description: User management
+    operations: ["Create", "Read", "Update", "Delete"]
+    fields:
+      - name: email
+        type: String
+        description: User email address
+        operations: ["Create", "Read", "Update"]
+      - name: name
+        type: String
+        description: User full name
+        operations: ["Create", "Read", "Update"]

--- a/specification/specification.go
+++ b/specification/specification.go
@@ -370,6 +370,9 @@ type SecurityScheme struct {
 // SecurityRequirement represents scheme names that must be satisfied together.
 type SecurityRequirement []string
 
+// SecurityDefinition represents a single security configuration combining schemes and requirements.
+type SecurityDefinition map[string][]SecurityScheme
+
 // RetryBackoffConfiguration defines the backoff behavior for retry attempts.
 type RetryBackoffConfiguration struct {
 	// InitialInterval is the initial interval between retries in milliseconds
@@ -423,11 +426,8 @@ type Service struct {
 	// Servers that are part of the service
 	Servers []ServiceServer `json:"servers,omitempty"`
 
-	// SecuritySchemes defines available security schemes
-	SecuritySchemes map[string]SecurityScheme `json:"securitySchemes,omitempty"`
-
-	// Security defines global security requirements (OR logic between requirements)
-	Security []SecurityRequirement `json:"security,omitempty"`
+	// Security defines security configurations combining schemes and requirements
+	Security SecurityDefinition `json:"security,omitempty"`
 
 	// Retry configuration for the service
 	Retry *RetryConfiguration `json:"retry,omitempty"`
@@ -611,18 +611,17 @@ func ApplyOverlay(input *Service) *Service {
 
 	// Create a deep copy of the input service
 	result := &Service{
-		Name:            input.Name,
-		Version:         input.Version,
-		Contact:         input.Contact,                               // Copy contact information
-		License:         input.License,                               // Copy license information
-		Servers:         append([]ServiceServer{}, input.Servers...), // Copy servers slice
-		SecuritySchemes: input.SecuritySchemes,                       // Copy security schemes
-		Security:        input.Security,                              // Copy security requirements
-		Retry:           input.Retry,                                 // Copy retry configuration
-		Timeout:         input.Timeout,                               // Copy timeout configuration
-		Enums:           make([]Enum, 0, len(input.Enums)+1),         // +1 for ErrorCode enum
-		Objects:         make([]Object, 0, len(input.Objects)+3),     // +3 for Error, Pagination, and Meta objects
-		Resources:       make([]Resource, len(input.Resources)),
+		Name:      input.Name,
+		Version:   input.Version,
+		Contact:   input.Contact,                               // Copy contact information
+		License:   input.License,                               // Copy license information
+		Servers:   append([]ServiceServer{}, input.Servers...), // Copy servers slice
+		Security:  input.Security,                              // Copy security configuration
+		Retry:     input.Retry,                                 // Copy retry configuration
+		Timeout:   input.Timeout,                               // Copy timeout configuration
+		Enums:     make([]Enum, 0, len(input.Enums)+1),         // +1 for ErrorCode enum
+		Objects:   make([]Object, 0, len(input.Objects)+3),     // +3 for Error, Pagination, and Meta objects
+		Resources: make([]Resource, len(input.Resources)),
 	}
 
 	// Add default enums and objects if they don't already exist
@@ -1104,18 +1103,17 @@ func ApplyFilterOverlay(input *Service) *Service {
 
 	// Create a deep copy of the input service
 	result := &Service{
-		Name:            input.Name,
-		Version:         input.Version,
-		Contact:         input.Contact,                               // Copy contact information
-		License:         input.License,                               // Copy license information
-		Servers:         append([]ServiceServer{}, input.Servers...), // Copy servers slice
-		SecuritySchemes: input.SecuritySchemes,                       // Copy security schemes
-		Security:        input.Security,                              // Copy security requirements
-		Retry:           input.Retry,                                 // Copy retry configuration
-		Timeout:         input.Timeout,                               // Copy timeout configuration
-		Enums:           make([]Enum, len(input.Enums)),
-		Objects:         make([]Object, 0, len(input.Objects)*7), // Estimate for filter objects
-		Resources:       make([]Resource, len(input.Resources)),
+		Name:      input.Name,
+		Version:   input.Version,
+		Contact:   input.Contact,                               // Copy contact information
+		License:   input.License,                               // Copy license information
+		Servers:   append([]ServiceServer{}, input.Servers...), // Copy servers slice
+		Security:  input.Security,                              // Copy security configuration
+		Retry:     input.Retry,                                 // Copy retry configuration
+		Timeout:   input.Timeout,                               // Copy timeout configuration
+		Enums:     make([]Enum, len(input.Enums)),
+		Objects:   make([]Object, 0, len(input.Objects)*7), // Estimate for filter objects
+		Resources: make([]Resource, len(input.Resources)),
 	}
 
 	// Copy enums


### PR DESCRIPTION
Refactor security configuration to define schemes and requirements in a single `SecurityDefinition` map to simplify OpenAPI generation.

---
Linear Issue: [INF-455](https://linear.app/meitner-se/issue/INF-455/define-security-scheme-at-one-place)

<a href="https://cursor.com/background-agent?bcId=bc-3070f81a-6869-4b8e-9946-61f9d3f4d475"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3070f81a-6869-4b8e-9946-61f9d3f4d475"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

