### PR TITLE
Add custom request id func to servergen

### DIFF
--- a/specification/servergen/servergen.go
+++ b/specification/servergen/servergen.go
@@ -270,7 +270,7 @@ func generateServer(buf *bytes.Buffer, service *specification.Service) error {
 	buf.WriteString("\t}\n\n")
 
 	buf.WriteString("\tif api.Server.GetRequestIDFunc == nil {\n")
-	buf.WriteString("\t\tapi.Server.GetRequestIDFunc = func(ctx context.Context) string {\n")
+	buf.WriteString("\t\tapi.Server.GetRequestIDFunc = func(_ context.Context) string {\n")
 	buf.WriteString("\t\t\treturn uuid.New().String()\n")
 	buf.WriteString("\t\t}\n")
 	buf.WriteString("\t}\n\n")

--- a/specification/servergen/servergen_test.go
+++ b/specification/servergen/servergen_test.go
@@ -264,7 +264,7 @@ func TestGenerateServer(t *testing.T) {
 			"RegisterAPI function should check if GetRequestIDFunc is nil")
 
 		// Check default function assignment
-		assert.Contains(t, generatedCode, "api.Server.GetRequestIDFunc = func(ctx context.Context) string",
+		assert.Contains(t, generatedCode, "api.Server.GetRequestIDFunc = func(_ context.Context) string",
 			"Should assign default GetRequestIDFunc when nil")
 		assert.Contains(t, generatedCode, "return uuid.New().String()",
 			"Default GetRequestIDFunc should generate UUID")


### PR DESCRIPTION
Add `GetRequestIDFunc` to the `Server` struct and update generated `serve` functions to allow custom request ID generation.

This change provides flexibility for implementers to define their own request ID logic, while maintaining backward compatibility by defaulting to UUID generation if no custom function is provided.

---
Linear Issue: [INF-483](https://linear.app/meitner-se/issue/INF-483/add-getrequestidfunc-to-server-struct-in-servergen)

<a href="https://cursor.com/background-agent?bcId=bc-5db34fb2-2cff-42b2-a7a8-c208ec5d0a84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5db34fb2-2cff-42b2-a7a8-c208ec5d0a84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

