### PR TITLE
Type error hook as function

### DIFF
--- a/specification/servergen/doc.go
+++ b/specification/servergen/doc.go
@@ -91,7 +91,7 @@
 //	type Server[Session any] struct {
 //	    GetRequestIDFunc  func(ctx context.Context) string
 //	    GetSessionFunc    func(ctx context.Context, headers http.Header) (Session, error)
-//	    ErrorHook  func(ctx context.Context, requestContext RequestContext, err error) *Error
+//	    ErrorHook  ErrorHook
 //	}
 //
 // # Error Handling

--- a/specification/servergen/error_interface_test.go
+++ b/specification/servergen/error_interface_test.go
@@ -403,9 +403,13 @@ func TestErrorInterfaceIntegration(t *testing.T) {
 
 	generatedCode := buf.String()
 
-	// Verify Error is used in ErrorHook
-	assert.Contains(t, generatedCode, "ErrorHook func(ctx context.Context, requestContext RequestContext, err error) *Error",
-		"ErrorHook should return *Error")
+	// Verify ErrorHook type is defined
+	assert.Contains(t, generatedCode, "type ErrorHook func(ctx context.Context, requestContext RequestContext, err error) *Error",
+		"ErrorHook should be defined as a type")
+
+	// Verify ErrorHook is used in Server struct
+	assert.Contains(t, generatedCode, "ErrorHook ErrorHook",
+		"Server struct should use ErrorHook type")
 
 	// Verify Error is used in error handling
 	assert.Contains(t, generatedCode, "return &Error{",

--- a/specification/servergen/servergen.go
+++ b/specification/servergen/servergen.go
@@ -324,7 +324,7 @@ func generateServer(buf *bytes.Buffer, service *specification.Service) error {
 	buf.WriteString("\tGetSessionFunc getSessionFunc[Session]\n")
 
 	buf.WriteString("\t// ErrorHook is a function that is used on each endpoint to convert an error to an Error object\n")
-	buf.WriteString("\tErrorHook func(ctx context.Context, requestContext RequestContext, err error) *Error\n")
+	buf.WriteString("\tErrorHook ErrorHook\n")
 
 	buf.WriteString("\t// PreHooks are executed before endpoint logic. The first non-nil error aborts request processing.\n")
 	buf.WriteString("\tPreHooks []PreHook\n")
@@ -387,7 +387,13 @@ func generateServer(buf *bytes.Buffer, service *specification.Service) error {
 }
 
 func generateRequestTypes(buf *bytes.Buffer, service *specification.Service) error {
-	// Generate PreHook types first
+	// Generate ErrorHook type
+	buf.WriteString("// ErrorHook converts application errors into API Error responses.\n")
+	buf.WriteString("// This hook is called whenever an error occurs during request processing,\n")
+	buf.WriteString("// allowing you to customize error formatting, logging, and HTTP status codes.\n")
+	buf.WriteString("type ErrorHook func(ctx context.Context, requestContext RequestContext, err error) *Error\n\n")
+
+	// Generate PreHook types
 	buf.WriteString("// PreHook runs before endpoint logic. Return nil to continue; non-nil to abort.\n")
 	buf.WriteString("type PreHook func(ctx context.Context, requestContext RequestContext) error\n\n")
 


### PR DESCRIPTION
Make ErrorHook a distinct function type for consistency with PreHooks and SessionHooks.

---
Linear Issue: [INF-513](https://linear.app/meitner-se/issue/INF-513/make-errorhook-a-function-type)

<a href="https://cursor.com/background-agent?bcId=bc-b6a41d03-662b-4668-bfcb-700ab630bd93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b6a41d03-662b-4668-bfcb-700ab630bd93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

