### PR TITLE
Refactor request object in servergen

### DIFF
--- a/specification/servergen/servergen.go
+++ b/specification/servergen/servergen.go
@@ -363,17 +363,17 @@ func generateRequestTypes(buf *bytes.Buffer, service *specification.Service) err
 	// Generate RequestContext struct first
 	buf.WriteString("type RequestContext struct {\n")
 	buf.WriteString("\t// ID of the request, can be used for debugging.\n")
-	buf.WriteString("\tRequestID string\n\n")
+	buf.WriteString("\tRequestID string `json:\"requestId\"`\n\n")
 	buf.WriteString("\t// Path of the request. For example, /employee/123/archive\n")
-	buf.WriteString("\tPath string\n\n")
+	buf.WriteString("\tPath string `json:\"path\"`\n\n")
 	buf.WriteString("\t// Route of the request. For example, /employee/:employee_id/archive\n")
-	buf.WriteString("\tRoute string\n\n")
+	buf.WriteString("\tRoute string `json:\"route\"`\n\n")
 	buf.WriteString("\t// UserAgent of the request\n")
-	buf.WriteString("\tUserAgent string\n\n")
+	buf.WriteString("\tUserAgent string `json:\"userAgent\"`\n\n")
 	buf.WriteString("\t// HTTPMethod of the request. For example, POST\n")
-	buf.WriteString("\tHTTPMethod string\n\n")
+	buf.WriteString("\tHTTPMethod string `json:\"httpMethod\"`\n\n")
 	buf.WriteString("\t// IPAddress of the request.\n")
-	buf.WriteString("\tIPAddress string\n")
+	buf.WriteString("\tIPAddress string `json:\"ipAddress\"`\n")
 	buf.WriteString("}\n\n")
 
 	// Generate Request struct

--- a/specification/servergen/servergen_test.go
+++ b/specification/servergen/servergen_test.go
@@ -88,12 +88,13 @@ const (
 	expectedFieldDecl  = "Name types.String `json:\"name\"`"
 
 	// Request/Response type constants
-	expectedRequestType     = "type Request[sessionType, pathParamsType, queryParamsType, bodyParamsType any] struct {"
-	expectedRequestIDMethod = "func (r Request[sessionType, pathParamsType, queryParamsType, bodyParamsType]) RequestID() string"
-	expectedPathParamsType  = "type UserCreateUserPathParams struct {"
-	expectedQueryParamsType = "type UserCreateUserQueryParams struct {"
-	expectedBodyParamsType  = "type UserCreateUserBodyParams struct {"
-	expectedResponseType    = "type UserCreateUserResponse struct {"
+	expectedRequestContextType = "type RequestContext struct {"
+	expectedRequestType        = "type Request[sessionType, pathParamsType, queryParamsType, bodyParamsType any] struct {"
+	expectedContextMethod      = "func (r Request[sessionType, pathParamsType, queryParamsType, bodyParamsType]) Context() RequestContext"
+	expectedPathParamsType     = "type UserCreateUserPathParams struct {"
+	expectedQueryParamsType    = "type UserCreateUserQueryParams struct {"
+	expectedBodyParamsType     = "type UserCreateUserBodyParams struct {"
+	expectedResponseType       = "type UserCreateUserResponse struct {"
 
 	// Utility function constants
 	expectedServeWithResponse    = "func serveWithResponse["
@@ -921,9 +922,10 @@ func TestGenerateRequestTypes(t *testing.T) {
 	assert.Nil(t, err, "Expected no error when generating request types")
 
 	generatedCode := buf.String()
+	assert.Contains(t, generatedCode, expectedRequestContextType, "Should generate RequestContext struct")
 	assert.Contains(t, generatedCode, expectedRequestType, "Should generate Request generic type")
-	assert.Contains(t, generatedCode, expectedRequestIDMethod, "Should generate RequestID() method")
-	assert.Contains(t, generatedCode, "return r.requestID", "RequestID method should return requestID field")
+	assert.Contains(t, generatedCode, expectedContextMethod, "Should generate Context() method")
+	assert.Contains(t, generatedCode, "return r.requestContext", "Context method should return requestContext field")
 
 	// Check path params type generation
 	assert.Contains(t, generatedCode, "type UserDeleteUserPathParams struct {", "Should generate path params type")

--- a/specification/testgen/testgen.go
+++ b/specification/testgen/testgen.go
@@ -1016,7 +1016,7 @@ func generateParseRequestTest(buf *bytes.Buffer, apiPackageName string) error {
 	buf.WriteString("\t\trequest, apiError := " + apiPackageName + ".ParseRequest[any, struct{}, struct{}, struct{}](c, \"test-123\", getSession)\n")
 	buf.WriteString("\t\tassert.Nil(t, apiError, \"Expected no error from parseRequest\")\n")
 	buf.WriteString("\t\tassert.Equal(t, \"test-session\", request.Session, \"Session should be set\")\n")
-	buf.WriteString("\t\tassert.Equal(t, \"test-123\", request.RequestID(), \"RequestID should be set\")\n")
+	buf.WriteString("\t\tassert.Equal(t, \"test-123\", request.Context().RequestID, \"RequestID should be set\")\n")
 	buf.WriteString("\t})\n\n")
 
 	buf.WriteString("\tt.Run(\"session function error returns API error\", func(t *testing.T) {\n")
@@ -1545,7 +1545,7 @@ func generateInternalUtilityTests(buf *bytes.Buffer, service *specification.Serv
 	buf.WriteString("\t\trequest, apiError := parseRequest[any, struct{}, struct{}, struct{}](c, \"test-123\", getSession)\n")
 	buf.WriteString("\t\tassert.Nil(t, apiError, \"Expected no error from parseRequest\")\n")
 	buf.WriteString("\t\tassert.Equal(t, \"test-session\", request.Session, \"Session should be set\")\n")
-	buf.WriteString("\t\tassert.Equal(t, \"test-123\", request.RequestID(), \"RequestID should be set\")\n")
+	buf.WriteString("\t\tassert.Equal(t, \"test-123\", request.Context().RequestID, \"RequestID should be set\")\n")
 	buf.WriteString("\t})\n\n")
 
 	buf.WriteString("\tt.Run(\"session function error returns API error\", func(t *testing.T) {\n")


### PR DESCRIPTION
Refactor the generated `Request` object to encapsulate request metadata in an unexported `RequestContext` struct, improving organization and maintainability.

---
Linear Issue: [INF-486](https://linear.app/meitner-se/issue/INF-486/refactor-the-generated-request-object-in-servergen)

<a href="https://cursor.com/background-agent?bcId=bc-e95f7a6a-3944-4529-9778-7f07fa077718"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e95f7a6a-3944-4529-9778-7f07fa077718"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

