### PR TITLE
Fix search filter example generation

### DIFF
--- a/specification/openapigen/openapigen_test.go
+++ b/specification/openapigen/openapigen_test.go
@@ -1501,14 +1501,10 @@ func TestRequestBodySchemaReferences(t *testing.T) {
 	jsonString := string(jsonBytes)
 
 	// Verify that a single body parameter referencing a component schema
-	// uses direct schema reference instead of object wrapper
-	assert.Contains(t, jsonString, "\"allOf\"", "Request body should use allOf for direct schema reference")
-	assert.Contains(t, jsonString, "\"$ref\": \"#/components/schemas/CreateUserRequest\"", "Request body should directly reference the component schema")
-
-	// Should NOT contain object wrapper with properties in the request body schema
-	// (error responses will still have properties, so we need to check specifically for the request body)
-	assert.NotContains(t, jsonString, "\"type\": \"object\",\n                \"properties\"", "Request body should not use object wrapper for single component schema parameter")
-	assert.NotContains(t, jsonString, "\"request\":", "Request body should not contain the parameter name as a property")
+	// wraps it in an object with the field name as a property
+	assert.Contains(t, jsonString, "\"request\":", "Request body should contain the parameter name as a property")
+	assert.Contains(t, jsonString, "\"$ref\": \"#/components/schemas/CreateUserRequest\"", "Request body should reference the component schema")
+	assert.Contains(t, jsonString, "\"allOf\"", "Request body should use allOf for schema reference")
 
 	t.Logf("Generated request body schema:\n%s", jsonString)
 }


### PR DESCRIPTION
Wrap search filter examples in the `filter` field in OpenAPI generation to match the expected API structure.

Previously, the OpenAPI example generation for request bodies with a single object parameter (like a search filter) would directly embed the object's content without wrapping it in the parameter's field name. This resulted in an incorrect example structure for search filters, which should be `{"filter": {...}}` but was generated as just `{...}`. This PR modifies the generation logic to consistently wrap all body parameters within their respective field names.

---
Linear Issue: [INF-540](https://linear.app/meitner-se/issue/INF-540/fix-search-filter-example-generation)

<a href="https://cursor.com/background-agent?bcId=bc-ed98f89f-d234-4355-a676-7c2bda3e2e56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ed98f89f-d234-4355-a676-7c2bda3e2e56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

