### PR TITLE
feat: add Development flag to Resource to exclude from generated output

### DIFF
--- a/specification/openapigen/openapigen.go
+++ b/specification/openapigen/openapigen.go
@@ -628,23 +628,19 @@ func (g *generator) createTagsFromResources(service *specification.Service) []*b
 		return nil
 	}
 
-	var nonDevResources []specification.Resource
-	for _, r := range service.Resources {
-		if !r.Development {
-			nonDevResources = append(nonDevResources, r)
+	tags := make([]*base.Tag, 0, len(service.Resources))
+	for _, resource := range service.Resources {
+		if resource.Development {
+			continue
 		}
-	}
-
-	if len(nonDevResources) == 0 {
-		return nil
-	}
-
-	tags := make([]*base.Tag, len(nonDevResources))
-	for i, resource := range nonDevResources {
-		tags[i] = &base.Tag{
+		tags = append(tags, &base.Tag{
 			Name:        resource.Name,
 			Description: resource.Description,
-		}
+		})
+	}
+
+	if len(tags) == 0 {
+		return nil
 	}
 
 	return tags

--- a/specification/openapigen/openapigen.go
+++ b/specification/openapigen/openapigen.go
@@ -607,6 +607,9 @@ func (g *generator) buildV3Document(service *specification.Service) *v3.Document
 	// Create Paths
 	paths := orderedmap.New[string, *v3.PathItem]()
 	for _, resource := range service.Resources {
+		if resource.Development {
+			continue
+		}
 		g.addResourceToPaths(resource, paths, service)
 	}
 	document.Paths = &v3.Paths{
@@ -625,8 +628,19 @@ func (g *generator) createTagsFromResources(service *specification.Service) []*b
 		return nil
 	}
 
-	tags := make([]*base.Tag, len(service.Resources))
-	for i, resource := range service.Resources {
+	var nonDevResources []specification.Resource
+	for _, r := range service.Resources {
+		if !r.Development {
+			nonDevResources = append(nonDevResources, r)
+		}
+	}
+
+	if len(nonDevResources) == 0 {
+		return nil
+	}
+
+	tags := make([]*base.Tag, len(nonDevResources))
+	for i, resource := range nonDevResources {
 		tags[i] = &base.Tag{
 			Name:        resource.Name,
 			Description: resource.Description,
@@ -1018,6 +1032,9 @@ func (g *generator) addRequestBodiesToComponents(components *v3.Components, serv
 
 	// Iterate through all resources and endpoints to collect request bodies
 	for _, resource := range service.Resources {
+		if resource.Development {
+			continue
+		}
 		for _, endpoint := range resource.Endpoints {
 			if len(endpoint.Request.BodyParams) > 0 {
 				requestBodyName := g.createRequestBodyName(resource.Name, endpoint.Name)
@@ -1281,6 +1298,9 @@ func (g *generator) addResponseBodiesToComponents(components *v3.Components, ser
 
 	// Iterate through all resources and endpoints to collect response bodies
 	for _, resource := range service.Resources {
+		if resource.Development {
+			continue
+		}
 		for _, endpoint := range resource.Endpoints {
 			// Add success response body if it has content
 			if endpoint.Response.BodyObject != nil || len(endpoint.Response.BodyFields) > 0 {

--- a/specification/openapigen/openapigen_test.go
+++ b/specification/openapigen/openapigen_test.go
@@ -1910,8 +1910,14 @@ func TestGenerator_DevelopmentFlag(t *testing.T) {
 		assert.NotNil(t, document, "Document should not be nil")
 
 		assert.Nil(t, document.Tags, "Document should have no tags when all resources are in development")
+		assert.NotNil(t, document.Paths, "Document paths should be initialized even when all resources are excluded")
+		assert.Equal(t, 0, document.Paths.PathItems.Len(), "Document should have no paths when all resources are in development")
 	})
 }
+
+// ============================================================================
+// RequestBodies Section Tests
+// ============================================================================
 
 // TestRequestBodiesMarkedAsRequired verifies that request bodies in operations are marked as required.
 func TestRequestBodiesMarkedAsRequired(t *testing.T) {

--- a/specification/openapigen/openapigen_test.go
+++ b/specification/openapigen/openapigen_test.go
@@ -1673,6 +1673,44 @@ func TestGenerator_createTagsFromResources(t *testing.T) {
 		assert.Equal(t, "Products", tags[0].Name, "Tag name should match resource name")
 		assert.Equal(t, "", tags[0].Description, "Tag description should be empty when resource has no description")
 	})
+
+	t.Run("development resources are excluded from tags", func(t *testing.T) {
+		service := &specification.Service{
+			Name: "TestService",
+			Resources: []specification.Resource{
+				{
+					Name:        "Users",
+					Description: "User management operations",
+				},
+				{
+					Name:        "NewFeature",
+					Description: "Feature not yet released",
+					Development: true,
+				},
+			},
+		}
+
+		tags := generator.createTagsFromResources(service)
+		assert.NotNil(t, tags, "Tags should not be nil with non-development resources")
+		assert.Equal(t, 1, len(tags), "Should create one tag, excluding the development resource")
+		assert.Equal(t, "Users", tags[0].Name, "Tag should be for the non-development resource")
+	})
+
+	t.Run("all development resources returns nil", func(t *testing.T) {
+		service := &specification.Service{
+			Name: "TestService",
+			Resources: []specification.Resource{
+				{
+					Name:        "NewFeature",
+					Description: "Feature not yet released",
+					Development: true,
+				},
+			},
+		}
+
+		tags := generator.createTagsFromResources(service)
+		assert.Nil(t, tags, "Tags should be nil when all resources are in development")
+	})
 }
 
 // TestGenerator_GenerateFromService_IncludesTags tests that generated documents include tags from resources.
@@ -1727,8 +1765,153 @@ func TestGenerator_GenerateFromService_IncludesTags(t *testing.T) {
 }
 
 // ============================================================================
-// RequestBodies Section Tests
+// Development Flag Tests
 // ============================================================================
+
+// TestGenerator_DevelopmentFlag tests that resources marked as development are excluded from generated output.
+func TestGenerator_DevelopmentFlag(t *testing.T) {
+	const (
+		devResourceName    = "GradeElementary"
+		devResourceDesc    = "Grade elementary resource in development"
+		stableResourceName = "Students"
+		stableResourceDesc = "Student management operations"
+	)
+
+	generator := newGenerator()
+
+	t.Run("development resource is excluded from paths", func(t *testing.T) {
+		service := &specification.Service{
+			Name: "TestService",
+			Resources: []specification.Resource{
+				{
+					Name:        stableResourceName,
+					Description: stableResourceDesc,
+					Endpoints: []specification.Endpoint{
+						{
+							Name:    "ListStudents",
+							Method:  "GET",
+							Path:    "",
+							Summary: "List students",
+							Response: specification.EndpointResponse{
+								StatusCode:  200,
+								ContentType: "application/json",
+							},
+						},
+					},
+				},
+				{
+					Name:        devResourceName,
+					Description: devResourceDesc,
+					Development: true,
+					Endpoints: []specification.Endpoint{
+						{
+							Name:    "ListGrades",
+							Method:  "GET",
+							Path:    "",
+							Summary: "List grades",
+							Response: specification.EndpointResponse{
+								StatusCode:  200,
+								ContentType: "application/json",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		document, err := generator.generateFromService(service)
+		assert.NoError(t, err, "Should not return error for valid service")
+		assert.NotNil(t, document, "Document should not be nil")
+
+		assert.NotNil(t, document.Paths, "Document should have paths")
+		// Stable resource should contribute exactly one path; development resource should contribute nothing
+		assert.Equal(t, 1, document.Paths.PathItems.Len(), "Only the stable resource path should appear in document")
+
+		// The stable resource path uses kebab-case: /students
+		_, stableExists := document.Paths.PathItems.Get("/students")
+		assert.True(t, stableExists, "Stable resource path /students should be present in document")
+
+		// The development resource path (/grade-elementary) must not appear
+		_, devExists := document.Paths.PathItems.Get("/grade-elementary")
+		assert.False(t, devExists, "Development resource path should NOT be present in document")
+	})
+
+	t.Run("development resource is excluded from tags", func(t *testing.T) {
+		service := &specification.Service{
+			Name: "TestService",
+			Resources: []specification.Resource{
+				{
+					Name:        stableResourceName,
+					Description: stableResourceDesc,
+				},
+				{
+					Name:        devResourceName,
+					Description: devResourceDesc,
+					Development: true,
+				},
+			},
+		}
+
+		document, err := generator.generateFromService(service)
+		assert.NoError(t, err, "Should not return error for valid service")
+		assert.NotNil(t, document, "Document should not be nil")
+
+		assert.NotNil(t, document.Tags, "Document should have tags for non-development resources")
+		assert.Equal(t, 1, len(document.Tags), "Should have exactly one tag (the non-development resource)")
+		assert.Equal(t, stableResourceName, document.Tags[0].Name, "Tag should be for the stable resource")
+	})
+
+	t.Run("non-development resource is included normally", func(t *testing.T) {
+		service := &specification.Service{
+			Name: "TestService",
+			Resources: []specification.Resource{
+				{
+					Name:        stableResourceName,
+					Description: stableResourceDesc,
+					Endpoints: []specification.Endpoint{
+						{
+							Name:    "ListStudents",
+							Method:  "GET",
+							Path:    "",
+							Summary: "List students",
+							Response: specification.EndpointResponse{
+								StatusCode:  200,
+								ContentType: "application/json",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		document, err := generator.generateFromService(service)
+		assert.NoError(t, err, "Should not return error for valid service")
+		assert.NotNil(t, document, "Document should not be nil")
+
+		assert.NotNil(t, document.Tags, "Document should have tags")
+		assert.Equal(t, 1, len(document.Tags), "Should have exactly one tag")
+		assert.Equal(t, stableResourceName, document.Tags[0].Name, "Tag should be for the stable resource")
+	})
+
+	t.Run("service with only development resources has nil tags and empty paths", func(t *testing.T) {
+		service := &specification.Service{
+			Name: "TestService",
+			Resources: []specification.Resource{
+				{
+					Name:        devResourceName,
+					Description: devResourceDesc,
+					Development: true,
+				},
+			},
+		}
+
+		document, err := generator.generateFromService(service)
+		assert.NoError(t, err, "Should not return error for valid service")
+		assert.NotNil(t, document, "Document should not be nil")
+
+		assert.Nil(t, document.Tags, "Document should have no tags when all resources are in development")
+	})
+}
 
 // TestRequestBodiesMarkedAsRequired verifies that request bodies in operations are marked as required.
 func TestRequestBodiesMarkedAsRequired(t *testing.T) {

--- a/specification/servergen/servergen.go
+++ b/specification/servergen/servergen.go
@@ -289,6 +289,9 @@ func generateServer(buf *bytes.Buffer, service *specification.Service) error {
 	buf.WriteString("\trouterGroup.StaticFileFS(\"/openapi.json\", \"openapi.json\", http.FS(api.OpenAPI_JSON))\n\n")
 
 	for _, resource := range service.Resources {
+		if resource.Development {
+			continue
+		}
 		for _, endpoint := range resource.Endpoints {
 			if endpoint.HasResponseType() {
 				buf.WriteString(fmt.Sprintf("\trouterGroup.%s(\"%s\", serveWithResponse(%d, api.Server, api.%s.%s))\n",
@@ -321,6 +324,9 @@ func generateServer(buf *bytes.Buffer, service *specification.Service) error {
 
 	buf.WriteString("\tOpenAPI_JSON embed.FS\n")
 	for _, resource := range service.Resources {
+		if resource.Development {
+			continue
+		}
 		buf.WriteString(fmt.Sprintf("\t%s %sAPI[Session] // Endpoints for the %s resource\n", resource.Name, resource.Name, resource.Name))
 	}
 	buf.WriteString("}\n\n")
@@ -375,6 +381,9 @@ func generateServer(buf *bytes.Buffer, service *specification.Service) error {
 	buf.WriteString("}\n\n")
 
 	for _, resource := range service.Resources {
+		if resource.Development {
+			continue
+		}
 		buf.WriteString(fmt.Sprintf("type %sAPI[Session any] interface {\n", resource.Name))
 		for _, endpoint := range resource.Endpoints {
 			if endpoint.HasResponseType() {
@@ -458,6 +467,9 @@ func generateRequestTypes(buf *bytes.Buffer, service *specification.Service) err
 	buf.WriteString("}\n\n")
 
 	for _, resource := range service.Resources {
+		if resource.Development {
+			continue
+		}
 		for _, endpoint := range resource.Endpoints {
 			if len(endpoint.Request.PathParams) > 0 {
 				buf.WriteString(fmt.Sprintf("type %s struct {\n", endpoint.GetPathParamsType(resource.Name)))
@@ -490,6 +502,9 @@ func generateRequestTypes(buf *bytes.Buffer, service *specification.Service) err
 
 func generateResponseTypes(buf *bytes.Buffer, service *specification.Service) error {
 	for _, resource := range service.Resources {
+		if resource.Development {
+			continue
+		}
 		for _, endpoint := range resource.Endpoints {
 			if len(endpoint.Response.BodyFields) == 0 {
 				continue

--- a/specification/servergen/servergen_test.go
+++ b/specification/servergen/servergen_test.go
@@ -1429,3 +1429,126 @@ func TestConvertOpenAPIPathToGin(t *testing.T) {
 		})
 	})
 }
+
+// ============================================================================
+// Development Flag Tests
+// ============================================================================
+
+// TestGenerateServer_DevelopmentFlag tests that resources with Development: true are excluded from all generated server code.
+func TestGenerateServer_DevelopmentFlag(t *testing.T) {
+	const (
+		devResourceName    = "GradeElementary"
+		stableResourceName = "Students"
+		devResourceDesc    = "Grade elementary resource in development"
+		stableResourceDesc = "Student management operations"
+	)
+
+	stableEndpoint := specification.Endpoint{
+		Name:   "ListStudents",
+		Method: "GET",
+		Path:   "",
+		Response: specification.EndpointResponse{
+			StatusCode: 200,
+			BodyFields: []specification.Field{
+				{Name: "Total", Type: "Int"},
+			},
+		},
+	}
+
+	devEndpoint := specification.Endpoint{
+		Name:   "ListGrades",
+		Method: "GET",
+		Path:   "",
+		Response: specification.EndpointResponse{
+			StatusCode: 200,
+			BodyFields: []specification.Field{
+				{Name: "Grade", Type: "String"},
+			},
+		},
+	}
+
+	t.Run("development resource route is not registered", func(t *testing.T) {
+		service := &specification.Service{
+			Name:    testServiceName,
+			Version: testServiceVersion,
+			Resources: []specification.Resource{
+				{Name: stableResourceName, Description: stableResourceDesc, Endpoints: []specification.Endpoint{stableEndpoint}},
+				{Name: devResourceName, Description: devResourceDesc, Development: true, Endpoints: []specification.Endpoint{devEndpoint}},
+			},
+		}
+
+		buf := &bytes.Buffer{}
+		err := GenerateServer(buf, service)
+		assert.Nil(t, err, "Should not return error when generating server with a development resource")
+
+		generated := buf.String()
+		assert.Contains(t, generated, stableResourceName, "Stable resource should appear in generated code")
+		assert.NotContains(t, generated, devResourceName, "Development resource should NOT appear in generated code")
+	})
+
+	t.Run("development resource has no API struct field", func(t *testing.T) {
+		service := &specification.Service{
+			Name:    testServiceName,
+			Version: testServiceVersion,
+			Resources: []specification.Resource{
+				{Name: stableResourceName, Description: stableResourceDesc, Endpoints: []specification.Endpoint{stableEndpoint}},
+				{Name: devResourceName, Description: devResourceDesc, Development: true, Endpoints: []specification.Endpoint{devEndpoint}},
+			},
+		}
+
+		buf := &bytes.Buffer{}
+		err := GenerateServer(buf, service)
+		assert.Nil(t, err, "Should not return error when generating server with a development resource")
+
+		generated := buf.String()
+
+		expectedStableField := stableResourceName + "API[Session]"
+		assert.Contains(t, generated, expectedStableField, "Stable resource API field should appear in generated struct")
+
+		expectedDevField := devResourceName + "API[Session]"
+		assert.NotContains(t, generated, expectedDevField, "Development resource API field should NOT appear in generated struct")
+	})
+
+	t.Run("development resource has no interface definition", func(t *testing.T) {
+		service := &specification.Service{
+			Name:    testServiceName,
+			Version: testServiceVersion,
+			Resources: []specification.Resource{
+				{Name: stableResourceName, Description: stableResourceDesc, Endpoints: []specification.Endpoint{stableEndpoint}},
+				{Name: devResourceName, Description: devResourceDesc, Development: true, Endpoints: []specification.Endpoint{devEndpoint}},
+			},
+		}
+
+		buf := &bytes.Buffer{}
+		err := GenerateServer(buf, service)
+		assert.Nil(t, err, "Should not return error when generating server with a development resource")
+
+		generated := buf.String()
+
+		expectedStableInterface := "type " + stableResourceName + "API[Session any] interface {"
+		assert.Contains(t, generated, expectedStableInterface, "Stable resource interface should appear in generated code")
+
+		expectedDevInterface := "type " + devResourceName + "API[Session any] interface {"
+		assert.NotContains(t, generated, expectedDevInterface, "Development resource interface should NOT appear in generated code")
+	})
+
+	t.Run("non-development resource is unaffected when other resources are in development", func(t *testing.T) {
+		service := &specification.Service{
+			Name:    testServiceName,
+			Version: testServiceVersion,
+			Resources: []specification.Resource{
+				{Name: stableResourceName, Description: stableResourceDesc, Endpoints: []specification.Endpoint{stableEndpoint}},
+				{Name: devResourceName, Description: devResourceDesc, Development: true, Endpoints: []specification.Endpoint{devEndpoint}},
+			},
+		}
+
+		buf := &bytes.Buffer{}
+		err := GenerateServer(buf, service)
+		assert.Nil(t, err, "Should not return error when generating server with a development resource")
+
+		generated := buf.String()
+
+		assert.Contains(t, generated, stableResourceName, "Stable resource should still appear in generated code")
+		assert.Contains(t, generated, "ListStudents", "Stable resource endpoint should still appear in generated code")
+	})
+}

--- a/specification/specification.go
+++ b/specification/specification.go
@@ -526,7 +526,7 @@ type Resource struct {
 	Description string `json:"description"`
 
 	// Development indicates this resource is not ready for public use.
-	// Resources with Development set to true are excluded from all generated output
+	// Resources with Development set to true are excluded from all generated output.
 	// (OpenAPI spec, server code, API types). This allows resources to be defined
 	// and implemented without being surfaced to third parties prematurely.
 	Development bool `json:"development,omitempty" yaml:"development,omitempty"`

--- a/specification/specification.go
+++ b/specification/specification.go
@@ -525,6 +525,12 @@ type Resource struct {
 	// Description about the resource
 	Description string `json:"description"`
 
+	// Development indicates this resource is not ready for public use.
+	// Resources with Development set to true are excluded from all generated output
+	// (OpenAPI spec, server code, API types). This allows resources to be defined
+	// and implemented without being surfaced to third parties prematurely.
+	Development bool `json:"development,omitempty" yaml:"development,omitempty"`
+
 	// Operations that are allowed for the resource can be all of Create, Get, List, Search, Update, Delete
 	Operations []string `json:"operations"`
 

--- a/specification/testgen/testgen.go
+++ b/specification/testgen/testgen.go
@@ -33,6 +33,9 @@ func GenerateInternalTests(buf *bytes.Buffer, service *specification.Service, pa
 
 	// Generate tests for each resource endpoint
 	for _, resource := range service.Resources {
+		if resource.Development {
+			continue
+		}
 		for _, endpoint := range resource.Endpoints {
 			err = generateInternalEndpointTest(buf, service, resource, endpoint)
 			if err != nil {
@@ -88,6 +91,9 @@ func GenerateTests(buf *bytes.Buffer, service *specification.Service, packageNam
 
 	// Generate tests for each resource endpoint
 	for _, resource := range service.Resources {
+		if resource.Development {
+			continue
+		}
 		for _, endpoint := range resource.Endpoints {
 			err = generateEndpointTest(buf, service, resource, endpoint, apiPackageName)
 			if err != nil {
@@ -492,6 +498,9 @@ func generateServerSetup(buf *bytes.Buffer, serviceName string, service *specifi
 
 	// Add all resource mocks to the API struct
 	for _, resource := range service.Resources {
+		if resource.Development {
+			continue
+		}
 		if len(resource.Endpoints) > 0 {
 			if resource.Name == currentResource.Name {
 				// Use the configured mock for the resource being tested
@@ -683,6 +692,9 @@ func generateHelperFunctions(buf *bytes.Buffer, service *specification.Service, 
 
 	// Generate mock interfaces for each resource
 	for _, resource := range service.Resources {
+		if resource.Development {
+			continue
+		}
 		if len(resource.Endpoints) == 0 {
 			continue
 		}
@@ -1500,6 +1512,9 @@ func generateInternalServerSetup(buf *bytes.Buffer, serviceName string, service 
 
 	// Add all resource mocks to the API struct
 	for _, resource := range service.Resources {
+		if resource.Development {
+			continue
+		}
 		if len(resource.Endpoints) > 0 {
 			if resource.Name == currentResource.Name {
 				// Use the configured mock for the resource being tested
@@ -1608,6 +1623,9 @@ func generateInternalHelperFunctions(buf *bytes.Buffer, service *specification.S
 
 	// Generate mock interfaces for each resource (no package prefixes)
 	for _, resource := range service.Resources {
+		if resource.Development {
+			continue
+		}
 		if len(resource.Endpoints) == 0 {
 			continue
 		}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `Development` boolean field to the `Resource` struct in `specification/specification.go`. Resources with `Development: true` are silently excluded from **all** generated output, allowing new resources to be fully specced and developed without being surfaced to third parties prematurely.

## Changes

### `specification/specification.go`
- Added `Development bool` field to the `Resource` struct with `json:"development,omitempty" yaml:"development,omitempty"` tags and a doc comment explaining the intent.

### `specification/openapigen/openapigen.go`
- **Paths loop**: skips development resources — their endpoints never appear in the OpenAPI `paths` section.
- **`createTagsFromResources`**: filters out development resources before building the tags slice; returns `nil` if all resources are in development.
- **Request bodies loop**: skips development resources.
- **Response bodies loop**: skips development resources.

### `specification/servergen/servergen.go`
- **Routes loop**: skips development resources — no `routerGroup.*` calls registered.
- **API struct fields loop**: skips development resources — no `<Name> <Name>API[Session]` field emitted.
- **Interface definitions loop**: skips development resources — no `type <Name>API[Session any] interface` emitted.
- **Request types loop**: skips development resources — no path/query/body param types emitted.
- **Response types loop**: skips development resources — no response body types emitted.

### `specification/testgen/testgen.go`
- All six loops over `service.Resources` skip development resources (endpoint tests, API struct mock fields, and mock interface definitions for both internal and external test variants).

### Tests
- **`openapigen_test.go`**: added subtests to `TestGenerator_createTagsFromResources` verifying development resources are excluded from tags, and a new `TestGenerator_DevelopmentFlag` function testing path exclusion, tag exclusion, backward compatibility for non-development resources, and the all-development edge case.
- **`servergen_test.go`**: added `TestGenerateServer_DevelopmentFlag` verifying that development resources produce no route registrations, no API struct fields, and no interface definitions in generated server code, while stable resources remain unaffected.

## Usage

```yaml
# Excluded from OpenAPI output while in development
GradeElementary:
  development: true
  search: false
  operations:
    - create
    - read

# Included normally
Students:
  operations:
    - create
    - read
    - list
```

## Testing

All existing tests continue to pass. New tests cover:
- Development resources excluded from OpenAPI paths
- Development resources excluded from OpenAPI tags
- Development resources excluded from server routes, struct fields, and interfaces
- Non-development resources unaffected (backward compatibility)
- Edge case: all resources in development → nil tags, empty paths
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [INF-1589](https://linear.app/meitner-se/issue/INF-1589/publicapis-gen-add-development-flag-to-api-spec-resources)

<div><a href="https://cursor.com/agents/bc-3e0ead03-ee21-4daf-8127-ade7b8b67276"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3e0ead03-ee21-4daf-8127-ade7b8b67276"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

