### PR TITLE
servergen: always generate server code for development resources, enums, and objects (INF-1624)

### DIFF
--- a/specification/servergen/servergen.go
+++ b/specification/servergen/servergen.go
@@ -289,9 +289,6 @@ func generateServer(buf *bytes.Buffer, service *specification.Service) error {
 	buf.WriteString("\trouterGroup.StaticFileFS(\"/openapi.json\", \"openapi.json\", http.FS(api.OpenAPI_JSON))\n\n")
 
 	for _, resource := range service.Resources {
-		if resource.Development {
-			continue
-		}
 		for _, endpoint := range resource.Endpoints {
 			if endpoint.HasResponseType() {
 				buf.WriteString(fmt.Sprintf("\trouterGroup.%s(\"%s\", serveWithResponse(%d, api.Server, api.%s.%s))\n",
@@ -324,9 +321,6 @@ func generateServer(buf *bytes.Buffer, service *specification.Service) error {
 
 	buf.WriteString("\tOpenAPI_JSON embed.FS\n")
 	for _, resource := range service.Resources {
-		if resource.Development {
-			continue
-		}
 		buf.WriteString(fmt.Sprintf("\t%s %sAPI[Session] // Endpoints for the %s resource\n", resource.Name, resource.Name, resource.Name))
 	}
 	buf.WriteString("}\n\n")
@@ -381,9 +375,6 @@ func generateServer(buf *bytes.Buffer, service *specification.Service) error {
 	buf.WriteString("}\n\n")
 
 	for _, resource := range service.Resources {
-		if resource.Development {
-			continue
-		}
 		buf.WriteString(fmt.Sprintf("type %sAPI[Session any] interface {\n", resource.Name))
 		for _, endpoint := range resource.Endpoints {
 			if endpoint.HasResponseType() {
@@ -467,9 +458,6 @@ func generateRequestTypes(buf *bytes.Buffer, service *specification.Service) err
 	buf.WriteString("}\n\n")
 
 	for _, resource := range service.Resources {
-		if resource.Development {
-			continue
-		}
 		for _, endpoint := range resource.Endpoints {
 			if len(endpoint.Request.PathParams) > 0 {
 				buf.WriteString(fmt.Sprintf("type %s struct {\n", endpoint.GetPathParamsType(resource.Name)))
@@ -502,9 +490,6 @@ func generateRequestTypes(buf *bytes.Buffer, service *specification.Service) err
 
 func generateResponseTypes(buf *bytes.Buffer, service *specification.Service) error {
 	for _, resource := range service.Resources {
-		if resource.Development {
-			continue
-		}
 		for _, endpoint := range resource.Endpoints {
 			if len(endpoint.Response.BodyFields) == 0 {
 				continue

--- a/specification/servergen/servergen_test.go
+++ b/specification/servergen/servergen_test.go
@@ -1434,7 +1434,9 @@ func TestConvertOpenAPIPathToGin(t *testing.T) {
 // Development Flag Tests
 // ============================================================================
 
-// TestGenerateServer_DevelopmentFlag tests that resources with Development: true are excluded from all generated server code.
+// TestGenerateServer_DevelopmentFlag tests that resources with Development: true are still fully
+// generated into server code. The development flag is an OpenAPI documentation gate only — it
+// must never suppress interface definitions, API struct fields, or route registrations.
 func TestGenerateServer_DevelopmentFlag(t *testing.T) {
 	const (
 		devResourceName    = "GradeElementary"
@@ -1467,8 +1469,8 @@ func TestGenerateServer_DevelopmentFlag(t *testing.T) {
 		},
 	}
 
-	t.Run("development resource route is not registered", func(t *testing.T) {
-		service := &specification.Service{
+	buildService := func() *specification.Service {
+		return &specification.Service{
 			Name:    testServiceName,
 			Version: testServiceVersion,
 			Resources: []specification.Resource{
@@ -1476,51 +1478,34 @@ func TestGenerateServer_DevelopmentFlag(t *testing.T) {
 				{Name: devResourceName, Description: devResourceDesc, Development: true, Endpoints: []specification.Endpoint{devEndpoint}},
 			},
 		}
+	}
 
+	t.Run("development resource route is registered", func(t *testing.T) {
 		buf := &bytes.Buffer{}
-		err := GenerateServer(buf, service)
+		err := GenerateServer(buf, buildService())
 		assert.Nil(t, err, "Should not return error when generating server with a development resource")
 
 		generated := buf.String()
 		assert.Contains(t, generated, stableResourceName, "Stable resource should appear in generated code")
-		assert.NotContains(t, generated, devResourceName, "Development resource should NOT appear in generated code")
+		assert.Contains(t, generated, devResourceName, "Development resource MUST appear in generated server code")
+		assert.Contains(t, generated, "api."+devResourceName+".ListGrades",
+			"Development resource route should be registered in server code")
 	})
 
-	t.Run("development resource has no API struct field", func(t *testing.T) {
-		service := &specification.Service{
-			Name:    testServiceName,
-			Version: testServiceVersion,
-			Resources: []specification.Resource{
-				{Name: stableResourceName, Description: stableResourceDesc, Endpoints: []specification.Endpoint{stableEndpoint}},
-				{Name: devResourceName, Description: devResourceDesc, Development: true, Endpoints: []specification.Endpoint{devEndpoint}},
-			},
-		}
-
+	t.Run("development resource has API struct field", func(t *testing.T) {
 		buf := &bytes.Buffer{}
-		err := GenerateServer(buf, service)
+		err := GenerateServer(buf, buildService())
 		assert.Nil(t, err, "Should not return error when generating server with a development resource")
 
 		generated := buf.String()
 
-		expectedStableField := stableResourceName + "API[Session]"
-		assert.Contains(t, generated, expectedStableField, "Stable resource API field should appear in generated struct")
-
-		expectedDevField := devResourceName + "API[Session]"
-		assert.NotContains(t, generated, expectedDevField, "Development resource API field should NOT appear in generated struct")
+		assert.Contains(t, generated, "StudentsAPI[Session]", "Stable resource API field should appear in generated struct")
+		assert.Contains(t, generated, "GradeElementaryAPI[Session]", "Development resource API field MUST appear in generated struct")
 	})
 
-	t.Run("development resource has no interface definition", func(t *testing.T) {
-		service := &specification.Service{
-			Name:    testServiceName,
-			Version: testServiceVersion,
-			Resources: []specification.Resource{
-				{Name: stableResourceName, Description: stableResourceDesc, Endpoints: []specification.Endpoint{stableEndpoint}},
-				{Name: devResourceName, Description: devResourceDesc, Development: true, Endpoints: []specification.Endpoint{devEndpoint}},
-			},
-		}
-
+	t.Run("development resource has interface definition", func(t *testing.T) {
 		buf := &bytes.Buffer{}
-		err := GenerateServer(buf, service)
+		err := GenerateServer(buf, buildService())
 		assert.Nil(t, err, "Should not return error when generating server with a development resource")
 
 		generated := buf.String()
@@ -1529,21 +1514,12 @@ func TestGenerateServer_DevelopmentFlag(t *testing.T) {
 		assert.Contains(t, generated, expectedStableInterface, "Stable resource interface should appear in generated code")
 
 		expectedDevInterface := "type " + devResourceName + "API[Session any] interface {"
-		assert.NotContains(t, generated, expectedDevInterface, "Development resource interface should NOT appear in generated code")
+		assert.Contains(t, generated, expectedDevInterface, "Development resource interface MUST appear in generated code")
 	})
 
 	t.Run("non-development resource is unaffected when other resources are in development", func(t *testing.T) {
-		service := &specification.Service{
-			Name:    testServiceName,
-			Version: testServiceVersion,
-			Resources: []specification.Resource{
-				{Name: stableResourceName, Description: stableResourceDesc, Endpoints: []specification.Endpoint{stableEndpoint}},
-				{Name: devResourceName, Description: devResourceDesc, Development: true, Endpoints: []specification.Endpoint{devEndpoint}},
-			},
-		}
-
 		buf := &bytes.Buffer{}
-		err := GenerateServer(buf, service)
+		err := GenerateServer(buf, buildService())
 		assert.Nil(t, err, "Should not return error when generating server with a development resource")
 
 		generated := buf.String()

--- a/specification/specification.go
+++ b/specification/specification.go
@@ -534,9 +534,10 @@ type Resource struct {
 	Description string `json:"description"`
 
 	// Development indicates this resource is not ready for public use.
-	// Resources with Development set to true are excluded from all generated output.
-	// (OpenAPI spec, server code, API types). This allows resources to be defined
-	// and implemented without being surfaced to third parties prematurely.
+	// Resources with Development set to true are excluded from the generated OpenAPI output,
+	// allowing resources to be defined and implemented without being surfaced to third parties
+	// prematurely. Server code (interfaces, struct fields, route registrations) is always
+	// generated regardless of this flag.
 	Development bool `json:"development,omitempty" yaml:"development,omitempty"`
 
 	// Operations that are allowed for the resource can be all of Create, Get, List, Search, Update, Delete


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The `development` flag on `Resource`, `Enum`, and `Object` is an **OpenAPI documentation gate only**. It must never suppress code generation in `servergen.go`. This PR enforces that contract.

## Problem

Five loops in `servergen.go` contained `if resource.Development { continue }` guards that were incorrectly skipping server code generation for development-flagged resources. This meant interfaces, API struct fields, route registrations, and request/response param types were all suppressed for development resources — the opposite of the intended behaviour.

`generateEnums` and `generateObjects` had no such guards (correct).

## Changes

### `specification/servergen/servergen.go`
Removed the following five `if resource.Development { continue }` guards:
- Route registration loop (`RegisterDirectoryAPI` function)
- API struct fields loop (`DirectoryAPI` struct)
- Resource interface generation loop (`type <Resource>API[Session any] interface`)
- `generateRequestTypes` (path/query/body param type structs)
- `generateResponseTypes` (response body type structs)

### `specification/specification.go`
Updated the `Resource.Development` doc comment to explicitly state that the flag is OpenAPI-only, not a code gate.

### `specification/servergen/servergen_test.go`
Updated `TestGenerateServer_DevelopmentFlag` to assert the **correct** behaviour:
- Development resource route **is** registered in `RegisterDirectoryAPI`
- Development resource **has** an API struct field in the service struct
- Development resource **has** an interface definition (`type GradeElementaryAPI[Session any] interface`)
- Stable (non-development) resource is unaffected

`TestGenerateServer_DevelopmentFlagEnumsObjects` (which already correctly asserted that development enums/objects appear in Go server code) is unchanged.

`openapigen.go` and its tests are **not modified** — development items are still correctly excluded from OpenAPI output.

## Testing

All tests pass:
```
ok  github.com/meitner-se/publicapis-gen                                  0.149s
ok  github.com/meitner-se/publicapis-gen/specification                    0.008s
ok  github.com/meitner-se/publicapis-gen/specification/openapigen         0.140s
ok  github.com/meitner-se/publicapis-gen/specification/schemagen          0.032s
ok  github.com/meitner-se/publicapis-gen/specification/servergen          0.022s
ok  github.com/meitner-se/publicapis-gen/specification/testgen            0.027s
```
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [INF-1624](https://linear.app/meitner-se/issue/INF-1624/publicapis-gen-always-generate-server-code-for-development-resources)

<div><a href="https://cursor.com/agents/bc-219383ba-9afa-48f5-a9cc-8c852daf2d02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-219383ba-9afa-48f5-a9cc-8c852daf2d02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

