### PR TITLE
Add response method to error object

### DIFF
--- a/specification/servergen/error_interface_test.go
+++ b/specification/servergen/error_interface_test.go
@@ -19,8 +19,8 @@ const (
 	testErrorMethodSignature = "func (e *Error) Error() string"
 	testErrorMethodBody      = "return e.Message.String()"
 	testHTTPStatusCodeMethod = "func (e *Error) HTTPStatusCode() int"
-	testResponseMethod       = "func (e *Error) Response() (int, *Error)"
-	testResponseMethodBody   = "return e.HTTPStatusCode(), e"
+	testResponseMethod       = "func (e *Error) Response() (int, map[string]*Error)"
+	testResponseMethodBody   = "return e.HTTPStatusCode(), map[string]*Error{\"error\": e}"
 )
 
 // ============================================================================
@@ -301,17 +301,17 @@ func TestResponseMethod(t *testing.T) {
 
 	// Verify Response method implementation
 	assert.Contains(t, generatedCode, testResponseMethodBody,
-		"Response() method should call HTTPStatusCode() and return self")
+		"Response() method should return HTTPStatusCode and error map")
 
 	t.Run("method signature", func(t *testing.T) {
 		// Verify the complete method signature
-		assert.Contains(t, generatedCode, "func (e *Error) Response() (int, *Error)",
-			"Response() method should have correct signature with two return values")
+		assert.Contains(t, generatedCode, "func (e *Error) Response() (int, map[string]*Error)",
+			"Response() method should return int and map[string]*Error")
 	})
 
 	t.Run("method implementation", func(t *testing.T) {
-		// Verify the method returns both status code and error pointer
-		responseMethodStart := strings.Index(generatedCode, "func (e *Error) Response() (int, *Error) {")
+		// Verify the method returns both status code and error map
+		responseMethodStart := strings.Index(generatedCode, "func (e *Error) Response() (int, map[string]*Error) {")
 		assert.NotEqual(t, -1, responseMethodStart, "Should find Response() method")
 
 		responseMethodEnd := strings.Index(generatedCode[responseMethodStart:], "}")
@@ -323,9 +323,9 @@ func TestResponseMethod(t *testing.T) {
 		assert.Contains(t, responseMethod, "e.HTTPStatusCode()",
 			"Response() method should call HTTPStatusCode()")
 
-		// Verify the method returns both values
-		assert.Contains(t, responseMethod, "return e.HTTPStatusCode(), e",
-			"Response() method should return status code and error pointer")
+		// Verify the method returns status code and error map
+		assert.Contains(t, responseMethod, "map[string]*Error{\"error\": e}",
+			"Response() method should return error in a map with key \"error\"")
 
 		// Verify exactly one return statement
 		assert.Equal(t, 1, strings.Count(responseMethod, "return"),

--- a/specification/servergen/servergen.go
+++ b/specification/servergen/servergen.go
@@ -247,8 +247,8 @@ func generateObjects(buf *bytes.Buffer, service *specification.Service) error {
 			buf.WriteString("\t}\n")
 			buf.WriteString("}\n\n")
 
-			buf.WriteString("func (e *Error) Response() (int, *Error) {\n")
-			buf.WriteString("\treturn e.HTTPStatusCode(), e\n")
+			buf.WriteString("func (e *Error) Response() (int, map[string]*Error) {\n")
+			buf.WriteString("\treturn e.HTTPStatusCode(), map[string]*Error{\"error\": e}\n")
 			buf.WriteString("}\n\n")
 		}
 	}


### PR DESCRIPTION
Add a `Response()` method to the generated `Error` object to facilitate direct error returns with HTTP status codes.

The `Response()` method returns `(int, *Error)` which includes the HTTP status code and the error object itself. This is intended to streamline error handling in API responses, allowing the error object to be returned directly.

---
Linear Issue: [INF-505](https://linear.app/meitner-se/issue/INF-505/add-response-method-on-error-object)

<a href="https://cursor.com/background-agent?bcId=bc-d8e3d8f4-ab3c-42f4-9547-c82003bda396"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d8e3d8f4-ab3c-42f4-9547-c82003bda396"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

