### PR TITLE
Fix error handling in handleRequest

### DIFF
--- a/specification/servergen/error_interface_test.go
+++ b/specification/servergen/error_interface_test.go
@@ -414,6 +414,4 @@ func TestErrorInterfaceIntegration(t *testing.T) {
 	// Verify the Response method is used in error handling
 	assert.Contains(t, generatedCode, "c.JSON(server.ErrorHook(err, requestID).Response())",
 		"Should use Response() method for error responses")
-	assert.Contains(t, generatedCode, "c.JSON(server.ErrorHook(apiError, requestID).Response())",
-		"Should use Response() method for apiError responses")
 }

--- a/specification/servergen/servergen.go
+++ b/specification/servergen/servergen.go
@@ -593,7 +593,11 @@ func defaultGetRequestID(ctx context.Context) string {
 
 	session, err := server.GetSessionFunc(c.Request.Context(), c.Request.Header)
 	if err != nil {
-		return nilRequest, err
+		return nilRequest, &Error{
+			Code:      ErrorCodeUnauthorized,
+			Message:   types.NewString(err.Error()),
+			RequestID: types.NewString(requestID),
+		}
 	}
 
 	// Run session hooks after successful authentication
@@ -613,7 +617,11 @@ func defaultGetRequestID(ctx context.Context) string {
 	if _, ok := any(request.BodyParams).(struct{}); !ok {
 		bodyParams, err := decodeBodyParams[bodyParamsType](c.Request)
 		if err != nil {
-			return nilRequest, fmt.Errorf("cannot decode json body params: %w", err)
+			return nilRequest, &Error{
+				Code:      ErrorCodeBadRequest,
+				Message:   types.NewString("cannot decode json body params: " + err.Error()),
+				RequestID: types.NewString(requestID),
+			}
 		}
 
 		request.BodyParams = bodyParams
@@ -622,7 +630,11 @@ func defaultGetRequestID(ctx context.Context) string {
 	if _, ok := any(request.PathParams).(struct{}); !ok {
 		pathParams, err := decodePathParams[pathParamsType](c)
 		if err != nil {
-			return nilRequest, fmt.Errorf("cannot decode path params: %w", err)
+			return nilRequest, &Error{
+				Code:      ErrorCodeBadRequest,
+				Message:   types.NewString("cannot decode path params: " + err.Error()),
+				RequestID: types.NewString(requestID),
+			}
 		}
 
 		request.PathParams = pathParams
@@ -631,7 +643,11 @@ func defaultGetRequestID(ctx context.Context) string {
 	if _, ok := any(request.QueryParams).(struct{}); !ok {
 		queryParams, err := decodeQueryParams[queryParamsType](c)
 		if err != nil {
-			return nilRequest, fmt.Errorf("cannot decode query params: %w", err)
+			return nilRequest, &Error{
+				Code:      ErrorCodeBadRequest,
+				Message:   types.NewString("cannot decode query params: " + err.Error()),
+				RequestID: types.NewString(requestID),
+			}
 		}
 
 		request.QueryParams = queryParams

--- a/specification/servergen/servergen_test.go
+++ b/specification/servergen/servergen_test.go
@@ -1100,8 +1100,6 @@ func TestGenerateUtils(t *testing.T) {
 		"Should return JSON response with success code")
 	assert.Contains(t, generatedCode, "c.JSON(server.ErrorHook(err, requestID).Response())",
 		"Should return error using Response() method")
-	assert.Contains(t, generatedCode, "c.JSON(server.ErrorHook(apiError, requestID).Response())",
-		"Should return apiError using Response() method")
 
 	// Check handleRequest implementation
 	assert.Contains(t, generatedCode, "if _, ok := any(request.BodyParams).(struct{}); !ok {",


### PR DESCRIPTION
Refactor `handleRequest` to return the `error` interface and remove redundant `ErrorHook` calls, centralizing error processing in `serve` methods.

---
Linear Issue: [INF-507](https://linear.app/meitner-se/issue/INF-507/do-not-run-errorhook-in-handlerequest-func)

<a href="https://cursor.com/background-agent?bcId=bc-f7fd087b-8543-45bc-8356-7362daddc46e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f7fd087b-8543-45bc-8356-7362daddc46e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

