### PR TITLE
Refactor request context creation in serve functions

### DIFF
--- a/specification/servergen/error_interface_test.go
+++ b/specification/servergen/error_interface_test.go
@@ -412,6 +412,6 @@ func TestErrorInterfaceIntegration(t *testing.T) {
 		"Error handling should create Error instances")
 
 	// Verify the Response method is used in error handling
-	assert.Contains(t, generatedCode, "c.JSON(server.ErrorHook(err, requestID).Response())",
+	assert.Contains(t, generatedCode, "c.JSON(server.ErrorHook(err, requestContext.RequestID).Response())",
 		"Should use Response() method for error responses")
 }

--- a/specification/servergen/servergen_test.go
+++ b/specification/servergen/servergen_test.go
@@ -1100,12 +1100,16 @@ func TestGenerateUtils(t *testing.T) {
 		"Should call handleRequest with generic types")
 	assert.Contains(t, generatedCode, "c.JSON(successStatusCode, response)",
 		"Should return JSON response with success code")
-	assert.Contains(t, generatedCode, "c.JSON(server.ErrorHook(err, requestID).Response())",
+	assert.Contains(t, generatedCode, "c.JSON(server.ErrorHook(err, requestContext.RequestID).Response())",
 		"Should return error using Response() method")
 
-	// Check handleRequest implementation
+	// Check that requestContext is built in serve functions
 	assert.Contains(t, generatedCode, "requestContext := getRequestContext(c, requestID)",
-		"Should call getRequestContext to build RequestContext")
+		"Should call getRequestContext to build RequestContext in serve functions")
+
+	// Check handleRequest implementation
+	assert.Contains(t, generatedCode, "handleRequest[sessionType, pathParamsType, queryParamsType, bodyParamsType](c, requestContext, server)",
+		"Should call handleRequest with requestContext parameter")
 	assert.Contains(t, generatedCode, "if _, ok := any(request.BodyParams).(struct{}); !ok {",
 		"Should check if body params exist")
 	assert.Contains(t, generatedCode, "if _, ok := any(request.PathParams).(struct{}); !ok {",


### PR DESCRIPTION
Move `requestContext` creation from `handleRequest` to `serve` functions to improve code structure and consistency as per INF-510.

---
Linear Issue: [INF-510](https://linear.app/meitner-se/issue/INF-510/build-requestcontext-in-serve-functions-and-pass-it-to-handlerequest)

<a href="https://cursor.com/background-agent?bcId=bc-79c58653-9703-4e69-9ecc-ffe691c7892f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-79c58653-9703-4e69-9ecc-ffe691c7892f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

