### PR TITLE
Fix testgen getSession func

### DIFF
--- a/specification/testgen/testgen.go
+++ b/specification/testgen/testgen.go
@@ -1008,7 +1008,7 @@ func generateParseRequestTest(buf *bytes.Buffer, apiPackageName string) error {
 	buf.WriteString("\t\tc.Params = []gin.Param{{Key: \"id\", Value: \"123\"}}\n\n")
 
 	buf.WriteString("\t\t// Mock session function\n")
-	buf.WriteString("\t\tgetSession := func(ctx context.Context, headers http.Header, requestID string) (any, error) {\n")
+	buf.WriteString("\t\tgetSession := func(ctx context.Context, headers http.Header) (any, error) {\n")
 	buf.WriteString("\t\t\treturn \"test-session\", nil\n")
 	buf.WriteString("\t\t}\n\n")
 
@@ -1026,7 +1026,7 @@ func generateParseRequestTest(buf *bytes.Buffer, apiPackageName string) error {
 	buf.WriteString("\t\tc.Request = req\n\n")
 
 	buf.WriteString("\t\t// Mock session function that returns error\n")
-	buf.WriteString("\t\tgetSessionWithError := func(ctx context.Context, headers http.Header, requestID string) (any, error) {\n")
+	buf.WriteString("\t\tgetSessionWithError := func(ctx context.Context, headers http.Header) (any, error) {\n")
 	buf.WriteString("\t\t\treturn nil, fmt.Errorf(\"authentication failed\")\n")
 	buf.WriteString("\t\t}\n\n")
 
@@ -1052,7 +1052,7 @@ func generateParseRequestTest(buf *bytes.Buffer, apiPackageName string) error {
 	buf.WriteString("\t\tc.Request = req\n\n")
 
 	buf.WriteString("\t\t// Mock session function\n")
-	buf.WriteString("\t\tgetSession := func(ctx context.Context, headers http.Header, requestID string) (any, error) {\n")
+	buf.WriteString("\t\tgetSession := func(ctx context.Context, headers http.Header) (any, error) {\n")
 	buf.WriteString("\t\t\treturn \"test-session\", nil\n")
 	buf.WriteString("\t\t}\n\n")
 
@@ -1537,7 +1537,7 @@ func generateInternalUtilityTests(buf *bytes.Buffer, service *specification.Serv
 	buf.WriteString("\t\tc.Params = []gin.Param{{Key: \"id\", Value: \"123\"}}\n\n")
 
 	buf.WriteString("\t\t// Mock session function\n")
-	buf.WriteString("\t\tgetSession := func(ctx context.Context, headers http.Header, requestID string) (any, error) {\n")
+	buf.WriteString("\t\tgetSession := func(ctx context.Context, headers http.Header) (any, error) {\n")
 	buf.WriteString("\t\t\treturn \"test-session\", nil\n")
 	buf.WriteString("\t\t}\n\n")
 
@@ -1555,7 +1555,7 @@ func generateInternalUtilityTests(buf *bytes.Buffer, service *specification.Serv
 	buf.WriteString("\t\tc.Request = req\n\n")
 
 	buf.WriteString("\t\t// Mock session function that returns error\n")
-	buf.WriteString("\t\tgetSessionWithError := func(ctx context.Context, headers http.Header, requestID string) (any, error) {\n")
+	buf.WriteString("\t\tgetSessionWithError := func(ctx context.Context, headers http.Header) (any, error) {\n")
 	buf.WriteString("\t\t\treturn nil, fmt.Errorf(\"authentication failed\")\n")
 	buf.WriteString("\t\t}\n\n")
 
@@ -1581,7 +1581,7 @@ func generateInternalUtilityTests(buf *bytes.Buffer, service *specification.Serv
 	buf.WriteString("\t\tc.Request = req\n\n")
 
 	buf.WriteString("\t\t// Mock session function\n")
-	buf.WriteString("\t\tgetSession := func(ctx context.Context, headers http.Header, requestID string) (any, error) {\n")
+	buf.WriteString("\t\tgetSession := func(ctx context.Context, headers http.Header) (any, error) {\n")
 	buf.WriteString("\t\t\treturn \"test-session\", nil\n")
 	buf.WriteString("\t\t}\n\n")
 


### PR DESCRIPTION
Fix `testgen` to remove `requestID` from `getSession` and `getSessionWithError` function signatures because it was removed from the `servergen` package.

---
Linear Issue: [INF-487](https://linear.app/meitner-se/issue/INF-487/fix-testgen-to-not-include-requestid-in-getsession-func)

<a href="https://cursor.com/background-agent?bcId=bc-bbdab8c5-56a9-4696-9c4d-aa9636c26abd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bbdab8c5-56a9-4696-9c4d-aa9636c26abd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

