### PR TITLE
Order get request id func alphabetically

### DIFF
--- a/specification/servergen/doc.go
+++ b/specification/servergen/doc.go
@@ -89,6 +89,7 @@
 // a session object extracted by a user-provided GetSessionFunc:
 //
 //	type Server[Session any] struct {
+//	    GetRequestIDFunc  func(ctx context.Context) string
 //	    GetSessionFunc    func(ctx context.Context, headers http.Header) (Session, error)
 //	    ConvertErrorFunc  func(err error, requestID string) *Error
 //	    RateLimiterFunc   func(ctx context.Context, session Session) (bool, error)

--- a/specification/servergen/servergen.go
+++ b/specification/servergen/servergen.go
@@ -318,6 +318,10 @@ func generateServer(buf *bytes.Buffer, service *specification.Service) error {
 	buf.WriteString("}\n\n")
 
 	buf.WriteString("type Server[Session any] struct {\n")
+	buf.WriteString("\t// GetRequestIDFunc is a function that generates a request ID for each request\n")
+	buf.WriteString("\t// If nil, a default UUID-based request ID generator will be used\n")
+	buf.WriteString("\tGetRequestIDFunc func(ctx context.Context) string\n")
+
 	buf.WriteString("\t// GetSessionFunc is a function that is used on each endpoint to set the session to the request\n")
 	buf.WriteString("\tGetSessionFunc getSessionFunc[Session]\n")
 
@@ -327,10 +331,6 @@ func generateServer(buf *bytes.Buffer, service *specification.Service) error {
 	buf.WriteString("\t// RateLimiterFunc is a function that checks if a request is allowed to proceed based on rate limiting\n")
 	buf.WriteString("\t// It returns true if the request is allowed, false if rate limited, and an error if rate limit check fails\n")
 	buf.WriteString("\tRateLimiterFunc func(ctx context.Context, session Session) (bool, error)\n")
-
-	buf.WriteString("\t// GetRequestIDFunc is a function that generates a request ID for each request\n")
-	buf.WriteString("\t// If nil, a default UUID-based request ID generator will be used\n")
-	buf.WriteString("\tGetRequestIDFunc func(ctx context.Context) string\n")
 	buf.WriteString("}\n\n")
 
 	for _, resource := range service.Resources {


### PR DESCRIPTION
Move `GetRequestIDFunc` above `GetSessionFunc` in the `Server` struct to maintain alphabetical order of "Get" operations.

---
Linear Issue: [INF-485](https://linear.app/meitner-se/issue/INF-485/move-getrequestidfunc-to-be-above-the-getsessionfunc-in-server-struct)

<a href="https://cursor.com/background-agent?bcId=bc-60b9978b-f3fe-47fc-b7ac-d4a1fc1c9775"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-60b9978b-f3fe-47fc-b7ac-d4a1fc1c9775"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

