### PR TITLE
Add common response headers to spec

### DIFF
--- a/specification/openapigen/openapigen.go
+++ b/specification/openapigen/openapigen.go
@@ -1395,6 +1395,23 @@ func (g *generator) generateAutoErrorDescription(resourceName, endpointName, sta
 	}
 }
 
+// createResponseHeaders creates an ordered map of response headers from the service's common response headers.
+func (g *generator) createResponseHeaders(service *specification.Service) *orderedmap.Map[string, *v3.Header] {
+	if len(service.ResponseHeaders) == 0 {
+		return nil
+	}
+
+	headers := orderedmap.New[string, *v3.Header]()
+	for _, headerField := range service.ResponseHeaders {
+		header := &v3.Header{
+			Description: headerField.Description,
+			Schema:      base.CreateSchemaProxy(g.createParameterSchema(headerField, service)),
+		}
+		headers.Set(headerField.TagJSON(), header)
+	}
+	return headers
+}
+
 // createComponentResponse creates a v3.Response for the components section.
 func (g *generator) createComponentResponse(response specification.EndpointResponse, resourceName, endpointName string, service *specification.Service) *v3.Response {
 	componentResponse := &v3.Response{}
@@ -1403,6 +1420,11 @@ func (g *generator) createComponentResponse(response specification.EndpointRespo
 	description := g.generateAutoResponseDescription(resourceName, endpointName, response.Description)
 	if description != "" {
 		componentResponse.Description = description
+	}
+
+	// Add common response headers
+	if headers := g.createResponseHeaders(service); headers != nil {
+		componentResponse.Headers = headers
 	}
 
 	// Add response content if present
@@ -1613,10 +1635,17 @@ func (g *generator) createEndpointSpecific422ErrorResponse(resourceName, endpoin
 
 	content.Set(contentTypeJSON, mediaType)
 
-	return &v3.Response{
+	response := &v3.Response{
 		Description: g.generateAutoErrorDescription(resourceName, endpointName, httpStatus422),
 		Content:     content,
 	}
+
+	// Add common response headers
+	if headers := g.createResponseHeaders(service); headers != nil {
+		response.Headers = headers
+	}
+
+	return response
 }
 
 // createResponseReference creates a v3.Response that references a component response body.
@@ -1902,6 +1931,12 @@ func (g *generator) addErrorResponseBodiesToComponents(components *v3.Components
 			Description: errorResponse.description,
 			Content:     content,
 		}
+
+		// Add common response headers to error responses as well
+		if headers := g.createResponseHeaders(service); headers != nil {
+			standardResponse.Headers = headers
+		}
+
 		components.Responses.Set(standardResponseBodyName, standardResponse)
 	}
 }
@@ -1914,6 +1949,11 @@ func (g *generator) createResponse(response specification.EndpointResponse, reso
 	description := g.generateAutoResponseDescription(resourceName, endpointName, response.Description)
 	if description != "" {
 		openAPIResponse.Description = description
+	}
+
+	// Add common response headers
+	if headers := g.createResponseHeaders(service); headers != nil {
+		openAPIResponse.Headers = headers
 	}
 
 	// Add response content if present

--- a/specification/servergen/servergen_test.go
+++ b/specification/servergen/servergen_test.go
@@ -1073,9 +1073,10 @@ func TestGenerateResponseTypes(t *testing.T) {
 func TestGenerateUtils(t *testing.T) {
 	// Arrange
 	buf := &bytes.Buffer{}
+	service := createTestService()
 
 	// Act
-	err := generateUtils(buf)
+	err := generateUtils(buf, service)
 
 	// Assert
 	assert.Nil(t, err, "Expected no error when generating utils")
@@ -1129,9 +1130,10 @@ func TestGenerateUtils(t *testing.T) {
 		// Generate twice and compare
 		buf1 := &bytes.Buffer{}
 		buf2 := &bytes.Buffer{}
+		service := createTestService()
 
-		err1 := generateUtils(buf1)
-		err2 := generateUtils(buf2)
+		err1 := generateUtils(buf1, service)
+		err2 := generateUtils(buf2, service)
 
 		assert.Nil(t, err1, "First generation should not error")
 		assert.Nil(t, err2, "Second generation should not error")

--- a/specification/specification.go
+++ b/specification/specification.go
@@ -436,6 +436,9 @@ type Service struct {
 	// Timeout configuration for the service
 	Timeout *TimeoutConfiguration `json:"timeout,omitempty"`
 
+	// ResponseHeaders are common headers returned by all endpoints
+	ResponseHeaders []Field `json:"responseHeaders,omitempty"`
+
 	// Enums that are used in the service
 	Enums []Enum `json:"enums"`
 
@@ -621,6 +624,7 @@ func ApplyOverlay(input *Service) *Service {
 		Security:        input.Security,                              // Copy security requirements
 		Retry:           input.Retry,                                 // Copy retry configuration
 		Timeout:         input.Timeout,                               // Copy timeout configuration
+		ResponseHeaders: append([]Field{}, input.ResponseHeaders...), // Copy response headers
 		Enums:           make([]Enum, 0, len(input.Enums)+1),         // +1 for ErrorCode enum
 		Objects:         make([]Object, 0, len(input.Objects)+3),     // +3 for Error, Pagination, and Meta objects
 		Resources:       make([]Resource, len(input.Resources)),
@@ -1115,6 +1119,7 @@ func ApplyFilterOverlay(input *Service) *Service {
 		Security:        input.Security,                              // Copy security requirements
 		Retry:           input.Retry,                                 // Copy retry configuration
 		Timeout:         input.Timeout,                               // Copy timeout configuration
+		ResponseHeaders: append([]Field{}, input.ResponseHeaders...), // Copy response headers
 		Enums:           make([]Enum, len(input.Enums)),
 		Objects:         make([]Object, 0, len(input.Objects)*7), // Estimate for filter objects
 		Resources:       make([]Resource, len(input.Resources)),

--- a/testdata/response-headers-api.yaml
+++ b/testdata/response-headers-api.yaml
@@ -1,0 +1,28 @@
+name: "Response Headers Test API"
+version: "1.0.0"
+
+# Common response headers returned by all endpoints
+responseHeaders:
+  - name: "TraceID"
+    type: "String"
+    description: "Unique trace identifier for request tracing"
+  - name: "RateLimitReset"
+    type: "Timestamp"
+    description: "Time when the rate limit will reset"
+  - name: "RequestID"
+    type: "UUID"
+    description: "Unique identifier for this request"
+
+resources:
+  - name: "Users"
+    description: "User management resource"
+    operations: ["Create", "Read"]
+    fields:
+      - name: "id"
+        type: "UUID"
+        description: "Unique user identifier"
+        operations: ["Read"]
+      - name: "name"
+        type: "String"
+        description: "User's name"
+        operations: ["Create", "Read"]


### PR DESCRIPTION
Add support for specifying common response headers in the API specification to generate them in OpenAPI and server code via a user-implementable hook.

This PR addresses INF-521 by allowing users to define global response headers (e.g., `RateLimit-Reset`, `TraceID`) in the specification YAML. These headers are then automatically included in the generated OpenAPI specification and handled in the server code through a new `ResponseHeaderHook`, which users can implement to provide dynamic header values.

---
Linear Issue: [INF-521](https://linear.app/meitner-se/issue/INF-521/specify-a-set-of-response-headers)

<a href="https://cursor.com/background-agent?bcId=bc-fdba05c9-f863-493f-90aa-e7578ea54898"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fdba05c9-f863-493f-90aa-e7578ea54898"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

