### PR TITLE
INF-1314: Add OAuth2 client credentials support to security scheme generation

### DIFF
--- a/specification/openapigen/openapigen.go
+++ b/specification/openapigen/openapigen.go
@@ -206,6 +206,7 @@ const (
 const (
 	securityTypeHTTP   = "http"
 	securityTypeAPIKey = "apiKey"
+	securityTypeOAuth2 = "oauth2"
 )
 
 // generator handles OpenAPI 3.1 specification generation from specification.Service.
@@ -2264,10 +2265,59 @@ func (g *generator) createSecurityScheme(scheme specification.SecurityScheme) *v
 	case securityTypeAPIKey:
 		securityScheme.Name = scheme.Name
 		securityScheme.In = scheme.In
+	case securityTypeOAuth2:
+		securityScheme.Flows = g.createOAuthFlows(scheme.Flows)
 	}
 	// mutualTLS type doesn't require additional fields
 
 	return securityScheme
+}
+
+// createOAuthFlows creates a v3.OAuthFlows from a specification.OAuth2Flows.
+func (g *generator) createOAuthFlows(flows *specification.OAuth2Flows) *v3.OAuthFlows {
+	if flows == nil {
+		return &v3.OAuthFlows{}
+	}
+
+	oauthFlows := &v3.OAuthFlows{}
+
+	if flows.ClientCredentials != nil {
+		oauthFlows.ClientCredentials = g.createOAuthFlow(flows.ClientCredentials)
+	}
+
+	if flows.AuthorizationCode != nil {
+		oauthFlows.AuthorizationCode = g.createOAuthFlow(flows.AuthorizationCode)
+	}
+
+	if flows.Implicit != nil {
+		oauthFlows.Implicit = g.createOAuthFlow(flows.Implicit)
+	}
+
+	if flows.Password != nil {
+		oauthFlows.Password = g.createOAuthFlow(flows.Password)
+	}
+
+	return oauthFlows
+}
+
+// createOAuthFlow creates a v3.OAuthFlow from a specification.OAuth2Flow.
+func (g *generator) createOAuthFlow(flow *specification.OAuth2Flow) *v3.OAuthFlow {
+	if flow == nil {
+		return nil
+	}
+
+	oauthFlow := &v3.OAuthFlow{
+		TokenUrl:         flow.TokenURL,
+		AuthorizationUrl: flow.AuthorizationURL,
+		RefreshUrl:       flow.RefreshURL,
+		Scopes:           orderedmap.New[string, string](),
+	}
+
+	for scopeName, scopeDesc := range flow.Scopes {
+		oauthFlow.Scopes.Set(scopeName, scopeDesc)
+	}
+
+	return oauthFlow
 }
 
 // addSecurityToDocument adds security requirements from the service to the OpenAPI document.

--- a/specification/openapigen/openapigen_test.go
+++ b/specification/openapigen/openapigen_test.go
@@ -3925,3 +3925,172 @@ func TestGenerator_SecuritySchemesConsistentOrder(t *testing.T) {
 	expectedKeys := []string{"Bearer", "ClientCredentials", "ClientSecret"}
 	assert.Equal(t, expectedKeys, keys, "All security schemes should be present")
 }
+
+// ============================================================================
+// OAuth2 Security Scheme Tests
+// ============================================================================
+
+// TestGenerator_OAuth2ClientCredentials tests that OAuth2 client credentials flow is generated correctly.
+func TestGenerator_OAuth2ClientCredentials(t *testing.T) {
+	service := &specification.Service{
+		Name:    "OAuth2 Test API",
+		Version: "1.0.0",
+		SecuritySchemes: map[string]specification.SecurityScheme{
+			"ClientCredentials": {
+				Type:        "apiKey",
+				Name:        "Client-ID",
+				In:          "header",
+				Description: "Client ID header",
+			},
+			"ClientSecret": {
+				Type:        "apiKey",
+				Name:        "Client-Secret",
+				In:          "header",
+				Description: "Client secret header",
+			},
+			"OAuth2": {
+				Type:        "oauth2",
+				Description: "OAuth2 client credentials flow",
+				Flows: &specification.OAuth2Flows{
+					ClientCredentials: &specification.OAuth2Flow{
+						TokenURL: "/oauth/token",
+						Scopes:   map[string]string{},
+					},
+				},
+			},
+		},
+		Security: []specification.SecurityRequirement{
+			{"ClientCredentials", "ClientSecret"},
+			{"OAuth2"},
+		},
+		Enums:     []specification.Enum{},
+		Objects:   []specification.Object{},
+		Resources: []specification.Resource{},
+	}
+
+	generator := newGenerator()
+	document, err := generator.generateFromService(service)
+
+	assert.NoError(t, err, "Should generate document without error")
+	assert.NotNil(t, document, "Generated document should not be nil")
+	assert.NotNil(t, document.Components, "Document should have components")
+	assert.NotNil(t, document.Components.SecuritySchemes, "Components should have security schemes")
+
+	// Verify OAuth2 scheme exists
+	oauth2Scheme, ok := document.Components.SecuritySchemes.Get("OAuth2")
+	assert.True(t, ok, "OAuth2 scheme should exist")
+	assert.NotNil(t, oauth2Scheme, "OAuth2 scheme should not be nil")
+	assert.Equal(t, "oauth2", oauth2Scheme.Type, "OAuth2 scheme type should be oauth2")
+	assert.Equal(t, "OAuth2 client credentials flow", oauth2Scheme.Description, "OAuth2 scheme description should match")
+	assert.NotNil(t, oauth2Scheme.Flows, "OAuth2 scheme should have flows")
+	assert.NotNil(t, oauth2Scheme.Flows.ClientCredentials, "OAuth2 scheme should have client credentials flow")
+	assert.Equal(t, "/oauth/token", oauth2Scheme.Flows.ClientCredentials.TokenUrl, "Token URL should match")
+	assert.NotNil(t, oauth2Scheme.Flows.ClientCredentials.Scopes, "Client credentials flow should have scopes (empty)")
+
+	// Verify other schemes still present
+	clientCredScheme, ok := document.Components.SecuritySchemes.Get("ClientCredentials")
+	assert.True(t, ok, "ClientCredentials scheme should exist")
+	assert.Equal(t, "apiKey", clientCredScheme.Type, "ClientCredentials type should be apiKey")
+
+	clientSecretScheme, ok := document.Components.SecuritySchemes.Get("ClientSecret")
+	assert.True(t, ok, "ClientSecret scheme should exist")
+	assert.Equal(t, "apiKey", clientSecretScheme.Type, "ClientSecret type should be apiKey")
+
+	// Verify security requirements
+	assert.NotNil(t, document.Security, "Document should have security requirements")
+	assert.Len(t, document.Security, 2, "Should have 2 security requirements")
+
+	t.Run("edge cases", func(t *testing.T) {
+		t.Run("nil flows produces empty OAuthFlows", func(t *testing.T) {
+			serviceNilFlows := &specification.Service{
+				Name: "Nil Flows Test",
+				SecuritySchemes: map[string]specification.SecurityScheme{
+					"OAuth2": {
+						Type:  "oauth2",
+						Flows: nil,
+					},
+				},
+				Enums:     []specification.Enum{},
+				Objects:   []specification.Object{},
+				Resources: []specification.Resource{},
+			}
+
+			gen := newGenerator()
+			doc, genErr := gen.generateFromService(serviceNilFlows)
+			assert.NoError(t, genErr, "Should generate without error when flows is nil")
+			assert.NotNil(t, doc, "Document should not be nil")
+
+			scheme, schemeOk := doc.Components.SecuritySchemes.Get("OAuth2")
+			assert.True(t, schemeOk, "OAuth2 scheme should exist")
+			assert.NotNil(t, scheme.Flows, "Flows should not be nil even when spec flows is nil")
+		})
+
+		t.Run("OAuth2 YAML output contains expected structure", func(t *testing.T) {
+			yamlBytes, renderErr := document.Render()
+			assert.NoError(t, renderErr, "Should render document to YAML without error")
+
+			yamlStr := string(yamlBytes)
+			assert.Contains(t, yamlStr, "oauth2", "YAML should contain oauth2 type")
+			assert.Contains(t, yamlStr, "clientCredentials:", "YAML should contain clientCredentials flow")
+			assert.Contains(t, yamlStr, "tokenUrl:", "YAML should contain tokenUrl")
+			assert.Contains(t, yamlStr, "/oauth/token", "YAML should contain token URL value")
+			assert.Contains(t, yamlStr, "scopes:", "YAML should contain scopes")
+
+			t.Logf("Generated OAuth2 YAML:\n%s", yamlStr)
+		})
+	})
+}
+
+// TestGenerator_OAuth2WithMultipleFlows tests that OAuth2 with multiple flows generates correctly.
+func TestGenerator_OAuth2WithMultipleFlows(t *testing.T) {
+	service := &specification.Service{
+		Name:    "OAuth2 Multi-Flow Test API",
+		Version: "1.0.0",
+		SecuritySchemes: map[string]specification.SecurityScheme{
+			"OAuth2": {
+				Type: "oauth2",
+				Flows: &specification.OAuth2Flows{
+					ClientCredentials: &specification.OAuth2Flow{
+						TokenURL: "/oauth/token",
+						Scopes:   map[string]string{"read": "Read access", "write": "Write access"},
+					},
+					AuthorizationCode: &specification.OAuth2Flow{
+						AuthorizationURL: "/oauth/authorize",
+						TokenURL:         "/oauth/token",
+						Scopes:           map[string]string{"read": "Read access"},
+					},
+				},
+			},
+		},
+		Security: []specification.SecurityRequirement{
+			{"OAuth2"},
+		},
+		Enums:     []specification.Enum{},
+		Objects:   []specification.Object{},
+		Resources: []specification.Resource{},
+	}
+
+	generator := newGenerator()
+	document, err := generator.generateFromService(service)
+
+	assert.NoError(t, err, "Should generate document without error")
+	assert.NotNil(t, document, "Generated document should not be nil")
+
+	oauth2Scheme, ok := document.Components.SecuritySchemes.Get("OAuth2")
+	assert.True(t, ok, "OAuth2 scheme should exist")
+	assert.NotNil(t, oauth2Scheme.Flows, "OAuth2 scheme should have flows")
+
+	// Check client credentials flow
+	assert.NotNil(t, oauth2Scheme.Flows.ClientCredentials, "Should have client credentials flow")
+	assert.Equal(t, "/oauth/token", oauth2Scheme.Flows.ClientCredentials.TokenUrl, "Client credentials token URL should match")
+	assert.Equal(t, 2, oauth2Scheme.Flows.ClientCredentials.Scopes.Len(), "Client credentials should have 2 scopes")
+
+	readScopeDesc, readExists := oauth2Scheme.Flows.ClientCredentials.Scopes.Get("read")
+	assert.True(t, readExists, "read scope should exist in client credentials")
+	assert.Equal(t, "Read access", readScopeDesc, "read scope description should match")
+
+	// Check authorization code flow
+	assert.NotNil(t, oauth2Scheme.Flows.AuthorizationCode, "Should have authorization code flow")
+	assert.Equal(t, "/oauth/authorize", oauth2Scheme.Flows.AuthorizationCode.AuthorizationUrl, "Authorization code auth URL should match")
+	assert.Equal(t, "/oauth/token", oauth2Scheme.Flows.AuthorizationCode.TokenUrl, "Authorization code token URL should match")
+}

--- a/specification/specification.go
+++ b/specification/specification.go
@@ -361,14 +361,45 @@ type ServiceLicense struct {
 	Identifier string `json:"identifier,omitempty"`
 }
 
+// OAuth2Flow represents a single OAuth2 authorization flow definition.
+type OAuth2Flow struct {
+	// TokenURL is the token endpoint URL (required for clientCredentials flow)
+	TokenURL string `json:"tokenUrl,omitempty"`
+
+	// AuthorizationURL is the authorization endpoint URL (required for implicit and authorizationCode flows)
+	AuthorizationURL string `json:"authorizationUrl,omitempty"`
+
+	// RefreshURL is the refresh token endpoint URL (optional)
+	RefreshURL string `json:"refreshUrl,omitempty"`
+
+	// Scopes is a map of available scope names to their descriptions
+	Scopes map[string]string `json:"scopes,omitempty"`
+}
+
+// OAuth2Flows represents the supported OAuth2 flow configurations.
+type OAuth2Flows struct {
+	// ClientCredentials defines the OAuth2 client credentials flow
+	ClientCredentials *OAuth2Flow `json:"clientCredentials,omitempty"`
+
+	// AuthorizationCode defines the OAuth2 authorization code flow
+	AuthorizationCode *OAuth2Flow `json:"authorizationCode,omitempty"`
+
+	// Implicit defines the OAuth2 implicit flow
+	Implicit *OAuth2Flow `json:"implicit,omitempty"`
+
+	// Password defines the OAuth2 resource owner password credentials flow
+	Password *OAuth2Flow `json:"password,omitempty"`
+}
+
 // SecurityScheme represents a security scheme definition.
 type SecurityScheme struct {
-	Type         string `json:"type"`
-	Description  string `json:"description,omitempty"`
-	Scheme       string `json:"scheme,omitempty"`
-	BearerFormat string `json:"bearerFormat,omitempty"`
-	Name         string `json:"name,omitempty"`
-	In           string `json:"in,omitempty"`
+	Type         string       `json:"type"`
+	Description  string       `json:"description,omitempty"`
+	Scheme       string       `json:"scheme,omitempty"`
+	BearerFormat string       `json:"bearerFormat,omitempty"`
+	Name         string       `json:"name,omitempty"`
+	In           string       `json:"in,omitempty"`
+	Flows        *OAuth2Flows `json:"flows,omitempty"`
 }
 
 // SecurityRequirement represents scheme names that must be satisfied together.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds OAuth2 client credentials flow support to the `publicapis-gen` OpenAPI generator so that Speakeasy SDKs can automatically handle token exchange.

## Changes

### `specification/specification.go`
- Added `OAuth2Flow` struct with `TokenURL`, `AuthorizationURL`, `RefreshURL`, and `Scopes` fields
- Added `OAuth2Flows` struct supporting `ClientCredentials`, `AuthorizationCode`, `Implicit`, and `Password` flows
- Extended `SecurityScheme` struct with a `Flows *OAuth2Flows` field to support OAuth2 configuration

### `specification/openapigen/openapigen.go`
- Added `securityTypeOAuth2 = "oauth2"` constant
- Updated `createSecurityScheme()` to handle `oauth2` type by building `v3.OAuthFlows` via the new `createOAuthFlows()` helper
- Added `createOAuthFlows()` and `createOAuthFlow()` methods on the generator

### `specification/openapigen/openapigen_test.go`
- Added `TestGenerator_OAuth2ClientCredentials` — tests single client credentials flow, nil flows edge case, and YAML output
- Added `TestGenerator_OAuth2WithMultipleFlows` — tests multiple simultaneous flows with scopes

## Usage

Service spec authors can now add an OAuth2 security scheme:

```yaml
securitySchemes:
  ClientCredentials:
    name: Client-ID
    type: apiKey
    in: header
  ClientSecret:
    name: Client-Secret
    type: apiKey
    in: header
  OAuth2:
    type: oauth2
    flows:
      clientCredentials:
        tokenUrl: /oauth/token
        scopes: {}

security:
  - [ClientCredentials, ClientSecret]
  - [OAuth2]
```

This generates an OpenAPI spec that Speakeasy will use to produce SDK code with automatic token exchange — users only need to provide `client_id` and `client_secret` and the SDK handles fetching and refreshing Bearer tokens transparently.

## Testing

All existing tests pass. New OAuth2-specific tests added and passing.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [INF-1314](https://linear.app/meitner-se/issue/INF-1314/add-oauth2-client-credentials-support-to-publicapis-gen-for-speakeasy)

<div><a href="https://cursor.com/agents/bc-47ad29bd-7fe9-4c31-8b5f-fafdd1ce98b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-47ad29bd-7fe9-4c31-8b5f-fafdd1ce98b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

