### PR TITLE
Add default getRequestID function

### DIFF
--- a/specification/servergen/servergen.go
+++ b/specification/servergen/servergen.go
@@ -269,12 +269,6 @@ func generateServer(buf *bytes.Buffer, service *specification.Service) error {
 	buf.WriteString("\t\tpanic(\"GetSessionFunc is nil\")\n")
 	buf.WriteString("\t}\n\n")
 
-	buf.WriteString("\tif api.Server.GetRequestIDFunc == nil {\n")
-	buf.WriteString("\t\tapi.Server.GetRequestIDFunc = func(_ context.Context) string {\n")
-	buf.WriteString("\t\t\treturn uuid.New().String()\n")
-	buf.WriteString("\t\t}\n")
-	buf.WriteString("\t}\n\n")
-
 	buf.WriteString(fmt.Sprintf("\trouterGroup := router.Group(\"/%s/%s\")\n\n", service.PathName(), service.Version))
 
 	buf.WriteString("\t// OpenAPI Documentation in JSON format\n")

--- a/specification/servergen/servergen_test.go
+++ b/specification/servergen/servergen_test.go
@@ -109,8 +109,7 @@ const (
 	expectedObjectComment = "// Address object"
 
 	// GetRequestIDFunc constants
-	expectedGetRequestIDFunc     = "GetRequestIDFunc func(ctx context.Context) string"
-	expectedGetRequestIDNilCheck = "if api.Server.GetRequestIDFunc == nil"
+	expectedGetRequestIDFunc = "GetRequestIDFunc func(ctx context.Context) string"
 )
 
 // ============================================================================
@@ -210,16 +209,6 @@ func TestGenerateServer(t *testing.T) {
 		// Check that GetRequestIDFunc is defined in Server struct
 		assert.Contains(t, generatedCode, expectedGetRequestIDFunc,
 			"Server struct should contain GetRequestIDFunc definition")
-
-		// Check that GetRequestIDFunc nil check is in RegisterAPI function
-		assert.Contains(t, generatedCode, expectedGetRequestIDNilCheck,
-			"RegisterAPI function should check if GetRequestIDFunc is nil")
-
-		// Check default function assignment
-		assert.Contains(t, generatedCode, "api.Server.GetRequestIDFunc = func(_ context.Context) string",
-			"Should assign default GetRequestIDFunc when nil")
-		assert.Contains(t, generatedCode, "return uuid.New().String()",
-			"Default GetRequestIDFunc should generate UUID")
 
 		// Verify defaultGetRequestID function exists
 		assert.Contains(t, generatedCode, "func defaultGetRequestID(ctx context.Context) string",

--- a/specification/servergen/servergen_test.go
+++ b/specification/servergen/servergen_test.go
@@ -221,14 +221,26 @@ func TestGenerateServer(t *testing.T) {
 		assert.Contains(t, generatedCode, "return uuid.New().String()",
 			"Default GetRequestIDFunc should generate UUID")
 
-		// Verify GetRequestIDFunc usage in serve functions
-		assert.Contains(t, generatedCode, "requestID := server.GetRequestIDFunc(c.Request.Context())",
-			"Should use GetRequestIDFunc with context in serve functions")
+		// Verify defaultGetRequestID function exists
+		assert.Contains(t, generatedCode, "func defaultGetRequestID(ctx context.Context) string",
+			"Should define defaultGetRequestID function")
+		assert.Contains(t, generatedCode, "// defaultGetRequestID is the default request ID generator function",
+			"Should document defaultGetRequestID function")
 
-		// Count occurrences to ensure it's in both serve functions
-		getRequestIDUsageCount := strings.Count(generatedCode, "server.GetRequestIDFunc(c.Request.Context())")
+		// Verify GetRequestIDFunc usage in serve functions with nil check
+		assert.Contains(t, generatedCode, "getRequestID := server.GetRequestIDFunc",
+			"Should assign GetRequestIDFunc to local variable")
+		assert.Contains(t, generatedCode, "if getRequestID == nil {",
+			"Should check if GetRequestIDFunc is nil")
+		assert.Contains(t, generatedCode, "getRequestID = defaultGetRequestID",
+			"Should use defaultGetRequestID when GetRequestIDFunc is nil")
+		assert.Contains(t, generatedCode, "requestID := getRequestID(c.Request.Context())",
+			"Should call getRequestID with context")
+
+		// Count occurrences to ensure the pattern is in both serve functions
+		getRequestIDUsageCount := strings.Count(generatedCode, "getRequestID := server.GetRequestIDFunc")
 		assert.Equal(t, 2, getRequestIDUsageCount,
-			"GetRequestIDFunc should be called in both serveWithResponse and serveWithoutResponse")
+			"GetRequestIDFunc assignment should be in both serveWithResponse and serveWithoutResponse")
 	})
 }
 
@@ -1089,7 +1101,10 @@ func TestGenerateUtils(t *testing.T) {
 	assert.Contains(t, generatedCode, expectedDecodeQueryParams, "Should generate decodeQueryParams")
 
 	// Check function implementations
-	assert.Contains(t, generatedCode, `requestID := server.GetRequestIDFunc(c.Request.Context())`, "Should use GetRequestIDFunc with context")
+	assert.Contains(t, generatedCode, `getRequestID := server.GetRequestIDFunc`, "Should assign GetRequestIDFunc to local variable")
+	assert.Contains(t, generatedCode, `if getRequestID == nil {`, "Should check if GetRequestIDFunc is nil")
+	assert.Contains(t, generatedCode, `getRequestID = defaultGetRequestID`, "Should use defaultGetRequestID when nil")
+	assert.Contains(t, generatedCode, `requestID := getRequestID(c.Request.Context())`, "Should call getRequestID with context")
 	assert.Contains(t, generatedCode, "handleRequest[sessionType, pathParamsType, queryParamsType, bodyParamsType]",
 		"Should call handleRequest with generic types")
 	assert.Contains(t, generatedCode, "c.JSON(successStatusCode, response)",


### PR DESCRIPTION
Add a default `getRequestID` function to prevent nil pointer panics if `server.GetRequestIDFunc` is not set.

---
Linear Issue: [INF-504](https://linear.app/meitner-se/issue/INF-504/default-getrequestid-function)

<a href="https://cursor.com/background-agent?bcId=bc-644d1812-d9b3-4f66-813b-5154cf6a3c7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-644d1812-d9b3-4f66-813b-5154cf6a3c7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

