### PR TITLE
Fix inconsistent security scheme generation

### DIFF
--- a/specification/openapigen/openapigen.go
+++ b/specification/openapigen/openapigen.go
@@ -2219,7 +2219,16 @@ func (g *generator) addSecuritySchemesToComponents(components *v3.Components, se
 		return
 	}
 
-	for schemeName, scheme := range service.SecuritySchemes {
+	// Get sorted list of scheme names for deterministic iteration
+	schemeNames := make([]string, 0, len(service.SecuritySchemes))
+	for schemeName := range service.SecuritySchemes {
+		schemeNames = append(schemeNames, schemeName)
+	}
+	sort.Strings(schemeNames)
+
+	// Add security schemes in sorted order
+	for _, schemeName := range schemeNames {
+		scheme := service.SecuritySchemes[schemeName]
 		securityScheme := g.createSecurityScheme(scheme)
 		components.SecuritySchemes.Set(schemeName, securityScheme)
 	}


### PR DESCRIPTION
Sort security scheme names to ensure consistent OpenAPI document generation.

The previous implementation iterated over Go maps for security schemes, which have non-deterministic ordering. This led to inconsistent OpenAPI JSON output on regeneration, as seen in the Linear issue INF-463. Sorting the scheme names alphabetically before adding them to the components guarantees a stable order.

---
Linear Issue: [INF-463](https://linear.app/meitner-se/issue/INF-463/securityscheme-generation-is-not-consistent)

<a href="https://cursor.com/background-agent?bcId=bc-61ab0b63-aec1-4d6b-8611-82a23a8cd252"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-61ab0b63-aec1-4d6b-8611-82a23a8cd252"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

