### PR TITLE
Extract request context building to function

### DIFF
--- a/specification/servergen/servergen.go
+++ b/specification/servergen/servergen.go
@@ -562,6 +562,17 @@ func defaultGetRequestID(ctx context.Context) string {
 	}
 }` + "\n\n")
 
+	buf.WriteString(`func getRequestContext(c *gin.Context, requestID string) RequestContext {
+	return RequestContext{
+		RequestID:  requestID,
+		Path:       c.Request.URL.Path,
+		Route:      c.FullPath(),
+		UserAgent:  c.Request.UserAgent(),
+		HTTPMethod: c.Request.Method,
+		IPAddress:  c.ClientIP(),
+	}
+}` + "\n\n")
+
 	buf.WriteString(`func handleRequest[
 	sessionType any,
 	pathParamsType any,
@@ -575,14 +586,7 @@ func defaultGetRequestID(ctx context.Context) string {
 	var nilRequest Request[sessionType, pathParamsType, queryParamsType, bodyParamsType]
 
 	// Build RequestContext first for pre-hooks
-	requestContext := RequestContext{
-		RequestID:  requestID,
-		Path:       c.Request.URL.Path,
-		Route:      c.FullPath(),
-		UserAgent:  c.Request.UserAgent(),
-		HTTPMethod: c.Request.Method,
-		IPAddress:  c.ClientIP(),
-	}
+	requestContext := getRequestContext(c, requestID)
 
 	// Run pre-hooks before parsing request
 	for _, preHook := range server.PreHooks {

--- a/specification/servergen/servergen_test.go
+++ b/specification/servergen/servergen_test.go
@@ -97,6 +97,7 @@ const (
 	expectedResponseType       = "type UserCreateUserResponse struct {"
 
 	// Utility function constants
+	expectedGetRequestContext    = "func getRequestContext(c *gin.Context, requestID string) RequestContext"
 	expectedServeWithResponse    = "func serveWithResponse["
 	expectedServeWithoutResponse = "func serveWithoutResponse["
 	expectedHandleRequest        = "func handleRequest["
@@ -1082,6 +1083,7 @@ func TestGenerateUtils(t *testing.T) {
 	generatedCode := buf.String()
 
 	// Check all utility functions are generated
+	assert.Contains(t, generatedCode, expectedGetRequestContext, "Should generate getRequestContext")
 	assert.Contains(t, generatedCode, expectedServeWithResponse, "Should generate serveWithResponse")
 	assert.Contains(t, generatedCode, expectedServeWithoutResponse, "Should generate serveWithoutResponse")
 	assert.Contains(t, generatedCode, expectedHandleRequest, "Should generate handleRequest")
@@ -1102,6 +1104,8 @@ func TestGenerateUtils(t *testing.T) {
 		"Should return error using Response() method")
 
 	// Check handleRequest implementation
+	assert.Contains(t, generatedCode, "requestContext := getRequestContext(c, requestID)",
+		"Should call getRequestContext to build RequestContext")
 	assert.Contains(t, generatedCode, "if _, ok := any(request.BodyParams).(struct{}); !ok {",
 		"Should check if body params exist")
 	assert.Contains(t, generatedCode, "if _, ok := any(request.PathParams).(struct{}); !ok {",


### PR DESCRIPTION
Extract `RequestContext` building to a new `getRequestContext` function to avoid code duplication.

---
Linear Issue: [INF-509](https://linear.app/meitner-se/issue/INF-509/extract-requestcontext-building-to-a-separate-function)

<a href="https://cursor.com/background-agent?bcId=bc-fc1d0b65-26aa-4b04-8e58-c1a93d5b282d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fc1d0b65-26aa-4b04-8e58-c1a93d5b282d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

