### PR TITLE
Fix search request content required

### DIFF
--- a/specification/openapigen/openapigen.go
+++ b/specification/openapigen/openapigen.go
@@ -1016,7 +1016,7 @@ func (g *generator) addRequestBodiesToComponents(components *v3.Components, serv
 
 				// Only add if we haven't seen this request body before
 				if _, exists := requestBodyMap[requestBodyName]; !exists {
-					requestBody := g.createComponentRequestBody(endpoint.Request.BodyParams, endpoint.Name, service)
+					requestBody := g.createComponentRequestBody(endpoint.Request.BodyParams, service)
 					requestBodyMap[requestBodyName] = requestBody
 					components.RequestBodies.Set(requestBodyName, requestBody)
 				}
@@ -1231,7 +1231,7 @@ func (g *generator) generateResponseBodyExample(response specification.EndpointR
 }
 
 // createComponentRequestBody creates a v3.RequestBody for the components section.
-func (g *generator) createComponentRequestBody(bodyParams []specification.Field, endpointName string, service *specification.Service) *v3.RequestBody {
+func (g *generator) createComponentRequestBody(bodyParams []specification.Field, service *specification.Service) *v3.RequestBody {
 	var schema *base.Schema
 	var isRequired bool
 
@@ -1274,11 +1274,6 @@ func (g *generator) createComponentRequestBody(bodyParams []specification.Field,
 		}
 
 		isRequired = len(requiredFields) > 0
-	}
-
-	// Search endpoints should always have required request bodies
-	if endpointName == searchEndpointNameValue {
-		isRequired = true
 	}
 
 	// Create media type

--- a/specification/openapigen/openapigen.go
+++ b/specification/openapigen/openapigen.go
@@ -1016,7 +1016,7 @@ func (g *generator) addRequestBodiesToComponents(components *v3.Components, serv
 
 				// Only add if we haven't seen this request body before
 				if _, exists := requestBodyMap[requestBodyName]; !exists {
-					requestBody := g.createComponentRequestBody(endpoint.Request.BodyParams, service)
+					requestBody := g.createComponentRequestBody(endpoint.Request.BodyParams, endpoint.Name, service)
 					requestBodyMap[requestBodyName] = requestBody
 					components.RequestBodies.Set(requestBodyName, requestBody)
 				}
@@ -1231,7 +1231,7 @@ func (g *generator) generateResponseBodyExample(response specification.EndpointR
 }
 
 // createComponentRequestBody creates a v3.RequestBody for the components section.
-func (g *generator) createComponentRequestBody(bodyParams []specification.Field, service *specification.Service) *v3.RequestBody {
+func (g *generator) createComponentRequestBody(bodyParams []specification.Field, endpointName string, service *specification.Service) *v3.RequestBody {
 	var schema *base.Schema
 	var isRequired bool
 
@@ -1274,6 +1274,11 @@ func (g *generator) createComponentRequestBody(bodyParams []specification.Field,
 		}
 
 		isRequired = len(requiredFields) > 0
+	}
+
+	// Search endpoints should always have required request bodies
+	if endpointName == searchEndpointNameValue {
+		isRequired = true
 	}
 
 	// Create media type

--- a/specification/specification.go
+++ b/specification/specification.go
@@ -48,6 +48,7 @@ const (
 const (
 	ModifierNullable = "Nullable"
 	ModifierArray    = "Array"
+	ModifierRequired = "Required"
 )
 
 // Retry Strategies
@@ -919,6 +920,7 @@ func generateSearchEndpoint(result *Service, resource Resource) {
 			Name:        searchFilterParamName,
 			Description: searchFilterParamDesc,
 			Type:        resource.Name + filterSuffix,
+			Modifiers:   []string{ModifierRequired},
 		}
 		paginationField := createPaginationField()
 		dataField := createDataField(resource.Name)
@@ -1384,6 +1386,11 @@ func (t Field) GetComment(tabs string) string {
 
 // IsRequired determines if the field is required based on its properties and service context.
 func (f Field) IsRequired(service *Service) bool {
+	// Explicitly marked as required via modifier
+	if slices.Contains(f.Modifiers, ModifierRequired) {
+		return true
+	}
+
 	if f.IsNullable() {
 		return false
 	}

--- a/testdata/school-management-api-openapi.json
+++ b/testdata/school-management-api-openapi.json
@@ -18,249 +18,6 @@
     }
   ],
   "paths": {
-    "/students/bulk-import": {
-      "post": {
-        "tags": [
-          "Students"
-        ],
-        "summary": "Bulk Import Students",
-        "description": "Import multiple students from a CSV file or structured data",
-        "operationId": "StudentsBulkImport",
-        "parameters": [
-          {
-            "name": "validateOnly",
-            "in": "query",
-            "description": "Only validate data without importing",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "examples": [
-                true
-              ],
-              "default": false
-            }
-          }
-        ],
-        "requestBody": {
-          "$ref": "#/components/requestBodies/StudentsBulkImport"
-        },
-        "responses": {
-          "200": {
-            "description": "Successfully imported students",
-            "$ref": "#/components/responses/StudentsBulkImport"
-          },
-          "400": {
-            "description": "Bad Request error for Students BulkImport operation - request contains invalid parameters",
-            "$ref": "#/components/responses/Error400ResponseBody"
-          },
-          "401": {
-            "description": "Unauthorized error for Students BulkImport operation - authentication required",
-            "$ref": "#/components/responses/Error401ResponseBody"
-          },
-          "403": {
-            "description": "Forbidden error for Students BulkImport operation - insufficient permissions",
-            "$ref": "#/components/responses/Error403ResponseBody"
-          },
-          "404": {
-            "description": "Not Found error for Students BulkImport operation - resource does not exist",
-            "$ref": "#/components/responses/Error404ResponseBody"
-          },
-          "409": {
-            "description": "Conflict error for Students BulkImport operation - request conflicts with current state",
-            "$ref": "#/components/responses/Error409ResponseBody"
-          },
-          "422": {
-            "description": "Validation error for Students BulkImport operation - request data failed validation",
-            "$ref": "#/components/responses/StudentsBulkImport422ResponseBody"
-          },
-          "429": {
-            "description": "Rate Limit error for Students BulkImport operation - too many requests",
-            "$ref": "#/components/responses/Error429ResponseBody"
-          },
-          "500": {
-            "description": "Internal Server error for Students BulkImport operation - unexpected server error",
-            "$ref": "#/components/responses/Error500ResponseBody"
-          }
-        },
-        "x-speakeasy-group": "students",
-        "x-speakeasy-name-override": "bulkImport"
-      }
-    },
-    "/students/reports/generate": {
-      "post": {
-        "tags": [
-          "Students"
-        ],
-        "summary": "Generate Student Report",
-        "description": "Generate a comprehensive report for students based on filters",
-        "operationId": "StudentsGenerateReport",
-        "parameters": [
-          {
-            "name": "format",
-            "in": "query",
-            "description": "Report format (pdf, excel, csv)",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "examples": [
-                "example"
-              ],
-              "default": "pdf"
-            }
-          }
-        ],
-        "requestBody": {
-          "$ref": "#/components/requestBodies/StudentsGenerateReport"
-        },
-        "responses": {
-          "202": {
-            "description": "Successfully queued report generation",
-            "$ref": "#/components/responses/StudentsGenerateReport"
-          },
-          "400": {
-            "description": "Bad Request error for Students GenerateReport operation - request contains invalid parameters",
-            "$ref": "#/components/responses/Error400ResponseBody"
-          },
-          "401": {
-            "description": "Unauthorized error for Students GenerateReport operation - authentication required",
-            "$ref": "#/components/responses/Error401ResponseBody"
-          },
-          "403": {
-            "description": "Forbidden error for Students GenerateReport operation - insufficient permissions",
-            "$ref": "#/components/responses/Error403ResponseBody"
-          },
-          "404": {
-            "description": "Not Found error for Students GenerateReport operation - resource does not exist",
-            "$ref": "#/components/responses/Error404ResponseBody"
-          },
-          "409": {
-            "description": "Conflict error for Students GenerateReport operation - request conflicts with current state",
-            "$ref": "#/components/responses/Error409ResponseBody"
-          },
-          "422": {
-            "description": "Validation error for Students GenerateReport operation - request data failed validation",
-            "$ref": "#/components/responses/StudentsGenerateReport422ResponseBody"
-          },
-          "429": {
-            "description": "Rate Limit error for Students GenerateReport operation - too many requests",
-            "$ref": "#/components/responses/Error429ResponseBody"
-          },
-          "500": {
-            "description": "Internal Server error for Students GenerateReport operation - unexpected server error",
-            "$ref": "#/components/responses/Error500ResponseBody"
-          }
-        },
-        "x-speakeasy-group": "students",
-        "x-speakeasy-name-override": "generateReport"
-      }
-    },
-    "/students/advanced-search": {
-      "post": {
-        "tags": [
-          "Students"
-        ],
-        "summary": "Advanced Student Search",
-        "description": "Search students with advanced filtering and sorting options",
-        "operationId": "StudentsAdvancedSearch",
-        "parameters": [
-          {
-            "name": "limit",
-            "in": "query",
-            "description": "Maximum number of results to return",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "examples": [
-                42
-              ],
-              "default": 50
-            }
-          },
-          {
-            "name": "offset",
-            "in": "query",
-            "description": "Number of results to skip",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "examples": [
-                42
-              ],
-              "default": 0
-            }
-          },
-          {
-            "name": "sortBy",
-            "in": "query",
-            "description": "Field to sort by",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "examples": [
-                "example"
-              ],
-              "default": "lastName"
-            }
-          },
-          {
-            "name": "sortOrder",
-            "in": "query",
-            "description": "Sort order (asc, desc)",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "examples": [
-                "example"
-              ],
-              "default": "asc"
-            }
-          }
-        ],
-        "requestBody": {
-          "$ref": "#/components/requestBodies/StudentsAdvancedSearch"
-        },
-        "responses": {
-          "200": {
-            "description": "Successfully performed advanced search",
-            "$ref": "#/components/responses/StudentsAdvancedSearch"
-          },
-          "400": {
-            "description": "Bad Request error for Students AdvancedSearch operation - request contains invalid parameters",
-            "$ref": "#/components/responses/Error400ResponseBody"
-          },
-          "401": {
-            "description": "Unauthorized error for Students AdvancedSearch operation - authentication required",
-            "$ref": "#/components/responses/Error401ResponseBody"
-          },
-          "403": {
-            "description": "Forbidden error for Students AdvancedSearch operation - insufficient permissions",
-            "$ref": "#/components/responses/Error403ResponseBody"
-          },
-          "404": {
-            "description": "Not Found error for Students AdvancedSearch operation - resource does not exist",
-            "$ref": "#/components/responses/Error404ResponseBody"
-          },
-          "409": {
-            "description": "Conflict error for Students AdvancedSearch operation - request conflicts with current state",
-            "$ref": "#/components/responses/Error409ResponseBody"
-          },
-          "422": {
-            "description": "Validation error for Students AdvancedSearch operation - request data failed validation",
-            "$ref": "#/components/responses/StudentsAdvancedSearch422ResponseBody"
-          },
-          "429": {
-            "description": "Rate Limit error for Students AdvancedSearch operation - too many requests",
-            "$ref": "#/components/responses/Error429ResponseBody"
-          },
-          "500": {
-            "description": "Internal Server error for Students AdvancedSearch operation - unexpected server error",
-            "$ref": "#/components/responses/Error500ResponseBody"
-          }
-        },
-        "x-speakeasy-group": "students",
-        "x-speakeasy-name-override": "advancedSearch"
-      }
-    },
     "/students": {
       "get": {
         "tags": [
@@ -361,6 +118,7 @@
         "operationId": "StudentsCreate",
         "parameters": [],
         "requestBody": {
+          "required": true,
           "$ref": "#/components/requestBodies/StudentsCreate"
         },
         "responses": {
@@ -403,6 +161,352 @@
         },
         "x-speakeasy-group": "students",
         "x-speakeasy-name-override": "create"
+      }
+    },
+    "/students/_search": {
+      "post": {
+        "tags": [
+          "Students"
+        ],
+        "summary": "Search Students",
+        "description": "Search for `Students` with filtering capabilities.",
+        "operationId": "StudentsSearch",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "The maximum number of Students to return (default: 50) when searching Students",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "examples": [
+                1
+              ],
+              "default": 50
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "description": "The number of Students to skip before starting to return results (default: 0) when searching Students",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "examples": [
+                0
+              ],
+              "default": 0
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "$ref": "#/components/requestBodies/StudentsSearch"
+        },
+        "responses": {
+          "200": {
+            "description": "Response for Students Search operation - returns filtered Students results",
+            "$ref": "#/components/responses/StudentsSearch"
+          },
+          "400": {
+            "description": "Bad Request error for Students Search operation - request contains invalid parameters",
+            "$ref": "#/components/responses/Error400ResponseBody"
+          },
+          "401": {
+            "description": "Unauthorized error for Students Search operation - authentication required",
+            "$ref": "#/components/responses/Error401ResponseBody"
+          },
+          "403": {
+            "description": "Forbidden error for Students Search operation - insufficient permissions",
+            "$ref": "#/components/responses/Error403ResponseBody"
+          },
+          "404": {
+            "description": "Not Found error for Students Search operation - resource does not exist",
+            "$ref": "#/components/responses/Error404ResponseBody"
+          },
+          "409": {
+            "description": "Conflict error for Students Search operation - request conflicts with current state",
+            "$ref": "#/components/responses/Error409ResponseBody"
+          },
+          "422": {
+            "description": "Validation error for Students Search operation - request data failed validation",
+            "$ref": "#/components/responses/StudentsSearch422ResponseBody"
+          },
+          "429": {
+            "description": "Rate Limit error for Students Search operation - too many requests",
+            "$ref": "#/components/responses/Error429ResponseBody"
+          },
+          "500": {
+            "description": "Internal Server error for Students Search operation - unexpected server error",
+            "$ref": "#/components/responses/Error500ResponseBody"
+          }
+        },
+        "x-speakeasy-pagination": {
+          "type": "offsetLimit",
+          "inputs": [
+            {
+              "name": "offset",
+              "in": "parameters",
+              "type": "offset"
+            },
+            {
+              "name": "limit",
+              "in": "parameters",
+              "type": "limit"
+            }
+          ],
+          "outputs": {
+            "results": "$.data.resultArray"
+          }
+        },
+        "x-speakeasy-group": "students",
+        "x-speakeasy-name-override": "search"
+      }
+    },
+    "/students/advanced-search": {
+      "post": {
+        "tags": [
+          "Students"
+        ],
+        "summary": "Advanced Student Search",
+        "description": "Search students with advanced filtering and sorting options",
+        "operationId": "StudentsAdvancedSearch",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum number of results to return",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "examples": [
+                42
+              ],
+              "default": 50
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "description": "Number of results to skip",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "examples": [
+                42
+              ],
+              "default": 0
+            }
+          },
+          {
+            "name": "sortBy",
+            "in": "query",
+            "description": "Field to sort by",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "examples": [
+                "example"
+              ],
+              "default": "lastName"
+            }
+          },
+          {
+            "name": "sortOrder",
+            "in": "query",
+            "description": "Sort order (asc, desc)",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "examples": [
+                "example"
+              ],
+              "default": "asc"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "$ref": "#/components/requestBodies/StudentsAdvancedSearch"
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully performed advanced search",
+            "$ref": "#/components/responses/StudentsAdvancedSearch"
+          },
+          "400": {
+            "description": "Bad Request error for Students AdvancedSearch operation - request contains invalid parameters",
+            "$ref": "#/components/responses/Error400ResponseBody"
+          },
+          "401": {
+            "description": "Unauthorized error for Students AdvancedSearch operation - authentication required",
+            "$ref": "#/components/responses/Error401ResponseBody"
+          },
+          "403": {
+            "description": "Forbidden error for Students AdvancedSearch operation - insufficient permissions",
+            "$ref": "#/components/responses/Error403ResponseBody"
+          },
+          "404": {
+            "description": "Not Found error for Students AdvancedSearch operation - resource does not exist",
+            "$ref": "#/components/responses/Error404ResponseBody"
+          },
+          "409": {
+            "description": "Conflict error for Students AdvancedSearch operation - request conflicts with current state",
+            "$ref": "#/components/responses/Error409ResponseBody"
+          },
+          "422": {
+            "description": "Validation error for Students AdvancedSearch operation - request data failed validation",
+            "$ref": "#/components/responses/StudentsAdvancedSearch422ResponseBody"
+          },
+          "429": {
+            "description": "Rate Limit error for Students AdvancedSearch operation - too many requests",
+            "$ref": "#/components/responses/Error429ResponseBody"
+          },
+          "500": {
+            "description": "Internal Server error for Students AdvancedSearch operation - unexpected server error",
+            "$ref": "#/components/responses/Error500ResponseBody"
+          }
+        },
+        "x-speakeasy-group": "students",
+        "x-speakeasy-name-override": "advancedSearch"
+      }
+    },
+    "/students/bulk-import": {
+      "post": {
+        "tags": [
+          "Students"
+        ],
+        "summary": "Bulk Import Students",
+        "description": "Import multiple students from a CSV file or structured data",
+        "operationId": "StudentsBulkImport",
+        "parameters": [
+          {
+            "name": "validateOnly",
+            "in": "query",
+            "description": "Only validate data without importing",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "examples": [
+                true
+              ],
+              "default": false
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "$ref": "#/components/requestBodies/StudentsBulkImport"
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully imported students",
+            "$ref": "#/components/responses/StudentsBulkImport"
+          },
+          "400": {
+            "description": "Bad Request error for Students BulkImport operation - request contains invalid parameters",
+            "$ref": "#/components/responses/Error400ResponseBody"
+          },
+          "401": {
+            "description": "Unauthorized error for Students BulkImport operation - authentication required",
+            "$ref": "#/components/responses/Error401ResponseBody"
+          },
+          "403": {
+            "description": "Forbidden error for Students BulkImport operation - insufficient permissions",
+            "$ref": "#/components/responses/Error403ResponseBody"
+          },
+          "404": {
+            "description": "Not Found error for Students BulkImport operation - resource does not exist",
+            "$ref": "#/components/responses/Error404ResponseBody"
+          },
+          "409": {
+            "description": "Conflict error for Students BulkImport operation - request conflicts with current state",
+            "$ref": "#/components/responses/Error409ResponseBody"
+          },
+          "422": {
+            "description": "Validation error for Students BulkImport operation - request data failed validation",
+            "$ref": "#/components/responses/StudentsBulkImport422ResponseBody"
+          },
+          "429": {
+            "description": "Rate Limit error for Students BulkImport operation - too many requests",
+            "$ref": "#/components/responses/Error429ResponseBody"
+          },
+          "500": {
+            "description": "Internal Server error for Students BulkImport operation - unexpected server error",
+            "$ref": "#/components/responses/Error500ResponseBody"
+          }
+        },
+        "x-speakeasy-group": "students",
+        "x-speakeasy-name-override": "bulkImport"
+      }
+    },
+    "/students/reports/generate": {
+      "post": {
+        "tags": [
+          "Students"
+        ],
+        "summary": "Generate Student Report",
+        "description": "Generate a comprehensive report for students based on filters",
+        "operationId": "StudentsGenerateReport",
+        "parameters": [
+          {
+            "name": "format",
+            "in": "query",
+            "description": "Report format (pdf, excel, csv)",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "examples": [
+                "example"
+              ],
+              "default": "pdf"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "$ref": "#/components/requestBodies/StudentsGenerateReport"
+        },
+        "responses": {
+          "202": {
+            "description": "Successfully queued report generation",
+            "$ref": "#/components/responses/StudentsGenerateReport"
+          },
+          "400": {
+            "description": "Bad Request error for Students GenerateReport operation - request contains invalid parameters",
+            "$ref": "#/components/responses/Error400ResponseBody"
+          },
+          "401": {
+            "description": "Unauthorized error for Students GenerateReport operation - authentication required",
+            "$ref": "#/components/responses/Error401ResponseBody"
+          },
+          "403": {
+            "description": "Forbidden error for Students GenerateReport operation - insufficient permissions",
+            "$ref": "#/components/responses/Error403ResponseBody"
+          },
+          "404": {
+            "description": "Not Found error for Students GenerateReport operation - resource does not exist",
+            "$ref": "#/components/responses/Error404ResponseBody"
+          },
+          "409": {
+            "description": "Conflict error for Students GenerateReport operation - request conflicts with current state",
+            "$ref": "#/components/responses/Error409ResponseBody"
+          },
+          "422": {
+            "description": "Validation error for Students GenerateReport operation - request data failed validation",
+            "$ref": "#/components/responses/StudentsGenerateReport422ResponseBody"
+          },
+          "429": {
+            "description": "Rate Limit error for Students GenerateReport operation - too many requests",
+            "$ref": "#/components/responses/Error429ResponseBody"
+          },
+          "500": {
+            "description": "Internal Server error for Students GenerateReport operation - unexpected server error",
+            "$ref": "#/components/responses/Error500ResponseBody"
+          }
+        },
+        "x-speakeasy-group": "students",
+        "x-speakeasy-name-override": "generateReport"
       }
     },
     "/students/{id}": {
@@ -546,6 +650,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "$ref": "#/components/requestBodies/StudentsUpdate"
         },
         "responses": {
@@ -588,105 +693,6 @@
         },
         "x-speakeasy-group": "students",
         "x-speakeasy-name-override": "update"
-      }
-    },
-    "/students/_search": {
-      "post": {
-        "tags": [
-          "Students"
-        ],
-        "summary": "Search Students",
-        "description": "Search for `Students` with filtering capabilities.",
-        "operationId": "StudentsSearch",
-        "parameters": [
-          {
-            "name": "limit",
-            "in": "query",
-            "description": "The maximum number of Students to return (default: 50) when searching Students",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "examples": [
-                1
-              ],
-              "default": 50
-            }
-          },
-          {
-            "name": "offset",
-            "in": "query",
-            "description": "The number of Students to skip before starting to return results (default: 0) when searching Students",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "examples": [
-                0
-              ],
-              "default": 0
-            }
-          }
-        ],
-        "requestBody": {
-          "$ref": "#/components/requestBodies/StudentsSearch"
-        },
-        "responses": {
-          "200": {
-            "description": "Response for Students Search operation - returns filtered Students results",
-            "$ref": "#/components/responses/StudentsSearch"
-          },
-          "400": {
-            "description": "Bad Request error for Students Search operation - request contains invalid parameters",
-            "$ref": "#/components/responses/Error400ResponseBody"
-          },
-          "401": {
-            "description": "Unauthorized error for Students Search operation - authentication required",
-            "$ref": "#/components/responses/Error401ResponseBody"
-          },
-          "403": {
-            "description": "Forbidden error for Students Search operation - insufficient permissions",
-            "$ref": "#/components/responses/Error403ResponseBody"
-          },
-          "404": {
-            "description": "Not Found error for Students Search operation - resource does not exist",
-            "$ref": "#/components/responses/Error404ResponseBody"
-          },
-          "409": {
-            "description": "Conflict error for Students Search operation - request conflicts with current state",
-            "$ref": "#/components/responses/Error409ResponseBody"
-          },
-          "422": {
-            "description": "Validation error for Students Search operation - request data failed validation",
-            "$ref": "#/components/responses/StudentsSearch422ResponseBody"
-          },
-          "429": {
-            "description": "Rate Limit error for Students Search operation - too many requests",
-            "$ref": "#/components/responses/Error429ResponseBody"
-          },
-          "500": {
-            "description": "Internal Server error for Students Search operation - unexpected server error",
-            "$ref": "#/components/responses/Error500ResponseBody"
-          }
-        },
-        "x-speakeasy-pagination": {
-          "type": "offsetLimit",
-          "inputs": [
-            {
-              "name": "offset",
-              "in": "parameters",
-              "type": "offset"
-            },
-            {
-              "name": "limit",
-              "in": "parameters",
-              "type": "limit"
-            }
-          ],
-          "outputs": {
-            "results": "$.data.resultArray"
-          }
-        },
-        "x-speakeasy-group": "students",
-        "x-speakeasy-name-override": "search"
       }
     }
   },
@@ -928,10 +934,12 @@
           "updatedAt": {
             "type": "string",
             "examples": [
-              "2024-01-15T14:45:00Z"
+              "2024-01-15T14:45:00Z",
+              null
             ],
             "format": "date-time",
-            "description": "Timestamp when the resource was last updated"
+            "description": "Timestamp when the resource was last updated",
+            "nullable": true
           },
           "updatedBy": {
             "type": "string",
@@ -945,8 +953,7 @@
           }
         },
         "required": [
-          "createdAt",
-          "updatedAt"
+          "createdAt"
         ],
         "description": "Meta contains information about the creation and modification of a resource for auditing purposes"
       },
@@ -1418,7 +1425,14 @@
             ],
             "examples": [
               {
-                "address": true,
+                "meta": {
+                  "createdBy": true,
+                  "updatedAt": true,
+                  "updatedBy": true
+                },
+                "contact": {
+                  "phone": true
+                },
                 "graduationDate": true
               },
               null
@@ -1434,7 +1448,14 @@
             ],
             "examples": [
               {
-                "address": true,
+                "meta": {
+                  "createdBy": true,
+                  "updatedAt": true,
+                  "updatedBy": true
+                },
+                "contact": {
+                  "phone": true
+                },
                 "graduationDate": true
               },
               null
@@ -1665,11 +1686,25 @@
                     }
                   },
                   "null": {
-                    "address": true,
+                    "meta": {
+                      "createdBy": true,
+                      "updatedAt": true,
+                      "updatedBy": true
+                    },
+                    "contact": {
+                      "phone": true
+                    },
                     "graduationDate": true
                   },
                   "notNull": {
-                    "address": true,
+                    "meta": {
+                      "createdBy": true,
+                      "updatedAt": true,
+                      "updatedBy": true
+                    },
+                    "contact": {
+                      "phone": true
+                    },
                     "graduationDate": true
                   },
                   "orCondition": true
@@ -2132,11 +2167,43 @@
       "StudentsFilterNull": {
         "type": "object",
         "properties": {
-          "address": {
-            "type": "boolean",
+          "meta": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MetaFilterNull"
+              }
+            ],
             "examples": [
-              true,
+              {
+                "createdBy": true,
+                "updatedAt": true,
+                "updatedBy": true
+              },
               null
+            ],
+            "description": "Metadata information for the Students",
+            "nullable": true
+          },
+          "contact": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ContactFilterNull"
+              }
+            ],
+            "examples": [
+              {
+                "phone": true
+              },
+              null
+            ],
+            "description": "Student contact information",
+            "nullable": true
+          },
+          "address": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AddressFilterNull"
+              }
             ],
             "description": "Student home address",
             "nullable": true
@@ -2323,6 +2390,7 @@
             "examples": [
               {
                 "createdBy": true,
+                "updatedAt": true,
                 "updatedBy": true
               },
               null
@@ -2339,6 +2407,7 @@
             "examples": [
               {
                 "createdBy": true,
+                "updatedAt": true,
                 "updatedBy": true
               },
               null
@@ -2404,10 +2473,12 @@
                   },
                   "null": {
                     "createdBy": true,
+                    "updatedAt": true,
                     "updatedBy": true
                   },
                   "notNull": {
                     "createdBy": true,
+                    "updatedAt": true,
                     "updatedBy": true
                   },
                   "orCondition": true
@@ -2547,6 +2618,15 @@
               null
             ],
             "description": "User who created the resource",
+            "nullable": true
+          },
+          "updatedAt": {
+            "type": "boolean",
+            "examples": [
+              true,
+              null
+            ],
+            "description": "Timestamp when the resource was last updated",
             "nullable": true
           },
           "updatedBy": {
@@ -5006,11 +5086,25 @@
                     }
                   },
                   "null": {
-                    "address": true,
+                    "meta": {
+                      "createdBy": true,
+                      "updatedAt": true,
+                      "updatedBy": true
+                    },
+                    "contact": {
+                      "phone": true
+                    },
                     "graduationDate": true
                   },
                   "notNull": {
-                    "address": true,
+                    "meta": {
+                      "createdBy": true,
+                      "updatedAt": true,
+                      "updatedBy": true
+                    },
+                    "contact": {
+                      "phone": true
+                    },
                     "graduationDate": true
                   },
                   "orCondition": true
@@ -5019,7 +5113,7 @@
             }
           }
         },
-        "required": false
+        "required": true
       }
     }
   },

--- a/testdata/timeout-example-api-openapi.json
+++ b/testdata/timeout-example-api-openapi.json
@@ -106,6 +106,7 @@
         "operationId": "UsersCreate",
         "parameters": [],
         "requestBody": {
+          "required": true,
           "$ref": "#/components/requestBodies/UsersCreate"
         },
         "responses": {
@@ -148,6 +149,106 @@
         },
         "x-speakeasy-group": "users",
         "x-speakeasy-name-override": "create"
+      }
+    },
+    "/users/_search": {
+      "post": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Search Users",
+        "description": "Search for `Users` with filtering capabilities.",
+        "operationId": "UsersSearch",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "The maximum number of Users to return (default: 50) when searching Users",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "examples": [
+                1
+              ],
+              "default": 50
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "description": "The number of Users to skip before starting to return results (default: 0) when searching Users",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "examples": [
+                0
+              ],
+              "default": 0
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "$ref": "#/components/requestBodies/UsersSearch"
+        },
+        "responses": {
+          "200": {
+            "description": "Response for Users Search operation - returns filtered Users results",
+            "$ref": "#/components/responses/UsersSearch"
+          },
+          "400": {
+            "description": "Bad Request error for Users Search operation - request contains invalid parameters",
+            "$ref": "#/components/responses/Error400ResponseBody"
+          },
+          "401": {
+            "description": "Unauthorized error for Users Search operation - authentication required",
+            "$ref": "#/components/responses/Error401ResponseBody"
+          },
+          "403": {
+            "description": "Forbidden error for Users Search operation - insufficient permissions",
+            "$ref": "#/components/responses/Error403ResponseBody"
+          },
+          "404": {
+            "description": "Not Found error for Users Search operation - resource does not exist",
+            "$ref": "#/components/responses/Error404ResponseBody"
+          },
+          "409": {
+            "description": "Conflict error for Users Search operation - request conflicts with current state",
+            "$ref": "#/components/responses/Error409ResponseBody"
+          },
+          "422": {
+            "description": "Validation error for Users Search operation - request data failed validation",
+            "$ref": "#/components/responses/UsersSearch422ResponseBody"
+          },
+          "429": {
+            "description": "Rate Limit error for Users Search operation - too many requests",
+            "$ref": "#/components/responses/Error429ResponseBody"
+          },
+          "500": {
+            "description": "Internal Server error for Users Search operation - unexpected server error",
+            "$ref": "#/components/responses/Error500ResponseBody"
+          }
+        },
+        "x-speakeasy-pagination": {
+          "type": "offsetLimit",
+          "inputs": [
+            {
+              "name": "offset",
+              "in": "parameters",
+              "type": "offset"
+            },
+            {
+              "name": "limit",
+              "in": "parameters",
+              "type": "limit"
+            }
+          ],
+          "outputs": {
+            "results": "$.data.resultArray"
+          }
+        },
+        "x-speakeasy-group": "users",
+        "x-speakeasy-name-override": "search"
       }
     },
     "/users/{id}": {
@@ -291,6 +392,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "$ref": "#/components/requestBodies/UsersUpdate"
         },
         "responses": {
@@ -333,105 +435,6 @@
         },
         "x-speakeasy-group": "users",
         "x-speakeasy-name-override": "update"
-      }
-    },
-    "/users/_search": {
-      "post": {
-        "tags": [
-          "Users"
-        ],
-        "summary": "Search Users",
-        "description": "Search for `Users` with filtering capabilities.",
-        "operationId": "UsersSearch",
-        "parameters": [
-          {
-            "name": "limit",
-            "in": "query",
-            "description": "The maximum number of Users to return (default: 50) when searching Users",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "examples": [
-                1
-              ],
-              "default": 50
-            }
-          },
-          {
-            "name": "offset",
-            "in": "query",
-            "description": "The number of Users to skip before starting to return results (default: 0) when searching Users",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "examples": [
-                0
-              ],
-              "default": 0
-            }
-          }
-        ],
-        "requestBody": {
-          "$ref": "#/components/requestBodies/UsersSearch"
-        },
-        "responses": {
-          "200": {
-            "description": "Response for Users Search operation - returns filtered Users results",
-            "$ref": "#/components/responses/UsersSearch"
-          },
-          "400": {
-            "description": "Bad Request error for Users Search operation - request contains invalid parameters",
-            "$ref": "#/components/responses/Error400ResponseBody"
-          },
-          "401": {
-            "description": "Unauthorized error for Users Search operation - authentication required",
-            "$ref": "#/components/responses/Error401ResponseBody"
-          },
-          "403": {
-            "description": "Forbidden error for Users Search operation - insufficient permissions",
-            "$ref": "#/components/responses/Error403ResponseBody"
-          },
-          "404": {
-            "description": "Not Found error for Users Search operation - resource does not exist",
-            "$ref": "#/components/responses/Error404ResponseBody"
-          },
-          "409": {
-            "description": "Conflict error for Users Search operation - request conflicts with current state",
-            "$ref": "#/components/responses/Error409ResponseBody"
-          },
-          "422": {
-            "description": "Validation error for Users Search operation - request data failed validation",
-            "$ref": "#/components/responses/UsersSearch422ResponseBody"
-          },
-          "429": {
-            "description": "Rate Limit error for Users Search operation - too many requests",
-            "$ref": "#/components/responses/Error429ResponseBody"
-          },
-          "500": {
-            "description": "Internal Server error for Users Search operation - unexpected server error",
-            "$ref": "#/components/responses/Error500ResponseBody"
-          }
-        },
-        "x-speakeasy-pagination": {
-          "type": "offsetLimit",
-          "inputs": [
-            {
-              "name": "offset",
-              "in": "parameters",
-              "type": "offset"
-            },
-            {
-              "name": "limit",
-              "in": "parameters",
-              "type": "limit"
-            }
-          ],
-          "outputs": {
-            "results": "$.data.resultArray"
-          }
-        },
-        "x-speakeasy-group": "users",
-        "x-speakeasy-name-override": "search"
       }
     }
   },
@@ -540,10 +543,12 @@
           "updatedAt": {
             "type": "string",
             "examples": [
-              "2024-01-15T14:45:00Z"
+              "2024-01-15T14:45:00Z",
+              null
             ],
             "format": "date-time",
-            "description": "Timestamp when the resource was last updated"
+            "description": "Timestamp when the resource was last updated",
+            "nullable": true
           },
           "updatedBy": {
             "type": "string",
@@ -557,8 +562,7 @@
           }
         },
         "required": [
-          "createdAt",
-          "updatedAt"
+          "createdAt"
         ],
         "description": "Meta contains information about the creation and modification of a resource for auditing purposes"
       },
@@ -832,6 +836,16 @@
                 "$ref": "#/components/schemas/UsersFilterNull"
               }
             ],
+            "examples": [
+              {
+                "meta": {
+                  "createdBy": true,
+                  "updatedAt": true,
+                  "updatedBy": true
+                }
+              },
+              null
+            ],
             "description": "Null filters for Users",
             "nullable": true
           },
@@ -840,6 +854,16 @@
               {
                 "$ref": "#/components/schemas/UsersFilterNull"
               }
+            ],
+            "examples": [
+              {
+                "meta": {
+                  "createdBy": true,
+                  "updatedAt": true,
+                  "updatedBy": true
+                }
+              },
+              null
             ],
             "description": "Not null filters for Users",
             "nullable": true
@@ -947,6 +971,20 @@
                   "notLike": {
                     "email": "example",
                     "name": "example"
+                  },
+                  "null": {
+                    "meta": {
+                      "createdBy": true,
+                      "updatedAt": true,
+                      "updatedBy": true
+                    }
+                  },
+                  "notNull": {
+                    "meta": {
+                      "createdBy": true,
+                      "updatedAt": true,
+                      "updatedBy": true
+                    }
                   },
                   "orCondition": true
                 }
@@ -1139,6 +1177,25 @@
       },
       "UsersFilterNull": {
         "type": "object",
+        "properties": {
+          "meta": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MetaFilterNull"
+              }
+            ],
+            "examples": [
+              {
+                "createdBy": true,
+                "updatedAt": true,
+                "updatedBy": true
+              },
+              null
+            ],
+            "description": "Metadata information for the Users",
+            "nullable": true
+          }
+        },
         "description": "Null filter fields for Users"
       },
       "MetaFilter": {
@@ -1311,6 +1368,7 @@
             "examples": [
               {
                 "createdBy": true,
+                "updatedAt": true,
                 "updatedBy": true
               },
               null
@@ -1327,6 +1385,7 @@
             "examples": [
               {
                 "createdBy": true,
+                "updatedAt": true,
                 "updatedBy": true
               },
               null
@@ -1392,10 +1451,12 @@
                   },
                   "null": {
                     "createdBy": true,
+                    "updatedAt": true,
                     "updatedBy": true
                   },
                   "notNull": {
                     "createdBy": true,
+                    "updatedAt": true,
                     "updatedBy": true
                   },
                   "orCondition": true
@@ -1535,6 +1596,15 @@
               null
             ],
             "description": "User who created the resource",
+            "nullable": true
+          },
+          "updatedAt": {
+            "type": "boolean",
+            "examples": [
+              true,
+              null
+            ],
+            "description": "Timestamp when the resource was last updated",
             "nullable": true
           },
           "updatedBy": {
@@ -2397,13 +2467,27 @@
                     "email": "example",
                     "name": "example"
                   },
+                  "null": {
+                    "meta": {
+                      "createdBy": true,
+                      "updatedAt": true,
+                      "updatedBy": true
+                    }
+                  },
+                  "notNull": {
+                    "meta": {
+                      "createdBy": true,
+                      "updatedAt": true,
+                      "updatedBy": true
+                    }
+                  },
                   "orCondition": true
                 }
               }
             }
           }
         },
-        "required": false
+        "required": true
       }
     }
   },


### PR DESCRIPTION
Make content in autogenerated Search request bodies `required: true` in the OpenAPI specification to align with API requirements where search filter content is mandatory.

---
Linear Issue: [INF-519](https://linear.app/meitner-se/issue/INF-519/make-content-in-search-requests-required)

<a href="https://cursor.com/background-agent?bcId=bc-343305df-e276-4bfe-8c40-9acdd5e6a9c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-343305df-e276-4bfe-8c40-9acdd5e6a9c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

