### PR TITLE
[publicapis-gen] Extend development flag to Enum and Object types (INF-1623)

### DIFF
--- a/specification/openapigen/openapigen.go
+++ b/specification/openapigen/openapigen.go
@@ -578,6 +578,9 @@ func (g *generator) buildV3Document(service *specification.Service) *v3.Document
 
 	// Add enums to components
 	for _, enum := range service.Enums {
+		if enum.Development {
+			continue
+		}
 		schema := g.createEnumSchema(enum)
 		proxy := base.CreateSchemaProxy(schema)
 		components.Schemas.Set(enum.Name, proxy)
@@ -585,6 +588,9 @@ func (g *generator) buildV3Document(service *specification.Service) *v3.Document
 
 	// Add objects to components
 	for _, obj := range service.Objects {
+		if obj.Development {
+			continue
+		}
 		schema := g.createObjectSchema(obj, service)
 		proxy := base.CreateSchemaProxy(schema)
 		components.Schemas.Set(obj.Name, proxy)

--- a/specification/openapigen/openapigen_test.go
+++ b/specification/openapigen/openapigen_test.go
@@ -1916,6 +1916,193 @@ func TestGenerator_DevelopmentFlag(t *testing.T) {
 }
 
 // ============================================================================
+// Development Flag Tests - Enums and Objects
+// ============================================================================
+
+// TestGenerator_DevelopmentFlagEnumsObjects tests that enums and objects marked as development
+// are excluded from the generated OpenAPI schemas, while server generation is unaffected.
+func TestGenerator_DevelopmentFlagEnumsObjects(t *testing.T) {
+	const (
+		devEnumName    = "InternalGradeType"
+		devEnumDesc    = "Internal grade type enum in development"
+		stableEnumName = "Status"
+		stableEnumDesc = "Status enumeration"
+
+		devObjectName    = "GradeElementary"
+		devObjectDesc    = "Grade elementary object in development"
+		stableObjectName = "Student"
+		stableObjectDesc = "Student object"
+	)
+
+	generator := newGenerator()
+
+	t.Run("development enum is excluded from OpenAPI schemas", func(t *testing.T) {
+		service := &specification.Service{
+			Name: "TestService",
+			Enums: []specification.Enum{
+				{
+					Name:        stableEnumName,
+					Description: stableEnumDesc,
+					Values: []specification.EnumValue{
+						{Name: "Active", Description: "Active status"},
+						{Name: "Inactive", Description: "Inactive status"},
+					},
+				},
+				{
+					Name:        devEnumName,
+					Description: devEnumDesc,
+					Development: true,
+					Values: []specification.EnumValue{
+						{Name: "Grade1", Description: "Grade 1"},
+						{Name: "Grade2", Description: "Grade 2"},
+					},
+				},
+			},
+		}
+
+		document, err := generator.generateFromService(service)
+		assert.NoError(t, err, "Should not return error for valid service")
+		assert.NotNil(t, document, "Document should not be nil")
+		assert.NotNil(t, document.Components, "Document should have components")
+
+		_, stableExists := document.Components.Schemas.Get(stableEnumName)
+		assert.True(t, stableExists, "Stable enum should be present in component schemas")
+
+		_, devExists := document.Components.Schemas.Get(devEnumName)
+		assert.False(t, devExists, "Development enum should NOT be present in component schemas")
+	})
+
+	t.Run("development object is excluded from OpenAPI schemas", func(t *testing.T) {
+		service := &specification.Service{
+			Name: "TestService",
+			Objects: []specification.Object{
+				{
+					Name:        stableObjectName,
+					Description: stableObjectDesc,
+					Fields: []specification.Field{
+						{Name: "ID", Description: "Student ID", Type: specification.FieldTypeUUID, Example: "123e4567-e89b-12d3-a456-426614174000"},
+					},
+				},
+				{
+					Name:        devObjectName,
+					Description: devObjectDesc,
+					Development: true,
+					Fields: []specification.Field{
+						{Name: "Grade", Description: "Grade value", Type: specification.FieldTypeString, Example: "A"},
+					},
+				},
+			},
+		}
+
+		document, err := generator.generateFromService(service)
+		assert.NoError(t, err, "Should not return error for valid service")
+		assert.NotNil(t, document, "Document should not be nil")
+		assert.NotNil(t, document.Components, "Document should have components")
+
+		_, stableExists := document.Components.Schemas.Get(stableObjectName)
+		assert.True(t, stableExists, "Stable object should be present in component schemas")
+
+		_, devExists := document.Components.Schemas.Get(devObjectName)
+		assert.False(t, devExists, "Development object should NOT be present in component schemas")
+	})
+
+	t.Run("development resource auto-generated object is excluded from OpenAPI schemas", func(t *testing.T) {
+		const (
+			devResourceName    = "GradeUpperSecondary"
+			stableResourceName = "Student"
+		)
+
+		service := &specification.Service{
+			Name: "TestService",
+			Resources: []specification.Resource{
+				{
+					Name:        stableResourceName,
+					Description: "Student resource",
+					Operations:  []string{specification.OperationGet, specification.OperationList},
+					Fields: []specification.ResourceField{
+						{
+							Field: specification.Field{
+								Name:        "Name",
+								Description: "Student name",
+								Type:        specification.FieldTypeString,
+								Example:     "John Doe",
+							},
+							Operations: []string{specification.OperationRead},
+						},
+					},
+				},
+				{
+					Name:        devResourceName,
+					Description: "Grade upper secondary resource in development",
+					Development: true,
+					Operations:  []string{specification.OperationGet, specification.OperationList},
+					Fields: []specification.ResourceField{
+						{
+							Field: specification.Field{
+								Name:        "Grade",
+								Description: "Grade value",
+								Type:        specification.FieldTypeString,
+								Example:     "A",
+							},
+							Operations: []string{specification.OperationRead},
+						},
+					},
+				},
+			},
+		}
+
+		result := specification.ApplyOverlay(service)
+		assert.NotNil(t, result, "ApplyOverlay result should not be nil")
+
+		document, err := generator.generateFromService(result)
+		assert.NoError(t, err, "Should not return error for valid service")
+		assert.NotNil(t, document, "Document should not be nil")
+		assert.NotNil(t, document.Components, "Document should have components")
+
+		_, stableExists := document.Components.Schemas.Get(stableResourceName)
+		assert.True(t, stableExists, "Auto-generated object for stable resource should be present in component schemas")
+
+		_, devExists := document.Components.Schemas.Get(devResourceName)
+		assert.False(t, devExists, "Auto-generated object for development resource should NOT be present in component schemas")
+	})
+
+	t.Run("non-development enums and objects are completely unaffected", func(t *testing.T) {
+		service := &specification.Service{
+			Name: "TestService",
+			Enums: []specification.Enum{
+				{
+					Name:        stableEnumName,
+					Description: stableEnumDesc,
+					Values: []specification.EnumValue{
+						{Name: "Active", Description: "Active status"},
+					},
+				},
+			},
+			Objects: []specification.Object{
+				{
+					Name:        stableObjectName,
+					Description: stableObjectDesc,
+					Fields: []specification.Field{
+						{Name: "ID", Description: "Student ID", Type: specification.FieldTypeUUID, Example: "123e4567-e89b-12d3-a456-426614174000"},
+					},
+				},
+			},
+		}
+
+		document, err := generator.generateFromService(service)
+		assert.NoError(t, err, "Should not return error for valid service")
+		assert.NotNil(t, document, "Document should not be nil")
+		assert.NotNil(t, document.Components, "Document should have components")
+
+		_, stableEnumExists := document.Components.Schemas.Get(stableEnumName)
+		assert.True(t, stableEnumExists, "Non-development enum should be present in component schemas")
+
+		_, stableObjectExists := document.Components.Schemas.Get(stableObjectName)
+		assert.True(t, stableObjectExists, "Non-development object should be present in component schemas")
+	})
+}
+
+// ============================================================================
 // RequestBodies Section Tests
 // ============================================================================
 

--- a/specification/servergen/servergen_test.go
+++ b/specification/servergen/servergen_test.go
@@ -1552,3 +1552,78 @@ func TestGenerateServer_DevelopmentFlag(t *testing.T) {
 		assert.Contains(t, generated, "ListStudents", "Stable resource endpoint should still appear in generated code")
 	})
 }
+
+// TestGenerateServer_DevelopmentFlagEnumsObjects tests that development enums and objects
+// are still included in generated server Go code (servergen is intentionally unaffected).
+func TestGenerateServer_DevelopmentFlagEnumsObjects(t *testing.T) {
+	const (
+		devEnumName    = "InternalGradeType"
+		stableEnumName = "Status"
+		devObjectName  = "GradeElementary"
+		stableObjName  = "Student"
+	)
+
+	t.Run("development enum is still generated as Go type in server code", func(t *testing.T) {
+		service := &specification.Service{
+			Name:    testServiceName,
+			Version: testServiceVersion,
+			Enums: []specification.Enum{
+				{
+					Name:        stableEnumName,
+					Description: "Stable status enum",
+					Values: []specification.EnumValue{
+						{Name: "Active", Description: "Active state"},
+					},
+				},
+				{
+					Name:        devEnumName,
+					Description: "Internal grade type in development",
+					Development: true,
+					Values: []specification.EnumValue{
+						{Name: "Grade1", Description: "Grade 1"},
+					},
+				},
+			},
+		}
+
+		buf := &bytes.Buffer{}
+		err := GenerateServer(buf, service)
+		assert.Nil(t, err, "Should not return error when generating server with development enum")
+
+		generated := buf.String()
+		assert.Contains(t, generated, stableEnumName, "Stable enum type should appear in generated Go code")
+		assert.Contains(t, generated, devEnumName, "Development enum type should still appear in generated Go code (servergen unaffected)")
+	})
+
+	t.Run("development object is still generated as Go type in server code", func(t *testing.T) {
+		service := &specification.Service{
+			Name:    testServiceName,
+			Version: testServiceVersion,
+			Objects: []specification.Object{
+				{
+					Name:        stableObjName,
+					Description: "Stable student object",
+					Fields: []specification.Field{
+						{Name: "Name", Description: "Student name", Type: "String"},
+					},
+				},
+				{
+					Name:        devObjectName,
+					Description: "Development grade object",
+					Development: true,
+					Fields: []specification.Field{
+						{Name: "Grade", Description: "Grade value", Type: "String"},
+					},
+				},
+			},
+		}
+
+		buf := &bytes.Buffer{}
+		err := GenerateServer(buf, service)
+		assert.Nil(t, err, "Should not return error when generating server with development object")
+
+		generated := buf.String()
+		assert.Contains(t, generated, stableObjName, "Stable object type should appear in generated Go code")
+		assert.Contains(t, generated, devObjectName, "Development object type should still appear in generated Go code (servergen unaffected)")
+	})
+}

--- a/specification/specification.go
+++ b/specification/specification.go
@@ -491,6 +491,10 @@ type Enum struct {
 	// Description of the enum
 	Description string `json:"description"`
 
+	// Development indicates this enum is not ready for public use and should
+	// be excluded from the generated OpenAPI output.
+	Development bool `json:"development,omitempty" yaml:"development,omitempty"`
+
 	// Values that are possible for the enum
 	Values []EnumValue `json:"values"`
 }
@@ -512,6 +516,10 @@ type Object struct {
 
 	// Description about the object
 	Description string `json:"description"`
+
+	// Development indicates this object is not ready for public use and should
+	// be excluded from the generated OpenAPI output.
+	Development bool `json:"development,omitempty" yaml:"development,omitempty"`
 
 	// Fields in the object
 	Fields []Field `json:"fields"`
@@ -813,6 +821,7 @@ func generateObjectsFromResources(result *Service, resources []Resource) {
 				newObject := Object{
 					Name:        resource.Name,
 					Description: resource.Description,
+					Development: resource.Development,
 					Fields:      fields,
 				}
 

--- a/specification/specification_test.go
+++ b/specification/specification_test.go
@@ -3854,3 +3854,266 @@ func TestIsValidStatusCode(t *testing.T) {
 		})
 	}
 }
+
+// ============================================================================
+// Development Flag Tests - Enum and Object Structs
+// ============================================================================
+
+// TestEnum_DevelopmentFlag tests that the Development field on Enum is properly set and serialized.
+func TestEnum_DevelopmentFlag(t *testing.T) {
+	t.Run("development enum has Development set to true", func(t *testing.T) {
+		enum := Enum{
+			Name:        "InternalStatus",
+			Description: "Internal status enum",
+			Development: true,
+			Values: []EnumValue{
+				{Name: "Draft", Description: "Draft state"},
+			},
+		}
+
+		assert.True(t, enum.Development, "Development flag should be true")
+		assert.Equal(t, "InternalStatus", enum.Name, "Name should match")
+	})
+
+	t.Run("non-development enum has Development set to false by default", func(t *testing.T) {
+		enum := Enum{
+			Name:        "Status",
+			Description: "Status enum",
+			Values: []EnumValue{
+				{Name: "Active", Description: "Active state"},
+			},
+		}
+
+		assert.False(t, enum.Development, "Development flag should be false by default")
+	})
+
+	t.Run("development enum is marshaled and unmarshaled correctly in YAML", func(t *testing.T) {
+		yamlInput := `
+name: TestService
+enums:
+  - name: InternalStatus
+    description: Internal status
+    development: true
+    values:
+      - name: Draft
+        description: Draft state
+  - name: Status
+    description: Public status
+    values:
+      - name: Active
+        description: Active state
+`
+		var service Service
+		err := yaml.Unmarshal([]byte(yamlInput), &service)
+		require.NoError(t, err, "Should parse YAML without error")
+
+		require.Len(t, service.Enums, 2, "Should have two enums")
+
+		assert.True(t, service.Enums[0].Development, "InternalStatus should have Development=true")
+		assert.Equal(t, "InternalStatus", service.Enums[0].Name, "First enum name should be InternalStatus")
+
+		assert.False(t, service.Enums[1].Development, "Status should have Development=false")
+		assert.Equal(t, "Status", service.Enums[1].Name, "Second enum name should be Status")
+	})
+}
+
+// TestObject_DevelopmentFlag tests that the Development field on Object is properly set and serialized.
+func TestObject_DevelopmentFlag(t *testing.T) {
+	t.Run("development object has Development set to true", func(t *testing.T) {
+		obj := Object{
+			Name:        "InternalGrade",
+			Description: "Internal grade object",
+			Development: true,
+			Fields: []Field{
+				{Name: "Grade", Description: "Grade value", Type: FieldTypeString},
+			},
+		}
+
+		assert.True(t, obj.Development, "Development flag should be true")
+		assert.Equal(t, "InternalGrade", obj.Name, "Name should match")
+	})
+
+	t.Run("non-development object has Development set to false by default", func(t *testing.T) {
+		obj := Object{
+			Name:        "Student",
+			Description: "Student object",
+			Fields: []Field{
+				{Name: "Name", Description: "Student name", Type: FieldTypeString},
+			},
+		}
+
+		assert.False(t, obj.Development, "Development flag should be false by default")
+	})
+
+	t.Run("development object is marshaled and unmarshaled correctly in YAML", func(t *testing.T) {
+		yamlInput := `
+name: TestService
+objects:
+  - name: InternalGrade
+    description: Internal grade
+    development: true
+    fields:
+      - name: Grade
+        description: Grade value
+        type: String
+        operations: []
+  - name: Student
+    description: Student
+    fields:
+      - name: Name
+        description: Student name
+        type: String
+        operations: []
+`
+		var service Service
+		err := yaml.Unmarshal([]byte(yamlInput), &service)
+		require.NoError(t, err, "Should parse YAML without error")
+
+		require.Len(t, service.Objects, 2, "Should have two objects")
+
+		assert.True(t, service.Objects[0].Development, "InternalGrade should have Development=true")
+		assert.Equal(t, "InternalGrade", service.Objects[0].Name, "First object name should be InternalGrade")
+
+		assert.False(t, service.Objects[1].Development, "Student should have Development=false")
+		assert.Equal(t, "Student", service.Objects[1].Name, "Second object name should be Student")
+	})
+}
+
+// TestApplyOverlay_DevelopmentFlagPropagation tests that the Development flag is propagated
+// from Resource to its auto-generated Object in generateObjectsFromResources.
+func TestApplyOverlay_DevelopmentFlagPropagation(t *testing.T) {
+	t.Run("development resource propagates Development flag to auto-generated object", func(t *testing.T) {
+		input := &Service{
+			Name: "TestService",
+			Resources: []Resource{
+				{
+					Name:        "GradeElementary",
+					Description: "Grade elementary resource in development",
+					Development: true,
+					Operations:  []string{OperationGet, OperationList},
+					Fields: []ResourceField{
+						{
+							Field: Field{
+								Name:        "Grade",
+								Description: "Grade value",
+								Type:        FieldTypeString,
+							},
+							Operations: []string{OperationRead},
+						},
+					},
+				},
+			},
+		}
+
+		result := ApplyOverlay(input)
+		require.NotNil(t, result, "ApplyOverlay result should not be nil")
+
+		var gradeObj *Object
+		for i := range result.Objects {
+			if result.Objects[i].Name == "GradeElementary" {
+				gradeObj = &result.Objects[i]
+				break
+			}
+		}
+
+		require.NotNil(t, gradeObj, "Auto-generated object should exist in service")
+		assert.True(t, gradeObj.Development, "Auto-generated object should have Development=true when resource has Development=true")
+	})
+
+	t.Run("non-development resource auto-generated object has Development false", func(t *testing.T) {
+		input := &Service{
+			Name: "TestService",
+			Resources: []Resource{
+				{
+					Name:        "Student",
+					Description: "Student resource",
+					Development: false,
+					Operations:  []string{OperationGet, OperationList},
+					Fields: []ResourceField{
+						{
+							Field: Field{
+								Name:        "Name",
+								Description: "Student name",
+								Type:        FieldTypeString,
+							},
+							Operations: []string{OperationRead},
+						},
+					},
+				},
+			},
+		}
+
+		result := ApplyOverlay(input)
+		require.NotNil(t, result, "ApplyOverlay result should not be nil")
+
+		var studentObj *Object
+		for i := range result.Objects {
+			if result.Objects[i].Name == "Student" {
+				studentObj = &result.Objects[i]
+				break
+			}
+		}
+
+		require.NotNil(t, studentObj, "Auto-generated object should exist in service")
+		assert.False(t, studentObj.Development, "Auto-generated object should have Development=false when resource has Development=false")
+	})
+
+	t.Run("mixed development and non-development resources propagate flags correctly", func(t *testing.T) {
+		input := &Service{
+			Name: "TestService",
+			Resources: []Resource{
+				{
+					Name:        "Student",
+					Description: "Student resource",
+					Development: false,
+					Operations:  []string{OperationGet},
+					Fields: []ResourceField{
+						{
+							Field: Field{
+								Name:        "Name",
+								Description: "Student name",
+								Type:        FieldTypeString,
+							},
+							Operations: []string{OperationRead},
+						},
+					},
+				},
+				{
+					Name:        "GradeElementary",
+					Description: "Grade elementary resource in development",
+					Development: true,
+					Operations:  []string{OperationGet},
+					Fields: []ResourceField{
+						{
+							Field: Field{
+								Name:        "Grade",
+								Description: "Grade value",
+								Type:        FieldTypeString,
+							},
+							Operations: []string{OperationRead},
+						},
+					},
+				},
+			},
+		}
+
+		result := ApplyOverlay(input)
+		require.NotNil(t, result, "ApplyOverlay result should not be nil")
+
+		var studentObj, gradeObj *Object
+		for i := range result.Objects {
+			if result.Objects[i].Name == "Student" {
+				studentObj = &result.Objects[i]
+			}
+			if result.Objects[i].Name == "GradeElementary" {
+				gradeObj = &result.Objects[i]
+			}
+		}
+
+		require.NotNil(t, studentObj, "Auto-generated Student object should exist")
+		require.NotNil(t, gradeObj, "Auto-generated GradeElementary object should exist")
+
+		assert.False(t, studentObj.Development, "Student object should have Development=false")
+		assert.True(t, gradeObj.Development, "GradeElementary object should have Development=true")
+	})
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Extends the `development` boolean flag (introduced on `Resource` in INF-1589) to also work for `Enum` and `Object` types in the generated OpenAPI output.

Server code generation (`servergen.go`) is intentionally **not** changed — development enums, objects, and resource types are still generated as Go types so the project compiles.

## Changes

### `specification/specification.go`

- Added `Development bool` field with `json:"development,omitempty" yaml:"development,omitempty"` tags to both `Enum` and `Object` structs.
- In `generateObjectsFromResources`, the auto-generated `Object` from a `Resource` now inherits `Development: resource.Development`, so it is automatically excluded from OpenAPI output without any additional filtering downstream.

### `specification/openapigen/openapigen.go`

- Added `if enum.Development { continue }` guard in the enums loop that populates `components.Schemas`.
- Added `if obj.Development { continue }` guard in the objects loop that populates `components.Schemas`.

## Tests Added

### `specification/openapigen/openapigen_test.go`

New `TestGenerator_DevelopmentFlagEnumsObjects` function with sub-tests:
- Development enum is excluded from OpenAPI component schemas
- Development object is excluded from OpenAPI component schemas
- Auto-generated object for a development resource is excluded from OpenAPI component schemas
- Non-development enums and objects are completely unaffected

### `specification/specification_test.go`

- `TestEnum_DevelopmentFlag` — verifies the field is properly set, defaults to false, and round-trips through YAML.
- `TestObject_DevelopmentFlag` — same for `Object`.
- `TestApplyOverlay_DevelopmentFlagPropagation` — verifies that `generateObjectsFromResources` copies the `Development` flag correctly (development resource → development object; non-development resource → non-development object; mixed scenario).

### `specification/servergen/servergen_test.go`

New `TestGenerateServer_DevelopmentFlagEnumsObjects` function with sub-tests:
- Development enum is **still** generated as a Go type in server code
- Development object is **still** generated as a Go type in server code

## Acceptance Criteria

- [x] `Enum.Development` and `Object.Development` bool fields added with correct json/yaml tags
- [x] Development enums excluded from OpenAPI component schemas
- [x] Development objects excluded from OpenAPI component schemas
- [x] Auto-generated objects from development resources inherit `Development: true` and are excluded from OpenAPI
- [x] Server code generation (`servergen.go`) is unaffected — development types still generated
- [x] All existing tests continue to pass
- [x] New tests added for each OpenAPI exclusion case

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [INF-1623](https://linear.app/meitner-se/issue/INF-1623/publicapis-gen-extend-development-flag-to-enums-and-objects)

<div><a href="https://cursor.com/agents/bc-ab08277d-ae56-43b2-93d6-da8ece99a88f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab08277d-ae56-43b2-93d6-da8ece99a88f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

