### PR TITLE
Migrate GitHub Actions workflows to Node 24 (INF-2941)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,6 @@ on:
     paths:
       - '**'
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,15 +14,15 @@ jobs:
         go-version: ['1.21', '1.22']
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version: ${{ matrix.go-version }}
 
     - name: Cache Go modules
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ~/.cache/go-build
@@ -69,15 +69,15 @@ jobs:
         go-version: ['1.21', '1.22']
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version: ${{ matrix.go-version }}
 
     - name: Cache Go modules
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ~/.cache/go-build
@@ -100,15 +100,15 @@ jobs:
         go-version: ['1.21', '1.22']
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version: ${{ matrix.go-version }}
 
     - name: Cache Go modules
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ~/.cache/go-build
@@ -136,9 +136,9 @@ jobs:
         fi
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v6
       with:
-        file: ./coverage.out
+        files: ./coverage.out
         fail_ci_if_error: false
         verbose: true
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ['1.21', '1.22']
+        go-version: ['1.24.2']
     
     steps:
     - uses: actions/checkout@v5
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ['1.21', '1.22']
+        go-version: ['1.24.2']
     
     steps:
     - uses: actions/checkout@v5
@@ -97,7 +97,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ['1.21', '1.22']
+        go-version: ['1.24.2']
     
     steps:
     - uses: actions/checkout@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     paths:
       - '**'
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
       run: go vet ./...
 
     - name: Install staticcheck
-      run: go install honnef.co/go/tools/cmd/staticcheck@latest
+      run: go install honnef.co/go/tools/cmd/staticcheck@v0.6.1
 
     - name: Run staticcheck
       run: staticcheck ./...


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Bump GitHub JavaScript actions in CI to Node 24-compatible major versions.
- Migrate Codecov from `codecov/codecov-action@v4` to `@v6`.
- Rename the Codecov upload input from `file: ./coverage.out` to `files: ./coverage.out` to preserve the existing coverage upload path.
- Align the CI Go matrix with the module toolchain (`go1.24.2`) so `actions/setup-go@v6` does not run an invalid Go 1.21/1.22 toolchain with `GOTOOLCHAIN=local`.
- Pin Staticcheck to `honnef.co/go/tools/cmd/staticcheck@v0.6.1`, the latest release verified with Go 1.24.2; `@latest` now resolves to a Go 1.25-only release.
- Removed the temporary `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` env after the trial run.

## Validation
- `python3`/PyYAML parse of `.github/workflows/ci.yml`: passed.
- `GOTOOLCHAIN=go1.24.2 staticcheck ./...`: passed locally with Staticcheck v0.6.1.
- `go test ./...`: passed locally.
- CI after the Go-version/Staticcheck fixes: passed (`26158548782`).
- Trial run with `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true`: passed (`26158628898`).
- Final CI after removing the temporary force env: passed (`26158777580`).
- Checked trial and final CI logs for `Node.js 20`; no deprecation warning text was present.

## Codecov note
- The v6 Codecov step ran with `files: ./coverage.out` and found exactly one coverage file: `/home/runner/work/publicapis-gen/publicapis-gen/coverage.out`.
- The upload request returned `Token required because branch is protected` because `CODECOV_TOKEN` was empty in the CI environment for this branch run. The job stayed green because the existing workflow keeps `fail_ci_if_error: false`.
- Codecov dashboard verification still requires a run where the repository Codecov token is available.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [INF-2941](https://linear.app/meitner-se/issue/INF-2941/migrate-github-actions-workflows-from-node-20-to-node-24)

<div><a href="https://cursor.com/agents/bc-c20639e7-b5b2-4ef8-87ee-e206367c1f77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c20639e7-b5b2-4ef8-87ee-e206367c1f77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

