### PR TITLE
Remove request id from get session func

### DIFF
--- a/specification/servergen/doc.go
+++ b/specification/servergen/doc.go
@@ -89,7 +89,7 @@
 // a session object extracted by a user-provided GetSessionFunc:
 //
 //	type Server[Session any] struct {
-//	    GetSessionFunc    func(ctx context.Context, headers http.Header, requestID string) (Session, error)
+//	    GetSessionFunc    func(ctx context.Context, headers http.Header) (Session, error)
 //	    ConvertErrorFunc  func(err error, requestID string) *Error
 //	    RateLimiterFunc   func(ctx context.Context, session Session) (bool, error)
 //	}

--- a/specification/servergen/servergen.go
+++ b/specification/servergen/servergen.go
@@ -305,7 +305,7 @@ func generateServer(buf *bytes.Buffer, service *specification.Service) error {
 	buf.WriteString("}\n\n")
 
 	buf.WriteString("// getSessionFunc is a function that is used on each endpoint to set the session to the request\n")
-	buf.WriteString("type getSessionFunc[T any] func(ctx context.Context, headers http.Header, requestID string) (T, error)\n\n")
+	buf.WriteString("type getSessionFunc[T any] func(ctx context.Context, headers http.Header) (T, error)\n\n")
 
 	buf.WriteString(fmt.Sprintf("type %sAPI[Session any] struct {\n", serviceName))
 	buf.WriteString("\t// Server is the server configuration for the API\n")
@@ -535,7 +535,7 @@ func generateUtils(buf *bytes.Buffer) error {
 ) (Request[sessionType, pathParamsType, queryParamsType, bodyParamsType], *Error) {
 	var nilRequest Request[sessionType, pathParamsType, queryParamsType, bodyParamsType]
 
-	session, err := getSession(c.Request.Context(), c.Request.Header, requestID)
+	session, err := getSession(c.Request.Context(), c.Request.Header)
 	if err != nil {
 		return nilRequest, &Error{
 			Code:      ErrorCodeUnauthorized,

--- a/specification/servergen/servergen_test.go
+++ b/specification/servergen/servergen_test.go
@@ -859,7 +859,7 @@ func TestGenerateServerFunc(t *testing.T) {
 		"Should register DELETE endpoint without response")
 
 	// Check type definitions
-	assert.Contains(t, generatedCode, "type getSessionFunc[T any] func(ctx context.Context, headers http.Header, requestID string) (T, error)",
+	assert.Contains(t, generatedCode, "type getSessionFunc[T any] func(ctx context.Context, headers http.Header) (T, error)",
 		"Should define getSessionFunc type")
 	assert.Contains(t, generatedCode, "type TestServiceAPI[Session any] struct {",
 		"Should define service API struct")

--- a/specification/testgen/testgen.go
+++ b/specification/testgen/testgen.go
@@ -441,7 +441,7 @@ func generateServerSetup(buf *bytes.Buffer, serviceName string, service *specifi
 
 	buf.WriteString(fmt.Sprintf("\t\t%s.Register%sAPI(router, &%s.%sAPI[any]{\n", apiPackageName, serviceName, apiPackageName, serviceName))
 	buf.WriteString(fmt.Sprintf("\t\t\tServer: %s.Server[any]{\n", apiPackageName))
-	buf.WriteString("\t\t\t\tGetSessionFunc: func(ctx context.Context, headers http.Header, requestID string) (any, error) {\n")
+	buf.WriteString("\t\t\t\tGetSessionFunc: func(ctx context.Context, headers http.Header) (any, error) {\n")
 	buf.WriteString("\t\t\t\t\treturn testSessionUserID, nil\n")
 	buf.WriteString("\t\t\t\t},\n")
 	buf.WriteString(fmt.Sprintf("\t\t\t\tConvertErrorFunc: func(err error, requestID string) *%s.Error {\n", apiPackageName))
@@ -919,7 +919,7 @@ func generateServeWithResponseTest(buf *bytes.Buffer, apiPackageName string) err
 
 	buf.WriteString("\t// Create server configuration\n")
 	buf.WriteString("\tserver := " + apiPackageName + ".Server[any]{\n")
-	buf.WriteString("\t\tGetSessionFunc: func(ctx context.Context, headers http.Header, requestID string) (any, error) {\n")
+	buf.WriteString("\t\tGetSessionFunc: func(ctx context.Context, headers http.Header) (any, error) {\n")
 	buf.WriteString("\t\t\treturn \"test-session\", nil\n")
 	buf.WriteString("\t\t},\n")
 	buf.WriteString("\t\tConvertErrorFunc: func(err error, requestID string) *" + apiPackageName + ".Error {\n")
@@ -962,7 +962,7 @@ func generateServeWithoutResponseTest(buf *bytes.Buffer, apiPackageName string) 
 
 	buf.WriteString("\t// Create server configuration\n")
 	buf.WriteString("\tserver := " + apiPackageName + ".Server[any]{\n")
-	buf.WriteString("\t\tGetSessionFunc: func(ctx context.Context, headers http.Header, requestID string) (any, error) {\n")
+	buf.WriteString("\t\tGetSessionFunc: func(ctx context.Context, headers http.Header) (any, error) {\n")
 	buf.WriteString("\t\t\treturn \"test-session\", nil\n")
 	buf.WriteString("\t\t},\n")
 	buf.WriteString("\t\tConvertErrorFunc: func(err error, requestID string) *" + apiPackageName + ".Error {\n")
@@ -1241,7 +1241,7 @@ func generateInternalServerSetup(buf *bytes.Buffer, serviceName string, service 
 
 	buf.WriteString(fmt.Sprintf("\t\tRegister%sAPI(router, &%sAPI[any]{\n", serviceName, serviceName))
 	buf.WriteString("\t\t\tServer: Server[any]{\n")
-	buf.WriteString("\t\t\t\tGetSessionFunc: func(ctx context.Context, headers http.Header, requestID string) (any, error) {\n")
+	buf.WriteString("\t\t\t\tGetSessionFunc: func(ctx context.Context, headers http.Header) (any, error) {\n")
 	buf.WriteString("\t\t\t\t\treturn testSessionUserID, nil\n")
 	buf.WriteString("\t\t\t\t},\n")
 	buf.WriteString("\t\t\t\tConvertErrorFunc: func(err error, requestID string) *Error {\n")
@@ -1456,7 +1456,7 @@ func generateInternalUtilityTests(buf *bytes.Buffer, service *specification.Serv
 
 	buf.WriteString("\t// Create server configuration\n")
 	buf.WriteString("\tserver := Server[any]{\n")
-	buf.WriteString("\t\tGetSessionFunc: func(ctx context.Context, headers http.Header, requestID string) (any, error) {\n")
+	buf.WriteString("\t\tGetSessionFunc: func(ctx context.Context, headers http.Header) (any, error) {\n")
 	buf.WriteString("\t\t\treturn \"test-session\", nil\n")
 	buf.WriteString("\t\t},\n")
 	buf.WriteString("\t\tConvertErrorFunc: func(err error, requestID string) *Error {\n")
@@ -1495,7 +1495,7 @@ func generateInternalUtilityTests(buf *bytes.Buffer, service *specification.Serv
 
 	buf.WriteString("\t// Create server configuration\n")
 	buf.WriteString("\tserver := Server[any]{\n")
-	buf.WriteString("\t\tGetSessionFunc: func(ctx context.Context, headers http.Header, requestID string) (any, error) {\n")
+	buf.WriteString("\t\tGetSessionFunc: func(ctx context.Context, headers http.Header) (any, error) {\n")
 	buf.WriteString("\t\t\treturn \"test-session\", nil\n")
 	buf.WriteString("\t\t},\n")
 	buf.WriteString("\t\tConvertErrorFunc: func(err error, requestID string) *Error {\n")


### PR DESCRIPTION
Remove `requestID` parameter from `GetSessionFunc` to simplify the API and rely on context propagation for tracing.

The `requestID` parameter is redundant as trace IDs are propagated through the `context.Context` for logging and tracing purposes, aligning with Go best practices. This change cleans up the `GetSessionFunc` interface.

---
Linear Issue: [INF-484](https://linear.app/meitner-se/issue/INF-484/remove-requestid-param-from-getsessionfunc)

<a href="https://cursor.com/background-agent?bcId=bc-5f9ffbcd-c415-4e11-a578-9206a2a4f004"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5f9ffbcd-c415-4e11-a578-9206a2a4f004"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

