### PR TITLE
Remove rate limiter function

### DIFF
--- a/specification/servergen/doc.go
+++ b/specification/servergen/doc.go
@@ -92,28 +92,7 @@
 //	    GetRequestIDFunc  func(ctx context.Context) string
 //	    GetSessionFunc    func(ctx context.Context, headers http.Header) (Session, error)
 //	    ConvertErrorFunc  func(err error, requestID string) *Error
-//	    RateLimiterFunc   func(ctx context.Context, session Session) (bool, error)
 //	}
-//
-// # Rate Limiting
-//
-// The server supports optional rate limiting through the RateLimiterFunc. When provided,
-// this function is called after request parsing and session retrieval but before the
-// endpoint handler executes:
-//
-//	api.Server.RateLimiterFunc = func(ctx context.Context, session MySession) (bool, error) {
-//	    // Check rate limit based on session (e.g., user ID, API key)
-//	    allowed, err := rateLimiter.CheckLimit(session.UserID)
-//	    if err != nil {
-//	        return false, err // Internal error during rate limit check
-//	    }
-//	    return allowed, nil
-//	}
-//
-// The function returns:
-// - (true, nil): Request is allowed to proceed
-// - (false, nil): Request is rate limited (returns HTTP 429 with ErrorCodeRateLimited)
-// - (false, error): Internal error during rate limit check (returns HTTP 500)
 //
 // # Error Handling
 //

--- a/specification/servergen/servergen.go
+++ b/specification/servergen/servergen.go
@@ -328,10 +328,6 @@ func generateServer(buf *bytes.Buffer, service *specification.Service) error {
 	buf.WriteString("\t// ConvertErrorFunc is a function that is used on each endpoint to convert an error to an Error object\n")
 	buf.WriteString("\tConvertErrorFunc func(err error, requestID string) *Error\n")
 
-	buf.WriteString("\t// RateLimiterFunc is a function that checks if a request is allowed to proceed based on rate limiting\n")
-	buf.WriteString("\t// It returns true if the request is allowed, false if rate limited, and an error if rate limit check fails\n")
-	buf.WriteString("\tRateLimiterFunc func(ctx context.Context, session Session) (bool, error)\n")
-
 	buf.WriteString("\t// PreHooks are executed before endpoint logic. The first non-nil error aborts request processing.\n")
 	buf.WriteString("\tPreHooks []PreHook\n")
 
@@ -513,26 +509,6 @@ func generateUtils(buf *bytes.Buffer) error {
 			return
 		}
 
-		// Check rate limit if RateLimiterFunc is provided
-		if server.RateLimiterFunc != nil {
-			allowed, err := server.RateLimiterFunc(c.Request.Context(), request.Session)
-			if err != nil {
-				// Internal error during rate limit check
-				apiError := server.ConvertErrorFunc(err, requestID)
-				c.JSON(apiError.HTTPStatusCode(), apiError)
-				return
-			}
-			if !allowed {
-				// Rate limit exceeded
-				c.JSON(http.StatusTooManyRequests, &Error{
-					Code:      ErrorCodeRateLimited,
-					Message:   types.NewString("Rate limit exceeded"),
-					RequestID: types.NewString(requestID),
-				})
-				return
-			}
-		}
-
 		response, err := function(c.Request.Context(), request)
 		if err != nil {
 			apiError := server.ConvertErrorFunc(err, requestID)
@@ -561,26 +537,6 @@ func generateUtils(buf *bytes.Buffer) error {
 		if apiError != nil {
 			c.JSON(apiError.HTTPStatusCode(), apiError)
 			return
-		}
-
-		// Check rate limit if RateLimiterFunc is provided
-		if server.RateLimiterFunc != nil {
-			allowed, err := server.RateLimiterFunc(c.Request.Context(), request.Session)
-			if err != nil {
-				// Internal error during rate limit check
-				apiError := server.ConvertErrorFunc(err, requestID)
-				c.JSON(apiError.HTTPStatusCode(), apiError)
-				return
-			}
-			if !allowed {
-				// Rate limit exceeded
-				c.JSON(http.StatusTooManyRequests, &Error{
-					Code:      ErrorCodeRateLimited,
-					Message:   types.NewString("Rate limit exceeded"),
-					RequestID: types.NewString(requestID),
-				})
-				return
-			}
 		}
 
 		err := function(c.Request.Context(), request)

--- a/specification/servergen/servergen_test.go
+++ b/specification/servergen/servergen_test.go
@@ -108,13 +108,6 @@ const (
 	expectedFieldComment  = "// Name: User name"
 	expectedObjectComment = "// Address object"
 
-	// Rate limiter constants
-	expectedRateLimiterFunc     = "RateLimiterFunc func(ctx context.Context, session Session) (bool, error)"
-	expectedRateLimiterCheck    = "if server.RateLimiterFunc != nil"
-	expectedRateLimitedError    = "ErrorCodeRateLimited"
-	expectedRateLimitedMessage  = "Rate limit exceeded"
-	expectedRateLimitStatusCode = "http.StatusTooManyRequests"
-
 	// GetRequestIDFunc constants
 	expectedGetRequestIDFunc     = "GetRequestIDFunc func(ctx context.Context) string"
 	expectedGetRequestIDNilCheck = "if api.Server.GetRequestIDFunc == nil"
@@ -167,9 +160,6 @@ func TestGenerateServer(t *testing.T) {
 	assert.Contains(t, generatedCode, expectedServeWithoutResponse, "Generated code should contain serveWithoutResponse function")
 	assert.Contains(t, generatedCode, expectedHandleRequest, "Generated code should contain handleRequest function")
 
-	// Verify RateLimiterFunc in Server struct
-	assert.Contains(t, generatedCode, expectedRateLimiterFunc, "Server struct should contain RateLimiterFunc")
-
 	t.Run("edge cases", func(t *testing.T) {
 		t.Run("empty service", func(t *testing.T) {
 			// Arrange
@@ -203,45 +193,6 @@ func TestGenerateServer(t *testing.T) {
 			// Note: Double spaces can appear in comments like "// //"
 			assert.Contains(t, generatedCode, "\t", "Generated code should use tabs for indentation")
 		})
-	})
-
-	t.Run("rate limiter functionality", func(t *testing.T) {
-		// Arrange
-		service := createTestServiceWithEndpoints()
-		buf := &bytes.Buffer{}
-
-		// Act
-		err := GenerateServer(buf, service)
-
-		// Assert
-		assert.Nil(t, err, "Expected no error when generating server with rate limiter")
-		generatedCode := buf.String()
-
-		// Check that RateLimiterFunc is defined in Server struct
-		assert.Contains(t, generatedCode, expectedRateLimiterFunc,
-			"Server struct should contain RateLimiterFunc definition")
-
-		// Check that rate limiter check is present in serveWithResponse
-		assert.Contains(t, generatedCode, expectedRateLimiterCheck,
-			"serveWithResponse should check if RateLimiterFunc is not nil")
-
-		// Check that rate limited error response is generated correctly
-		assert.Contains(t, generatedCode, expectedRateLimitedError,
-			"Should use ErrorCodeRateLimited for rate limit errors")
-		assert.Contains(t, generatedCode, expectedRateLimitedMessage,
-			"Should include rate limit exceeded message")
-		assert.Contains(t, generatedCode, expectedRateLimitStatusCode,
-			"Should return HTTP 429 Too Many Requests status")
-
-		// Verify rate limiter integration in both serve functions
-		// Check that the functions contain the rate limiter call
-		assert.Contains(t, generatedCode, "allowed, err := server.RateLimiterFunc(c.Request.Context(), request.Session)",
-			"Generated code should call RateLimiterFunc with correct parameters")
-
-		// Count occurrences to ensure it's in both functions
-		rateLimiterCallCount := strings.Count(generatedCode, "server.RateLimiterFunc(c.Request.Context(), request.Session)")
-		assert.Equal(t, 2, rateLimiterCallCount,
-			"RateLimiterFunc should be called in both serveWithResponse and serveWithoutResponse")
 	})
 
 	t.Run("GetRequestIDFunc functionality", func(t *testing.T) {


### PR DESCRIPTION
Remove `RateLimiterFunc` and its associated logic and tests as rate limiting is now handled by SessionHooks.

---
Linear Issue: [INF-494](https://linear.app/meitner-se/issue/INF-494/remove-ratelimiter-func)

<a href="https://cursor.com/background-agent?bcId=bc-5219333b-ca27-4166-87b8-db6a82094d44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5219333b-ca27-4166-87b8-db6a82094d44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

