### PR TITLE
Refactor error response handling in serve-methods

### DIFF
--- a/specification/servergen/error_interface_test.go
+++ b/specification/servergen/error_interface_test.go
@@ -411,11 +411,9 @@ func TestErrorInterfaceIntegration(t *testing.T) {
 	assert.Contains(t, generatedCode, "return &Error{",
 		"Error handling should create Error instances")
 
-	// Verify the Error type can be used as an error
-	assert.Contains(t, generatedCode, "apiError := server.ErrorHook(err, requestID)",
-		"Should be able to assign Error to error variables")
-
-	// Verify HTTPStatusCode is used
-	assert.Contains(t, generatedCode, "apiError.HTTPStatusCode()",
-		"Should use HTTPStatusCode() method for error responses")
+	// Verify the Response method is used in error handling
+	assert.Contains(t, generatedCode, "c.JSON(server.ErrorHook(err, requestID).Response())",
+		"Should use Response() method for error responses")
+	assert.Contains(t, generatedCode, "c.JSON(server.ErrorHook(apiError, requestID).Response())",
+		"Should use Response() method for apiError responses")
 }

--- a/specification/servergen/servergen.go
+++ b/specification/servergen/servergen.go
@@ -515,15 +515,13 @@ func defaultGetRequestID(ctx context.Context) string {
 
 		request, apiError := handleRequest[sessionType, pathParamsType, queryParamsType, bodyParamsType](c, requestID, server)
 		if apiError != nil {
-			apiError = server.ErrorHook(apiError, requestID)
-			c.JSON(apiError.HTTPStatusCode(), apiError)
+			c.JSON(server.ErrorHook(apiError, requestID).Response())
 			return
 		}
 
 		response, err := function(c.Request.Context(), request)
 		if err != nil {
-			apiError := server.ErrorHook(err, requestID)
-			c.JSON(apiError.HTTPStatusCode(), apiError)
+			c.JSON(server.ErrorHook(err, requestID).Response())
 			return
 		}
 
@@ -550,15 +548,13 @@ func defaultGetRequestID(ctx context.Context) string {
 
 		request, apiError := handleRequest[sessionType, pathParamsType, queryParamsType, bodyParamsType](c, requestID, server)
 		if apiError != nil {
-			apiError = server.ErrorHook(apiError, requestID)
-			c.JSON(apiError.HTTPStatusCode(), apiError)
+			c.JSON(server.ErrorHook(apiError, requestID).Response())
 			return
 		}
 
 		err := function(c.Request.Context(), request)
 		if err != nil {
-			apiError := server.ErrorHook(err, requestID)
-			c.JSON(apiError.HTTPStatusCode(), apiError)
+			c.JSON(server.ErrorHook(err, requestID).Response())
 			return
 		}
 		

--- a/specification/servergen/servergen_test.go
+++ b/specification/servergen/servergen_test.go
@@ -1098,8 +1098,10 @@ func TestGenerateUtils(t *testing.T) {
 		"Should call handleRequest with generic types")
 	assert.Contains(t, generatedCode, "c.JSON(successStatusCode, response)",
 		"Should return JSON response with success code")
-	assert.Contains(t, generatedCode, "c.JSON(apiError.HTTPStatusCode(), apiError)",
-		"Should return error with appropriate status code")
+	assert.Contains(t, generatedCode, "c.JSON(server.ErrorHook(err, requestID).Response())",
+		"Should return error using Response() method")
+	assert.Contains(t, generatedCode, "c.JSON(server.ErrorHook(apiError, requestID).Response())",
+		"Should return apiError using Response() method")
 
 	// Check handleRequest implementation
 	assert.Contains(t, generatedCode, "if _, ok := any(request.BodyParams).(struct{}); !ok {",


### PR DESCRIPTION
Refactor error response handling in `serve-methods` to use the `Response()` method on the error object for cleaner and more consistent API error responses.

---
Linear Issue: [INF-506](https://linear.app/meitner-se/issue/INF-506/fix-error-response-in-serve-methods)

<a href="https://cursor.com/background-agent?bcId=bc-e445a4ed-2ac7-4133-b321-9533afffe077"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e445a4ed-2ac7-4133-b321-9533afffe077"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

