### PR TITLE
Fix unused variable in testgen

### DIFF
--- a/specification/testgen/testgen.go
+++ b/specification/testgen/testgen.go
@@ -1134,7 +1134,7 @@ func generateHandleRequestTest(buf *bytes.Buffer, apiPackageName string) error {
 	buf.WriteString("\t\t}\n\n")
 
 	buf.WriteString("\t\t// Test handleRequest with pre-hook\n")
-	buf.WriteString("\t\trequest, apiError := " + apiPackageName + ".HandleRequest[any, struct{}, struct{}, struct{}](c, \"test-prehook\", server)\n")
+	buf.WriteString("\t\t_, apiError := " + apiPackageName + ".HandleRequest[any, struct{}, struct{}, struct{}](c, \"test-prehook\", server)\n")
 	buf.WriteString("\t\tassert.Nil(t, apiError, \"Expected no error from handleRequest\")\n")
 	buf.WriteString("\t\tassert.True(t, hookExecuted, \"Pre-hook should have been executed\")\n")
 	buf.WriteString("\t\tassert.Equal(t, \"test-prehook\", capturedContext.RequestID, \"Pre-hook should receive correct RequestID\")\n")
@@ -1833,7 +1833,7 @@ func generateInternalUtilityTests(buf *bytes.Buffer, service *specification.Serv
 	buf.WriteString("\t\t}\n\n")
 
 	buf.WriteString("\t\t// Test handleRequest with pre-hook\n")
-	buf.WriteString("\t\trequest, apiError := handleRequest[any, struct{}, struct{}, struct{}](c, \"test-prehook\", server)\n")
+	buf.WriteString("\t\t_, apiError := handleRequest[any, struct{}, struct{}, struct{}](c, \"test-prehook\", server)\n")
 	buf.WriteString("\t\tassert.Nil(t, apiError, \"Expected no error from handleRequest\")\n")
 	buf.WriteString("\t\tassert.True(t, hookExecuted, \"Pre-hook should have been executed\")\n")
 	buf.WriteString("\t\tassert.Equal(t, \"test-prehook\", capturedContext.RequestID, \"Pre-hook should receive correct RequestID\")\n")


### PR DESCRIPTION
Fix testgen to replace unused `request` variable with `_` to resolve linter warnings.

---
Linear Issue: [INF-496](https://linear.app/meitner-se/issue/INF-496/fix-testgen-to-not-generate-unused-variable)

<a href="https://cursor.com/background-agent?bcId=bc-41ff3960-2b97-4517-928f-bd78e146b656"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-41ff3960-2b97-4517-928f-bd78e146b656"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

