### PR TITLE
Ensure request bodies are required

### DIFF
--- a/specification/openapigen/openapigen.go
+++ b/specification/openapigen/openapigen.go
@@ -2167,9 +2167,13 @@ func (g *generator) createRequestBodyReference(resourceName, endpointName string
 	extensions := orderedmap.New[string, *yaml.Node]()
 	extensions.Set("$ref", &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: refString})
 
-	// Return a request body that serializes as a reference
+	// Mark request body as required (default behavior for request bodies in operations)
+	required := true
+
+	// Return a request body that serializes as a reference with required field
 	return &v3.RequestBody{
 		Extensions: extensions,
+		Required:   &required,
 	}
 }
 


### PR DESCRIPTION
Mark request bodies as required in OpenAPI generation to align with OpenAPI 3.0 specification.

---
Linear Issue: [INF-466](https://linear.app/meitner-se/issue/INF-466/make-sure-requestbodies-are-required)

<a href="https://cursor.com/background-agent?bcId=bc-1b630ca7-50bb-4352-b44b-0aa778dd160f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1b630ca7-50bb-4352-b44b-0aa778dd160f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

