### PR TITLE
Rename parseRequest function

### DIFF
--- a/specification/servergen/servergen.go
+++ b/specification/servergen/servergen.go
@@ -463,7 +463,7 @@ func generateUtils(buf *bytes.Buffer) error {
 	return func(c *gin.Context) {
 		requestID := server.GetRequestIDFunc(c.Request.Context())
 
-		request, apiError := parseRequest[sessionType, pathParamsType, queryParamsType, bodyParamsType](c, requestID, server)
+		request, apiError := handleRequest[sessionType, pathParamsType, queryParamsType, bodyParamsType](c, requestID, server)
 		if apiError != nil {
 			c.JSON(apiError.HTTPStatusCode(), apiError)
 			return
@@ -513,7 +513,7 @@ func generateUtils(buf *bytes.Buffer) error {
 	return func(c *gin.Context) {
 		requestID := server.GetRequestIDFunc(c.Request.Context())
 
-		request, apiError := parseRequest[sessionType, pathParamsType, queryParamsType, bodyParamsType](c, requestID, server)
+		request, apiError := handleRequest[sessionType, pathParamsType, queryParamsType, bodyParamsType](c, requestID, server)
 		if apiError != nil {
 			c.JSON(apiError.HTTPStatusCode(), apiError)
 			return
@@ -550,7 +550,7 @@ func generateUtils(buf *bytes.Buffer) error {
 	}
 }` + "\n\n")
 
-	buf.WriteString(`func parseRequest[
+	buf.WriteString(`func handleRequest[
 	sessionType any,
 	pathParamsType any,
 	queryParamsType any,

--- a/specification/servergen/servergen_test.go
+++ b/specification/servergen/servergen_test.go
@@ -99,7 +99,7 @@ const (
 	// Utility function constants
 	expectedServeWithResponse    = "func serveWithResponse["
 	expectedServeWithoutResponse = "func serveWithoutResponse["
-	expectedParseRequest         = "func parseRequest["
+	expectedHandleRequest        = "func handleRequest["
 	expectedDecodeBodyParams     = "func decodeBodyParams[T any](r *http.Request) (T, error)"
 	expectedDecodePathParams     = "func decodePathParams[T any](c *gin.Context) (T, error)"
 	expectedDecodeQueryParams    = "func decodeQueryParams[T any](c *gin.Context) (T, error)"
@@ -165,7 +165,7 @@ func TestGenerateServer(t *testing.T) {
 	// Verify utility functions
 	assert.Contains(t, generatedCode, expectedServeWithResponse, "Generated code should contain serveWithResponse function")
 	assert.Contains(t, generatedCode, expectedServeWithoutResponse, "Generated code should contain serveWithoutResponse function")
-	assert.Contains(t, generatedCode, expectedParseRequest, "Generated code should contain parseRequest function")
+	assert.Contains(t, generatedCode, expectedHandleRequest, "Generated code should contain handleRequest function")
 
 	// Verify RateLimiterFunc in Server struct
 	assert.Contains(t, generatedCode, expectedRateLimiterFunc, "Server struct should contain RateLimiterFunc")
@@ -1132,21 +1132,21 @@ func TestGenerateUtils(t *testing.T) {
 	// Check all utility functions are generated
 	assert.Contains(t, generatedCode, expectedServeWithResponse, "Should generate serveWithResponse")
 	assert.Contains(t, generatedCode, expectedServeWithoutResponse, "Should generate serveWithoutResponse")
-	assert.Contains(t, generatedCode, expectedParseRequest, "Should generate parseRequest")
+	assert.Contains(t, generatedCode, expectedHandleRequest, "Should generate handleRequest")
 	assert.Contains(t, generatedCode, expectedDecodeBodyParams, "Should generate decodeBodyParams")
 	assert.Contains(t, generatedCode, expectedDecodePathParams, "Should generate decodePathParams")
 	assert.Contains(t, generatedCode, expectedDecodeQueryParams, "Should generate decodeQueryParams")
 
 	// Check function implementations
 	assert.Contains(t, generatedCode, `requestID := server.GetRequestIDFunc(c.Request.Context())`, "Should use GetRequestIDFunc with context")
-	assert.Contains(t, generatedCode, "parseRequest[sessionType, pathParamsType, queryParamsType, bodyParamsType]",
-		"Should call parseRequest with generic types")
+	assert.Contains(t, generatedCode, "handleRequest[sessionType, pathParamsType, queryParamsType, bodyParamsType]",
+		"Should call handleRequest with generic types")
 	assert.Contains(t, generatedCode, "c.JSON(successStatusCode, response)",
 		"Should return JSON response with success code")
 	assert.Contains(t, generatedCode, "c.JSON(apiError.HTTPStatusCode(), apiError)",
 		"Should return error with appropriate status code")
 
-	// Check parseRequest implementation
+	// Check handleRequest implementation
 	assert.Contains(t, generatedCode, "if _, ok := any(request.BodyParams).(struct{}); !ok {",
 		"Should check if body params exist")
 	assert.Contains(t, generatedCode, "if _, ok := any(request.PathParams).(struct{}); !ok {",

--- a/specification/testgen/testgen.go
+++ b/specification/testgen/testgen.go
@@ -879,8 +879,8 @@ func generateUtilityTests(buf *bytes.Buffer, service *specification.Service, api
 		return err
 	}
 
-	// Test parseRequest
-	err = generateParseRequestTest(buf, apiPackageName)
+	// Test handleRequest
+	err = generateHandleRequestTest(buf, apiPackageName)
 	if err != nil {
 		return err
 	}
@@ -997,9 +997,9 @@ func generateServeWithoutResponseTest(buf *bytes.Buffer, apiPackageName string) 
 	return nil
 }
 
-// generateParseRequestTest generates test for parseRequest function.
-func generateParseRequestTest(buf *bytes.Buffer, apiPackageName string) error {
-	buf.WriteString("func Test_parseRequest(t *testing.T) {\n")
+// generateHandleRequestTest generates test for handleRequest function.
+func generateHandleRequestTest(buf *bytes.Buffer, apiPackageName string) error {
+	buf.WriteString("func Test_handleRequest(t *testing.T) {\n")
 	buf.WriteString("\tgin.SetMode(gin.TestMode)\n\n")
 
 	buf.WriteString("\tt.Run(\"successful request parsing\", func(t *testing.T) {\n")
@@ -1027,9 +1027,9 @@ func generateParseRequestTest(buf *bytes.Buffer, apiPackageName string) error {
 	buf.WriteString("\t\t\t},\n")
 	buf.WriteString("\t\t}\n\n")
 
-	buf.WriteString("\t\t// Test parseRequest\n")
-	buf.WriteString("\t\trequest, apiError := " + apiPackageName + ".ParseRequest[any, struct{}, struct{}, struct{}](c, \"test-123\", server)\n")
-	buf.WriteString("\t\tassert.Nil(t, apiError, \"Expected no error from parseRequest\")\n")
+	buf.WriteString("\t\t// Test handleRequest\n")
+	buf.WriteString("\t\trequest, apiError := " + apiPackageName + ".HandleRequest[any, struct{}, struct{}, struct{}](c, \"test-123\", server)\n")
+	buf.WriteString("\t\tassert.Nil(t, apiError, \"Expected no error from handleRequest\")\n")
 	buf.WriteString("\t\tassert.Equal(t, \"test-session\", request.Session, \"Session should be set\")\n")
 	buf.WriteString("\t\tassert.Equal(t, \"test-123\", request.Context().RequestID, \"RequestID should be set\")\n")
 	buf.WriteString("\t})\n\n")
@@ -1054,8 +1054,8 @@ func generateParseRequestTest(buf *bytes.Buffer, apiPackageName string) error {
 	buf.WriteString("\t\t\t},\n")
 	buf.WriteString("\t\t}\n\n")
 
-	buf.WriteString("\t\t// Test parseRequest with session error\n")
-	buf.WriteString("\t\t_, apiError := " + apiPackageName + ".ParseRequest[any, struct{}, struct{}, struct{}](c, \"test-456\", server)\n")
+	buf.WriteString("\t\t// Test handleRequest with session error\n")
+	buf.WriteString("\t\t_, apiError := " + apiPackageName + ".HandleRequest[any, struct{}, struct{}, struct{}](c, \"test-456\", server)\n")
 	buf.WriteString("\t\tassert.NotNil(t, apiError, \"Expected API error when session function fails\")\n")
 	buf.WriteString("\t\tassert.Equal(t, " + apiPackageName + ".ErrorCodeUnauthorized, apiError.Code, \"Should return Unauthorized error code\")\n")
 	buf.WriteString("\t\tassert.Contains(t, apiError.Message.String(), \"authentication failed\", \"Error message should contain session error\")\n")
@@ -1089,15 +1089,15 @@ func generateParseRequestTest(buf *bytes.Buffer, apiPackageName string) error {
 	buf.WriteString("\t\t\t},\n")
 	buf.WriteString("\t\t}\n\n")
 
-	buf.WriteString("\t\t// Test parseRequest with invalid JSON\n")
-	buf.WriteString("\t\t_, apiError := " + apiPackageName + ".ParseRequest[any, struct{}, struct{}, TestBodyParams](c, \"test-789\", server)\n")
+	buf.WriteString("\t\t// Test handleRequest with invalid JSON\n")
+	buf.WriteString("\t\t_, apiError := " + apiPackageName + ".HandleRequest[any, struct{}, struct{}, TestBodyParams](c, \"test-789\", server)\n")
 	buf.WriteString("\t\tassert.NotNil(t, apiError, \"Expected API error when JSON is invalid\")\n")
 	buf.WriteString("\t\tassert.Equal(t, " + apiPackageName + ".ErrorCodeBadRequest, apiError.Code, \"Should return BadRequest error code\")\n")
 	buf.WriteString("\t\tassert.Contains(t, apiError.Message.String(), \"cannot decode json body params\", \"Error message should mention JSON decoding\")\n")
 	buf.WriteString("\t\tassert.Equal(t, \"test-789\", apiError.RequestID.String(), \"Request ID should be set in error\")\n")
 	buf.WriteString("\t})\n\n")
 
-	buf.WriteString("\tt.Run(\"pre-hooks are executed in parseRequest\", func(t *testing.T) {\n")
+	buf.WriteString("\tt.Run(\"pre-hooks are executed in handleRequest\", func(t *testing.T) {\n")
 	buf.WriteString("\t\tc, _ := gin.CreateTestContext(httptest.NewRecorder())\n")
 	buf.WriteString("\t\treq, err := http.NewRequest(\"POST\", \"/test\", nil)\n")
 	buf.WriteString("\t\tassert.NoError(t, err, \"Failed to create request\")\n")
@@ -1127,15 +1127,15 @@ func generateParseRequestTest(buf *bytes.Buffer, apiPackageName string) error {
 	buf.WriteString("\t\t\t},\n")
 	buf.WriteString("\t\t}\n\n")
 
-	buf.WriteString("\t\t// Test parseRequest with pre-hook\n")
-	buf.WriteString("\t\trequest, apiError := " + apiPackageName + ".ParseRequest[any, struct{}, struct{}, struct{}](c, \"test-prehook\", server)\n")
-	buf.WriteString("\t\tassert.Nil(t, apiError, \"Expected no error from parseRequest\")\n")
+	buf.WriteString("\t\t// Test handleRequest with pre-hook\n")
+	buf.WriteString("\t\trequest, apiError := " + apiPackageName + ".HandleRequest[any, struct{}, struct{}, struct{}](c, \"test-prehook\", server)\n")
+	buf.WriteString("\t\tassert.Nil(t, apiError, \"Expected no error from handleRequest\")\n")
 	buf.WriteString("\t\tassert.True(t, hookExecuted, \"Pre-hook should have been executed\")\n")
 	buf.WriteString("\t\tassert.Equal(t, \"test-prehook\", capturedContext.RequestID, \"Pre-hook should receive correct RequestID\")\n")
 	buf.WriteString("\t\tassert.Equal(t, \"/test\", capturedContext.Path, \"Pre-hook should receive correct Path\")\n")
 	buf.WriteString("\t})\n\n")
 
-	buf.WriteString("\tt.Run(\"pre-hook error aborts parseRequest\", func(t *testing.T) {\n")
+	buf.WriteString("\tt.Run(\"pre-hook error aborts handleRequest\", func(t *testing.T) {\n")
 	buf.WriteString("\t\tc, _ := gin.CreateTestContext(httptest.NewRecorder())\n")
 	buf.WriteString("\t\treq, err := http.NewRequest(\"POST\", \"/test\", nil)\n")
 	buf.WriteString("\t\tassert.NoError(t, err, \"Failed to create request\")\n")
@@ -1160,8 +1160,8 @@ func generateParseRequestTest(buf *bytes.Buffer, apiPackageName string) error {
 	buf.WriteString("\t\t\t},\n")
 	buf.WriteString("\t\t}\n\n")
 
-	buf.WriteString("\t\t// Test parseRequest with pre-hook error\n")
-	buf.WriteString("\t\t_, apiError := " + apiPackageName + ".ParseRequest[any, struct{}, struct{}, struct{}](c, \"test-prehook-error\", server)\n")
+	buf.WriteString("\t\t// Test handleRequest with pre-hook error\n")
+	buf.WriteString("\t\t_, apiError := " + apiPackageName + ".HandleRequest[any, struct{}, struct{}, struct{}](c, \"test-prehook-error\", server)\n")
 	buf.WriteString("\t\tassert.NotNil(t, apiError, \"Expected API error when pre-hook fails\")\n")
 	buf.WriteString("\t\tassert.Equal(t, " + apiPackageName + ".ErrorCodeForbidden, apiError.Code, \"Should return Forbidden error code\")\n")
 	buf.WriteString("\t\tassert.Contains(t, apiError.Message.String(), \"pre-hook validation failed\", \"Error message should contain pre-hook error\")\n")
@@ -1624,8 +1624,8 @@ func generateInternalUtilityTests(buf *bytes.Buffer, service *specification.Serv
 	buf.WriteString("\tassert.Equal(t, 204, w.Code, \"Expected 204 status code\")\n")
 	buf.WriteString("}\n\n")
 
-	// Test parseRequest
-	buf.WriteString("func Test_parseRequest(t *testing.T) {\n")
+	// Test handleRequest
+	buf.WriteString("func Test_handleRequest(t *testing.T) {\n")
 	buf.WriteString("\tgin.SetMode(gin.TestMode)\n\n")
 
 	buf.WriteString("\tt.Run(\"successful request parsing\", func(t *testing.T) {\n")
@@ -1653,9 +1653,9 @@ func generateInternalUtilityTests(buf *bytes.Buffer, service *specification.Serv
 	buf.WriteString("\t\t\t},\n")
 	buf.WriteString("\t\t}\n\n")
 
-	buf.WriteString("\t\t// Test parseRequest\n")
-	buf.WriteString("\t\trequest, apiError := parseRequest[any, struct{}, struct{}, struct{}](c, \"test-123\", server)\n")
-	buf.WriteString("\t\tassert.Nil(t, apiError, \"Expected no error from parseRequest\")\n")
+	buf.WriteString("\t\t// Test handleRequest\n")
+	buf.WriteString("\t\trequest, apiError := handleRequest[any, struct{}, struct{}, struct{}](c, \"test-123\", server)\n")
+	buf.WriteString("\t\tassert.Nil(t, apiError, \"Expected no error from handleRequest\")\n")
 	buf.WriteString("\t\tassert.Equal(t, \"test-session\", request.Session, \"Session should be set\")\n")
 	buf.WriteString("\t\tassert.Equal(t, \"test-123\", request.Context().RequestID, \"RequestID should be set\")\n")
 	buf.WriteString("\t})\n\n")
@@ -1680,8 +1680,8 @@ func generateInternalUtilityTests(buf *bytes.Buffer, service *specification.Serv
 	buf.WriteString("\t\t\t},\n")
 	buf.WriteString("\t\t}\n\n")
 
-	buf.WriteString("\t\t// Test parseRequest with session error\n")
-	buf.WriteString("\t\t_, apiError := parseRequest[any, struct{}, struct{}, struct{}](c, \"test-456\", server)\n")
+	buf.WriteString("\t\t// Test handleRequest with session error\n")
+	buf.WriteString("\t\t_, apiError := handleRequest[any, struct{}, struct{}, struct{}](c, \"test-456\", server)\n")
 	buf.WriteString("\t\tassert.NotNil(t, apiError, \"Expected API error when session function fails\")\n")
 	buf.WriteString("\t\tassert.Equal(t, ErrorCodeUnauthorized, apiError.Code, \"Should return Unauthorized error code\")\n")
 	buf.WriteString("\t\tassert.Contains(t, apiError.Message.String(), \"authentication failed\", \"Error message should contain session error\")\n")
@@ -1715,15 +1715,15 @@ func generateInternalUtilityTests(buf *bytes.Buffer, service *specification.Serv
 	buf.WriteString("\t\t\t},\n")
 	buf.WriteString("\t\t}\n\n")
 
-	buf.WriteString("\t\t// Test parseRequest with invalid JSON\n")
-	buf.WriteString("\t\t_, apiError := parseRequest[any, struct{}, struct{}, TestBodyParams](c, \"test-789\", server)\n")
+	buf.WriteString("\t\t// Test handleRequest with invalid JSON\n")
+	buf.WriteString("\t\t_, apiError := handleRequest[any, struct{}, struct{}, TestBodyParams](c, \"test-789\", server)\n")
 	buf.WriteString("\t\tassert.NotNil(t, apiError, \"Expected API error when JSON is invalid\")\n")
 	buf.WriteString("\t\tassert.Equal(t, ErrorCodeBadRequest, apiError.Code, \"Should return BadRequest error code\")\n")
 	buf.WriteString("\t\tassert.Contains(t, apiError.Message.String(), \"cannot decode json body params\", \"Error message should mention JSON decoding\")\n")
 	buf.WriteString("\t\tassert.Equal(t, \"test-789\", apiError.RequestID.String(), \"Request ID should be set in error\")\n")
 	buf.WriteString("\t})\n\n")
 
-	buf.WriteString("\tt.Run(\"pre-hooks are executed in parseRequest\", func(t *testing.T) {\n")
+	buf.WriteString("\tt.Run(\"pre-hooks are executed in handleRequest\", func(t *testing.T) {\n")
 	buf.WriteString("\t\tc, _ := gin.CreateTestContext(httptest.NewRecorder())\n")
 	buf.WriteString("\t\treq, err := http.NewRequest(\"POST\", \"/test\", nil)\n")
 	buf.WriteString("\t\tassert.NoError(t, err, \"Failed to create request\")\n")
@@ -1753,15 +1753,15 @@ func generateInternalUtilityTests(buf *bytes.Buffer, service *specification.Serv
 	buf.WriteString("\t\t\t},\n")
 	buf.WriteString("\t\t}\n\n")
 
-	buf.WriteString("\t\t// Test parseRequest with pre-hook\n")
-	buf.WriteString("\t\trequest, apiError := parseRequest[any, struct{}, struct{}, struct{}](c, \"test-prehook\", server)\n")
-	buf.WriteString("\t\tassert.Nil(t, apiError, \"Expected no error from parseRequest\")\n")
+	buf.WriteString("\t\t// Test handleRequest with pre-hook\n")
+	buf.WriteString("\t\trequest, apiError := handleRequest[any, struct{}, struct{}, struct{}](c, \"test-prehook\", server)\n")
+	buf.WriteString("\t\tassert.Nil(t, apiError, \"Expected no error from handleRequest\")\n")
 	buf.WriteString("\t\tassert.True(t, hookExecuted, \"Pre-hook should have been executed\")\n")
 	buf.WriteString("\t\tassert.Equal(t, \"test-prehook\", capturedContext.RequestID, \"Pre-hook should receive correct RequestID\")\n")
 	buf.WriteString("\t\tassert.Equal(t, \"/test\", capturedContext.Path, \"Pre-hook should receive correct Path\")\n")
 	buf.WriteString("\t})\n\n")
 
-	buf.WriteString("\tt.Run(\"pre-hook error aborts parseRequest\", func(t *testing.T) {\n")
+	buf.WriteString("\tt.Run(\"pre-hook error aborts handleRequest\", func(t *testing.T) {\n")
 	buf.WriteString("\t\tc, _ := gin.CreateTestContext(httptest.NewRecorder())\n")
 	buf.WriteString("\t\treq, err := http.NewRequest(\"POST\", \"/test\", nil)\n")
 	buf.WriteString("\t\tassert.NoError(t, err, \"Failed to create request\")\n")
@@ -1786,8 +1786,8 @@ func generateInternalUtilityTests(buf *bytes.Buffer, service *specification.Serv
 	buf.WriteString("\t\t\t},\n")
 	buf.WriteString("\t\t}\n\n")
 
-	buf.WriteString("\t\t// Test parseRequest with pre-hook error\n")
-	buf.WriteString("\t\t_, apiError := parseRequest[any, struct{}, struct{}, struct{}](c, \"test-prehook-error\", server)\n")
+	buf.WriteString("\t\t// Test handleRequest with pre-hook error\n")
+	buf.WriteString("\t\t_, apiError := handleRequest[any, struct{}, struct{}, struct{}](c, \"test-prehook-error\", server)\n")
 	buf.WriteString("\t\tassert.NotNil(t, apiError, \"Expected API error when pre-hook fails\")\n")
 	buf.WriteString("\t\tassert.Equal(t, ErrorCodeForbidden, apiError.Code, \"Should return Forbidden error code\")\n")
 	buf.WriteString("\t\tassert.Contains(t, apiError.Message.String(), \"pre-hook validation failed\", \"Error message should contain pre-hook error\")\n")

--- a/specification/testgen/testgen_test.go
+++ b/specification/testgen/testgen_test.go
@@ -111,14 +111,14 @@ func TestGenerateInternalTests(t *testing.T) {
 	// Check utility function tests (no package prefixes)
 	assert.Contains(t, generatedCode, "func Test_serveWithResponse(t *testing.T) {", "Should generate serveWithResponse test")
 	assert.Contains(t, generatedCode, "func Test_serveWithoutResponse(t *testing.T) {", "Should generate serveWithoutResponse test")
-	assert.Contains(t, generatedCode, "func Test_parseRequest(t *testing.T) {", "Should generate parseRequest test")
+	assert.Contains(t, generatedCode, "func Test_handleRequest(t *testing.T) {", "Should generate handleRequest test")
 	assert.Contains(t, generatedCode, "func Test_decodeBodyParams(t *testing.T) {", "Should generate decodeBodyParams test")
 	assert.Contains(t, generatedCode, "func Test_decodePathParams(t *testing.T) {", "Should generate decodePathParams test")
 	assert.Contains(t, generatedCode, "func Test_decodeQueryParams(t *testing.T) {", "Should generate decodeQueryParams test")
 
 	// Verify no package prefixes are used
 	assert.Contains(t, generatedCode, "handler := serveWithResponse(", "Should call serveWithResponse without prefix")
-	assert.Contains(t, generatedCode, "parseRequest[any, struct{}, struct{}, struct{}](", "Should call parseRequest without prefix")
+	assert.Contains(t, generatedCode, "handleRequest[any, struct{}, struct{}, struct{}](", "Should call handleRequest without prefix")
 	assert.Contains(t, generatedCode, "decodeBodyParams[TestBody](", "Should call decodeBodyParams with struct type")
 	assert.Contains(t, generatedCode, "decodePathParams[TestPathParams](", "Should call decodePathParams with struct type")
 	assert.Contains(t, generatedCode, "decodeQueryParams[TestQueryParams](", "Should call decodeQueryParams with struct type")


### PR DESCRIPTION
Rename `parseRequest` function to `handleRequest` for improved clarity and semantic accuracy.

---
Linear Issue: [INF-493](https://linear.app/meitner-se/issue/INF-493/rename-parserequest-function-to-something-else)

<a href="https://cursor.com/background-agent?bcId=bc-50a20246-81ba-4732-a104-60fa8da9b191"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-50a20246-81ba-4732-a104-60fa8da9b191"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

